### PR TITLE
feat(client): implemented external signer support with wallet adapter…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Network, Logger } from './types/common';
+import { Network, Logger, Signer } from './types/common';
 
 /**
  * Contract addresses per network deployment.
@@ -21,6 +21,8 @@ export interface CoralSwapConfig {
   publicKey?: string;
   /** Optional logger for RPC request/response instrumentation. */
   logger?: Logger;
+  /** External signer for wallet adapter pattern. Takes precedence over secretKey. */
+  signer?: Signer;
   defaultSlippageBps?: number;
   defaultDeadlineSec?: number;
   maxRetries?: number;

--- a/src/contracts/pair.ts
+++ b/src/contracts/pair.ts
@@ -1,5 +1,5 @@
 import { Contract, SorobanRpc, TransactionBuilder, xdr, Address, nativeToScVal } from '@stellar/stellar-sdk';
-import { PoolState, FeeState, FlashLoanConfig } from '../types/pool';
+import { FeeState, FlashLoanConfig } from '../types/pool';
 
 /**
  * Type-safe client for a CoralSwap Pair contract.

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@
  */
 
 // Core client
-export { CoralSwapClient } from './client';
+export { CoralSwapClient, KeypairSigner } from './client';
 
 // Configuration
 export {

--- a/src/modules/fees.ts
+++ b/src/modules/fees.ts
@@ -1,5 +1,5 @@
 import { CoralSwapClient } from '../client';
-import { FeeEstimate, FeeHistoryEntry } from '../types/fee';
+import { FeeEstimate } from '../types/fee';
 import { FeeState } from '../types/pool';
 
 /**

--- a/src/modules/liquidity.ts
+++ b/src/modules/liquidity.ts
@@ -53,10 +53,6 @@ export class LiquidityModule {
 
     const amountBOptimal = (amountADesired * reserveB) / reserveA;
 
-    const currentProduct = reserveA * reserveB;
-    const newProduct = (reserveA + amountADesired) * (reserveB + amountBOptimal);
-    const lpRatio = this.sqrt(newProduct) - this.sqrt(currentProduct);
-
     const totalSupply = await this.getLPTotalSupply(pairAddress);
     const estimatedLP = totalSupply > 0n
       ? (amountADesired * totalSupply) / reserveA
@@ -151,7 +147,7 @@ export class LiquidityModule {
     owner: string,
   ): Promise<LPPosition> {
     const pair = this.client.pair(pairAddress);
-    const [reserves, tokens] = await Promise.all([
+    const [reserves] = await Promise.all([
       pair.getReserves(),
       pair.getTokens(),
     ]);

--- a/src/modules/swap.ts
+++ b/src/modules/swap.ts
@@ -3,6 +3,7 @@ import { TradeType } from '../types/common';
 import { SwapRequest, SwapQuote, SwapResult, HopResult } from '../types/swap';
 import { PRECISION, DEFAULTS } from '../config';
 import { PairNotFoundError, ValidationError, InsufficientLiquidityError } from '../errors';
+import { PairClient } from '../contracts/pair';
 
 /**
  * Swap module -- builds, quotes, and executes token swaps.
@@ -345,7 +346,7 @@ export class SwapModule {
   /**
    * Determine if tokenIn is token0 in the pair ordering.
    */
-  private async isToken0(pair: any, tokenIn: string): Promise<boolean> {
+  private async isToken0(pair: PairClient, tokenIn: string): Promise<boolean> {
     const tokens = await pair.getTokens();
     return tokens.token0 === tokenIn;
   }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -81,3 +81,16 @@ export interface Logger {
   /** Error-level log for failed simulations, submissions, and exceptions. */
   error(msg: string, err?: unknown): void;
 }
+
+/**
+ * External signer interface for wallet adapter pattern.
+ *
+ * Implement this interface to integrate external wallets (e.g. Freighter,
+ * Albedo) with CoralSwapClient instead of passing raw secret keys.
+ */
+export interface Signer {
+  /** Return the public key of the signer. */
+  publicKey(): Promise<string>;
+  /** Sign a Stellar transaction and return the signed transaction. */
+  signTransaction(xdr: string): Promise<string>;
+}

--- a/tests/signer.test.ts
+++ b/tests/signer.test.ts
@@ -1,0 +1,151 @@
+import { Keypair } from '@stellar/stellar-sdk';
+import { CoralSwapClient, KeypairSigner } from '../src/client';
+import { Network, Signer } from '../src/types/common';
+import { SignerError } from '../src/errors';
+
+/**
+ * Tests for the external signer support (wallet adapter pattern).
+ *
+ * Validates that CoralSwapClient accepts both secret key strings
+ * and custom Signer implementations, maintaining backward compatibility.
+ */
+describe('Signer Support', () => {
+  const TEST_SECRET = 'SB6K2AINTGNYBFX4M7TRPGSKQ5RKNOXXWB7UZUHRYOVTM7REDUGECKZU';
+  const TEST_PUBLIC = Keypair.fromSecret(TEST_SECRET).publicKey();
+
+  describe('KeypairSigner', () => {
+    it('returns the correct public key', async () => {
+      const signer = new KeypairSigner(
+        TEST_SECRET,
+        'Test SDF Network ; September 2015',
+      );
+      const pubKey = await signer.publicKey();
+      expect(pubKey).toBe(TEST_PUBLIC);
+    });
+
+    it('exposes publicKeySync for synchronous access', () => {
+      const signer = new KeypairSigner(
+        TEST_SECRET,
+        'Test SDF Network ; September 2015',
+      );
+      expect(signer.publicKeySync).toBe(TEST_PUBLIC);
+    });
+
+    it('signs transaction XDR and returns a string', async () => {
+      const signer = new KeypairSigner(
+        TEST_SECRET,
+        'Test SDF Network ; September 2015',
+      );
+      // signTransaction expects valid XDR -- tested via integration
+      expect(typeof signer.signTransaction).toBe('function');
+    });
+  });
+
+  describe('CoralSwapClient with secretKey (backward compatibility)', () => {
+    it('resolves publicKey synchronously when secretKey is provided', () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        secretKey: TEST_SECRET,
+      });
+      expect(client.publicKey).toBe(TEST_PUBLIC);
+    });
+
+    it('resolves publicKey asynchronously when secretKey is provided', async () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        secretKey: TEST_SECRET,
+      });
+      const pubKey = await client.resolvePublicKey();
+      expect(pubKey).toBe(TEST_PUBLIC);
+    });
+  });
+
+  describe('CoralSwapClient with custom Signer', () => {
+    it('accepts a custom signer object', async () => {
+      const mockSigner: Signer = {
+        publicKey: jest.fn().mockResolvedValue(TEST_PUBLIC),
+        signTransaction: jest.fn().mockResolvedValue('signed-xdr'),
+      };
+
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        signer: mockSigner,
+      });
+
+      const pubKey = await client.resolvePublicKey();
+      expect(pubKey).toBe(TEST_PUBLIC);
+      expect(mockSigner.publicKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches public key after first resolve', async () => {
+      const mockSigner: Signer = {
+        publicKey: jest.fn().mockResolvedValue(TEST_PUBLIC),
+        signTransaction: jest.fn().mockResolvedValue('signed-xdr'),
+      };
+
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        signer: mockSigner,
+      });
+
+      await client.resolvePublicKey();
+      await client.resolvePublicKey();
+      expect(mockSigner.publicKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('sync publicKey works after resolvePublicKey is called', async () => {
+      const mockSigner: Signer = {
+        publicKey: jest.fn().mockResolvedValue(TEST_PUBLIC),
+        signTransaction: jest.fn().mockResolvedValue('signed-xdr'),
+      };
+
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        signer: mockSigner,
+      });
+
+      await client.resolvePublicKey();
+      expect(client.publicKey).toBe(TEST_PUBLIC);
+    });
+
+    it('prefers signer over secretKey when both provided', async () => {
+      const mockSigner: Signer = {
+        publicKey: jest.fn().mockResolvedValue('GCUSTOM_PUBLIC_KEY'),
+        signTransaction: jest.fn().mockResolvedValue('signed-xdr'),
+      };
+
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        secretKey: TEST_SECRET,
+        signer: mockSigner,
+      });
+
+      const pubKey = await client.resolvePublicKey();
+      expect(pubKey).toBe('GCUSTOM_PUBLIC_KEY');
+    });
+  });
+
+  describe('CoralSwapClient without signer', () => {
+    it('throws SignerError when publicKey is accessed without signer', () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+      });
+      expect(() => client.publicKey).toThrow(SignerError);
+    });
+
+    it('throws SignerError on resolvePublicKey without signer', async () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+      });
+      await expect(client.resolvePublicKey()).rejects.toThrow(SignerError);
+    });
+
+    it('uses config.publicKey for read-only operations', () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        publicKey: TEST_PUBLIC,
+      });
+      expect(client.publicKey).toBe(TEST_PUBLIC);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refactored `CoralSwapClient` to accept an external `Signer` interface for
wallet adapter integration (Freighter, Albedo, etc.) while maintaining full
backward compatibility with the existing `secretKey` string mode.

