### PR TITLE
fix(errors): replaced raw Error throws with typed error classes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,12 +3,10 @@ import {
   SorobanRpc,
   TransactionBuilder,
   Transaction,
-  Networks,
   xdr,
-  Account,
 } from '@stellar/stellar-sdk';
 import { CoralSwapConfig, NetworkConfig, NETWORK_CONFIGS, DEFAULTS } from './config';
-import { Network, TxStatus, Result, Logger, Signer } from './types/common';
+import { Network, Result, Logger, Signer } from './types/common';
 import { SignerError } from './errors';
 import { FactoryClient } from './contracts/factory';
 import { PairClient } from './contracts/pair';

--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -6,6 +6,7 @@ import {
 } from '../types/flash-loan';
 import { FlashLoanConfig } from '../types/pool';
 import { calculateRepayment, validateFeeFloor } from '../contracts/flash-receiver';
+import { FlashLoanError, TransactionError } from '../errors';
 
 /**
  * Flash Loan module -- first-class flash loan support for CoralSwap.
@@ -33,7 +34,9 @@ export class FlashLoanModule {
     const config = await pair.getFlashLoanConfig();
 
     if (config.locked) {
-      throw new Error('Flash loans are currently disabled for this pair');
+      throw new FlashLoanError('Flash loans are currently disabled for this pair', {
+        pairAddress,
+      });
     }
 
     const feeAmount = (amount * BigInt(config.flashFeeBps)) / BigInt(10000);
@@ -60,11 +63,16 @@ export class FlashLoanModule {
     const config = await pair.getFlashLoanConfig();
 
     if (config.locked) {
-      throw new Error('Flash loans are currently disabled for this pair');
+      throw new FlashLoanError('Flash loans are currently disabled for this pair', {
+        pairAddress: request.pairAddress,
+      });
     }
 
     if (!validateFeeFloor(config.flashFeeBps, config.flashFeeFloor)) {
-      throw new Error('Flash loan fee below protocol floor');
+      throw new FlashLoanError('Flash loan fee below protocol floor', {
+        feeBps: config.flashFeeBps,
+        feeFloor: config.flashFeeFloor,
+      });
     }
 
     const feeEstimate = await this.estimateFee(
@@ -84,8 +92,9 @@ export class FlashLoanModule {
     const result = await this.client.submitTransaction([op]);
 
     if (!result.success) {
-      throw new Error(
+      throw new TransactionError(
         `Flash loan failed: ${result.error?.message ?? 'Unknown error'}`,
+        result.txHash,
       );
     }
 

--- a/src/modules/oracle.ts
+++ b/src/modules/oracle.ts
@@ -1,5 +1,6 @@
 import { CoralSwapClient } from '../client';
 import { PRECISION } from '../config';
+import { ValidationError, InsufficientLiquidityError } from '../errors';
 
 /**
  * TWAP Oracle data point from cumulative price accumulators.
@@ -78,7 +79,10 @@ export class OracleModule {
     const timeElapsed = endObs.blockTimestampLast - startObs.blockTimestampLast;
 
     if (timeElapsed <= 0) {
-      throw new Error('End observation must be after start observation');
+      throw new ValidationError('End observation must be after start observation', {
+        startTimestamp: startObs.blockTimestampLast,
+        endTimestamp: endObs.blockTimestampLast,
+      });
     }
 
     const price0TWAP =
@@ -141,7 +145,7 @@ export class OracleModule {
     const { reserve0, reserve1 } = await pair.getReserves();
 
     if (reserve0 === 0n || reserve1 === 0n) {
-      throw new Error('Pool has no liquidity');
+      throw new InsufficientLiquidityError(pairAddress);
     }
 
     return {

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,6 @@
 import { OracleModule, TWAPObservation } from '../src/modules/oracle';
 import { PRECISION } from '../src/config';
+import { InsufficientLiquidityError } from '../src/errors';
 
 function mockClient(pairOverrides: Record<string, (...args: any[]) => any> = {}) {
   return {
@@ -228,7 +229,7 @@ describe('OracleModule', () => {
 
       const oracle = new OracleModule(client);
       await expect(oracle.getSpotPrice(pairAddress)).rejects.toThrow(
-        'Pool has no liquidity',
+        InsufficientLiquidityError,
       );
     });
   });

--- a/tests/swap-math.test.ts
+++ b/tests/swap-math.test.ts
@@ -1,4 +1,9 @@
 import { SwapModule } from '../src/modules/swap';
+import {
+  ValidationError,
+  InsufficientLiquidityError,
+  CoralSwapSDKError,
+} from '../src/errors';
 
 /**
  * Test the V2 AMM swap math independently (no RPC calls).
@@ -45,16 +50,22 @@ describe('Swap Math', () => {
       expect(outLowFee).toBeGreaterThan(outHighFee);
     });
 
-    it('throws on zero input', () => {
+    it('throws ValidationError on zero input', () => {
       expect(() =>
         swap.getAmountOut(0n, 1000n, 1000n, 30),
-      ).toThrow('Insufficient input');
+      ).toThrow(ValidationError);
     });
 
-    it('throws on zero reserves', () => {
+    it('throws InsufficientLiquidityError on zero reserves', () => {
       expect(() =>
         swap.getAmountOut(100n, 0n, 1000n, 30),
-      ).toThrow('Insufficient liquidity');
+      ).toThrow(InsufficientLiquidityError);
+    });
+
+    it('thrown errors are instances of CoralSwapSDKError', () => {
+      expect(() =>
+        swap.getAmountOut(0n, 1000n, 1000n, 30),
+      ).toThrow(CoralSwapSDKError);
     });
   });
 
@@ -69,16 +80,16 @@ describe('Swap Math', () => {
       expect(amountIn).toBeGreaterThan(amountOut);
     });
 
-    it('throws when output exceeds reserve', () => {
+    it('throws InsufficientLiquidityError when output exceeds reserve', () => {
       expect(() =>
         swap.getAmountIn(2000n, 1000n, 1000n, 30),
-      ).toThrow('Insufficient reserve');
+      ).toThrow(InsufficientLiquidityError);
     });
 
-    it('throws on zero output', () => {
+    it('throws ValidationError on zero output', () => {
       expect(() =>
         swap.getAmountIn(0n, 1000n, 1000n, 30),
-      ).toThrow('Insufficient output');
+      ).toThrow(ValidationError);
     });
   });
 


### PR DESCRIPTION
Replaced all raw `throw new Error(...)` calls across `src/modules/` with the
typed error hierarchy from `src/errors.ts`. Every thrown error is now an
instance of `CoralSwapSDKError`, enabling programmatic error handling via
`error.code` and `instanceof` checks.

Closes #3

## Changes

### `src/modules/swap.ts`
- `new Error('No pair found ...')` → `new PairNotFoundError(tokenIn, tokenOut)`
- `new Error('Swap failed: ...')` → `new TransactionError(message, txHash)`
- `new Error('Insufficient input amount')` → `new ValidationError('Insufficient input amount')`
- `new Error('Insufficient liquidity')` → `new InsufficientLiquidityError('unknown')`
- `new Error('Insufficient output amount')` → `new ValidationError('Insufficient output amount')`
- `new Error('Insufficient reserve for output')` → `new InsufficientLiquidityError('unknown', { reason: ... })`

### `src/modules/liquidity.ts`
- `new Error('Add liquidity failed: ...')` → `new TransactionError(message, txHash)`
- `new Error('Remove liquidity failed: ...')` → `new TransactionError(message, txHash)`
- `new Error('Square root of negative number')` → `new ValidationError(...)`

### `src/modules/flash-loan.ts`
- `new Error('Flash loans are currently disabled ...')` → `new FlashLoanError(message, { pairAddress })`
- `new Error('Flash loan fee below protocol floor')` → `new FlashLoanError(message, { feeBps, feeFloor })`
- `new Error('Flash loan failed: ...')` → `new TransactionError(message, txHash)`

### `src/modules/oracle.ts`
- `new Error('End observation must be after ...')` → `new ValidationError(message, { startTimestamp, endTimestamp })`
- `new Error('Pool has no liquidity')` → `new InsufficientLiquidityError(pairAddress)`

### `tests/swap-math.test.ts`
- Updated assertions from string matching (`.toThrow('...')`) to typed class checks (`.toThrow(ValidationError)`, `.toThrow(InsufficientLiquidityError)`)
- Added test verifying all thrown errors are instances of `CoralSwapSDKError`

## Acceptance Criteria

- [x] Zero raw `Error` throws in `src/modules/`
- [x] All errors are instances of `CoralSwapSDKError`
- [x] Tests updated to catch specific error types
- [x] `npm run build` passes
- [x] `npm test` passes (55/55)