### PR TITLE
Add unit tests for SwapModule math edge cases

### DIFF
--- a/tests/swap-math.test.ts
+++ b/tests/swap-math.test.ts
@@ -100,4 +100,104 @@ describe('Swap Math', () => {
       expect(kAfter).toBeGreaterThanOrEqual(kBefore);
     });
   });
+
+  describe('Edge Cases', () => {
+    const RESERVE = 1_000_000_000n;
+    const FEE_30 = 30;
+
+    // getAmountOut
+
+    it('should return 0n for a 1-stroop input against very large equal reserves', () => {
+      const largeReserve = 1_000_000_000_000n;
+      const out = swap.getAmountOut(1n, largeReserve, largeReserve, FEE_30);
+      expect(out).toBe(0n);
+    });
+
+    it('should throw when reserveOut is zero', () => {
+      expect(() =>
+        swap.getAmountOut(1_000n, RESERVE, 0n, FEE_30),
+      ).toThrow('Insufficient liquidity');
+    });
+
+    it('should return 0n when feeBps equals 10000 (100% fee)', () => {
+      const out = swap.getAmountOut(1_000_000n, RESERVE, RESERVE, 10000);
+      expect(out).toBe(0n);
+    });
+
+    it('should match the no-fee constant-product formula exactly when feeBps is 0', () => {
+      const amountIn = 10_000_000n;
+      // feeBps=0 reduces to: out = (amountIn * reserveOut) / (reserveIn + amountIn)
+      const expected = (amountIn * RESERVE) / (RESERVE + amountIn);
+      const actual = swap.getAmountOut(amountIn, RESERVE, RESERVE, 0);
+      expect(actual).toBe(expected);
+    });
+
+    it('should return a positive value with reserves near the i128 ceiling (2^63 - 1)', () => {
+      const MAX_I63 = 9_223_372_036_854_775_807n;
+      const amountIn = 1_000_000n;
+      const out = swap.getAmountOut(amountIn, MAX_I63, MAX_I63, FEE_30);
+      expect(out).toBeGreaterThan(0n);
+      expect(out).toBeLessThanOrEqual(amountIn);
+    });
+
+    it('should yield less output for a highly imbalanced pool (reserveOut << reserveIn)', () => {
+      const amountIn = 1_000_000n;
+      const balancedOut = swap.getAmountOut(amountIn, RESERVE, RESERVE, FEE_30);
+      const skewedOut = swap.getAmountOut(amountIn, RESERVE * 10n, RESERVE / 10n, FEE_30);
+      expect(skewedOut).toBeLessThan(balancedOut);
+    });
+
+    it('should treat a negative amountIn as insufficient input and throw', () => {
+      expect(() =>
+        swap.getAmountOut(-1n, RESERVE, RESERVE, FEE_30),
+      ).toThrow('Insufficient input');
+    });
+
+    // getAmountIn
+
+    it('should throw when reserveOut is zero (getAmountIn)', () => {
+      expect(() =>
+        swap.getAmountIn(100n, RESERVE, 0n, FEE_30),
+      ).toThrow('Insufficient liquidity');
+    });
+
+    it('should throw when reserveIn is zero (getAmountIn)', () => {
+      expect(() =>
+        swap.getAmountIn(100n, 0n, RESERVE, FEE_30),
+      ).toThrow('Insufficient liquidity');
+    });
+
+    it('should compute a positive required input for a 1-stroop desired output', () => {
+      const requiredIn = swap.getAmountIn(1n, RESERVE, RESERVE, FEE_30);
+      expect(requiredIn).toBeGreaterThan(0n);
+    });
+
+    it('should treat a negative amountOut as insufficient output and throw (getAmountIn)', () => {
+      expect(() =>
+        swap.getAmountIn(-1n, RESERVE, RESERVE, FEE_30),
+      ).toThrow('Insufficient output');
+    });
+
+    // Cross-function invariants
+
+    it('roundtrip: getAmountOut(getAmountIn(y)) should return at least y', () => {
+      const desiredOut = 1_000_000n;
+      const requiredIn = swap.getAmountIn(desiredOut, RESERVE, RESERVE, FEE_30);
+      const actualOut = swap.getAmountOut(requiredIn, RESERVE, RESERVE, FEE_30);
+      expect(actualOut).toBeGreaterThanOrEqual(desiredOut);
+    });
+
+    it('should preserve constant-product invariant (k never decreases) across multiple fee levels', () => {
+      const amountIn = 50_000_000n;
+      const reserveIn = 500_000_000n;
+      const reserveOut = 800_000_000n;
+      const kBefore = reserveIn * reserveOut;
+
+      for (const feeBps of [0, 10, 30, 100]) {
+        const amountOut = swap.getAmountOut(amountIn, reserveIn, reserveOut, feeBps);
+        const kAfter = (reserveIn + amountIn) * (reserveOut - amountOut);
+        expect(kAfter).toBeGreaterThanOrEqual(kBefore);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary

Adds 13 new edge-case tests to `tests/swap-math.test.ts` inside a dedicated `Edge Cases` describe block, covering every scope listed in issue #4.

**getAmountOut:**
- 1-stroop input against very large reserves (integer floor → `0n`)
- Zero `reserveOut` throws `Insufficient liquidity`
- `feeBps = 10000` (100% fee) returns `0n`
- `feeBps = 0` matches the ideal no-fee constant-product formula exactly
- Reserves near i128 ceiling (2^63 − 1) return a positive result without overflow
- Highly imbalanced pool (`reserveOut << reserveIn`) yields less output than a balanced pool
- Negative `amountIn` throws `Insufficient input`

**getAmountIn:**
- Zero `reserveOut` throws `Insufficient liquidity`
- Zero `reserveIn` throws `Insufficient liquidity`
- 1-stroop desired output resolves to a positive required input
- Negative `amountOut` throws `Insufficient output`

**Cross-function invariants:**
- Roundtrip: `getAmountOut(getAmountIn(y)) >= y` (pool over-protection)
- Constant-product `k` never decreases across fee levels 0 / 10 / 30 / 100 bps

## Test plan

- [x] 13 new edge-case tests added (≥ 8 required by acceptance criteria)
- [x] All 22 swap-math tests pass
- [x] Full suite passes: 67 / 67
- [x] Only `tests/swap-math.test.ts` is modified — no production code touched
- [x] Branch is one clean commit ahead of `main` with no conflicts