Closes #2

## Changes

### `src/types/common.ts`
- Added `Signer` interface with `publicKey()` and `signTransaction(xdr)` methods

### `src/config.ts`
- Added optional `signer` field to `CoralSwapConfig` interface

### `src/client.ts`
- Added `KeypairSigner` class that wraps `Keypair` for backward-compatible
  secret key mode, implementing the `Signer` interface
- Replaced `private keypair: Keypair | null` with `private signer: Signer | null`
- Constructor now accepts `config.signer` (takes precedence) or falls back to
  wrapping `config.secretKey` in a `KeypairSigner`
- Added `resolvePublicKey()` async method for external signers that resolve
  the public key asynchronously
- Replaced `preparedTx.sign(this.keypair)` with
  `await this.signer.signTransaction(preparedTx.toXDR())` in `submitTransaction`
- `publicKey` sync getter still works for `secretKey` mode (eagerly cached)

### `src/index.ts`
- Exported `KeypairSigner` alongside `CoralSwapClient`

### `tests/signer.test.ts` (new)
- 12 tests covering:
  - `KeypairSigner` public key derivation and sync access
  - Backward compatibility: `secretKey` resolves `publicKey` synchronously
  - Custom `Signer`: mock signer accepted and called correctly
  - Public key caching after first `resolvePublicKey()` call
  - `signer` takes precedence over `secretKey` when both provided
  - `SignerError` thrown when no signer is configured
  - Read-only mode with `publicKey` config only

## Usage

**Existing (unchanged):**
```ts
const client = new CoralSwapClient({
  network: Network.TESTNET,
  secretKey: 'S...',
});