### PR TITLE
feat(client): added request/response logging middleware to CoralSwapClient

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Network } from './types/common';
+import { Network, Logger } from './types/common';
 
 /**
  * Contract addresses per network deployment.
@@ -19,6 +19,8 @@ export interface CoralSwapConfig {
   rpcUrl?: string;
   secretKey?: string;
   publicKey?: string;
+  /** Optional logger for RPC request/response instrumentation. */
+  logger?: Logger;
   defaultSlippageBps?: number;
   defaultDeadlineSec?: number;
   maxRetries?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export {
 
 // Type exports
 export * from './types';
+export type { Logger } from './types/common';
 
 // Contract clients
 export {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -65,3 +65,19 @@ export interface CoralSwapError {
   message: string;
   details?: Record<string, unknown>;
 }
+
+/**
+ * Logger interface for SDK request/response instrumentation.
+ *
+ * Implement this interface to receive debug, info, and error
+ * logs from all RPC interactions within CoralSwapClient.
+ * Defaults to undefined (no logging) for backward compatibility.
+ */
+export interface Logger {
+  /** Debug-level log for routine RPC calls and polling. */
+  debug(msg: string, data?: unknown): void;
+  /** Info-level log for successful operations. */
+  info(msg: string, data?: unknown): void;
+  /** Error-level log for failed simulations, submissions, and exceptions. */
+  error(msg: string, err?: unknown): void;
+}

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,153 @@
+import { CoralSwapClient } from '../src/client';
+import { Network, Logger } from '../src/types/common';
+
+/**
+ * Tests for request/response logging middleware.
+ *
+ * Validates that CoralSwapClient emits debug, info, and error logs
+ * for all RPC interactions when a Logger is provided, and remains
+ * silent when no logger is configured (backward compatibility).
+ */
+
+/**
+ * Create a mock Logger where every method is a jest.fn().
+ */
+function createMockLogger(): Logger & {
+  debug: jest.Mock;
+  info: jest.Mock;
+  error: jest.Mock;
+} {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+describe('Logger Middleware', () => {
+  describe('config acceptance', () => {
+    it('accepts a custom logger in config', () => {
+      const logger = createMockLogger();
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        publicKey: 'GABCDEFG',
+        logger,
+      });
+      expect(client.config.logger).toBe(logger);
+    });
+
+    it('defaults to undefined when no logger is provided', () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        publicKey: 'GABCDEFG',
+      });
+      expect(client.config.logger).toBeUndefined();
+    });
+
+    it('does not throw when logger is undefined (backward compatible)', () => {
+      expect(() => {
+        new CoralSwapClient({
+          network: Network.TESTNET,
+          publicKey: 'GABCDEFG',
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('submitTransaction logging', () => {
+    it('emits debug log for getAccount call', async () => {
+      const logger = createMockLogger();
+      const mockAccount = {
+        accountId: () => 'GABCDEFG',
+        sequenceNumber: () => '1',
+        sequence: '1',
+      };
+
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        secretKey: undefined,
+        publicKey: 'GABCDEFG',
+        logger,
+      });
+
+      // Mock server methods to isolate logging behavior
+      (client.server as unknown as Record<string, unknown>).getAccount = jest
+        .fn()
+        .mockRejectedValue(new Error('mock: stop after getAccount'));
+
+      try {
+        await client.submitTransaction([]);
+      } catch {
+        // Expected to fail -- we only care about the log call
+      }
+
+      // The debug log for getAccount should have been called before the error
+      expect(logger.debug).toHaveBeenCalledWith(
+        'getAccount: fetching account',
+        expect.objectContaining({ sourceKey: 'GABCDEFG' }),
+      );
+    });
+
+    it('emits error log when submitTransaction catches unexpected error', async () => {
+      const logger = createMockLogger();
+
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        publicKey: 'GABCDEFG',
+        logger,
+      });
+
+      (client.server as unknown as Record<string, unknown>).getAccount = jest
+        .fn()
+        .mockRejectedValue(new Error('RPC connection lost'));
+
+      const result = await client.submitTransaction([]);
+      expect(result.success).toBe(false);
+      expect(logger.error).toHaveBeenCalledWith(
+        'submitTransaction: unexpected error',
+        expect.any(Error),
+      );
+    });
+
+    it('does not throw when logger is undefined during submitTransaction', async () => {
+      const client = new CoralSwapClient({
+        network: Network.TESTNET,
+        publicKey: 'GABCDEFG',
+      });
+
+      (client.server as unknown as Record<string, unknown>).getAccount = jest
+        .fn()
+        .mockRejectedValue(new Error('fail'));
+
+      const result = await client.submitTransaction([]);
+      expect(result.success).toBe(false);
+      // No throws -- logger?.method() safely no-ops
+    });
+  });
+
+  describe('logger interface contract', () => {
+    it('Logger methods receive string message and optional data', () => {
+      const logger = createMockLogger();
+
+      logger.debug('test debug', { key: 'value' });
+      logger.info('test info', { key: 'value' });
+      logger.error('test error', new Error('e'));
+
+      expect(logger.debug).toHaveBeenCalledWith('test debug', { key: 'value' });
+      expect(logger.info).toHaveBeenCalledWith('test info', { key: 'value' });
+      expect(logger.error).toHaveBeenCalledWith('test error', expect.any(Error));
+    });
+
+    it('Logger methods can be called without data argument', () => {
+      const logger = createMockLogger();
+
+      logger.debug('debug only');
+      logger.info('info only');
+      logger.error('error only');
+
+      expect(logger.debug).toHaveBeenCalledWith('debug only');
+      expect(logger.info).toHaveBeenCalledWith('info only');
+      expect(logger.error).toHaveBeenCalledWith('error only');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Added opt-in logging middleware to `CoralSwapClient` that instruments all
RPC interactions with debug, info, and error logs. Developers can now plug
in any logger (console, pino, winston, custom) to get full visibility into
SDK ↔ Soroban RPC communication for debugging transaction failures.

Closes #6

## Changes

### `src/types/common.ts`
- Added `Logger` interface with `debug(msg, data?)`, `info(msg, data?)`,
  and `error(msg, err?)` methods

### `src/config.ts`
- Imported `Logger` type
- Added optional `logger` field to `CoralSwapConfig`

### `src/client.ts`
- Added `private readonly logger?: Logger` property
- Constructor assigns `config.logger` to the instance
- **`submitTransaction`** instrumented with:
  - `debug` log before/after `server.getAccount()` call
  - `debug` log before/after `server.simulateTransaction()` call
  - `error` log on simulation failure
  - `info` log on successful `server.sendTransaction()` (with tx hash)
  - `error` log on submission failure
  - `error` log on unexpected exceptions
- **`pollTransaction`** instrumented with:
  - `debug` log on each polling attempt (attempt number, tx hash)
  - `info` log on confirmed transaction (tx hash, ledger)
  - `error` log on on-chain failure
  - `error` log on polling timeout
- **`simulateTransaction` (dry-run)** instrumented with:
  - `debug` log before/after `getAccount` and `simulateTransaction`

### `src/index.ts`
- Exported `Logger` type for consumer use

### `tests/logger.test.ts` (new)
- 8 tests covering:
  - Config accepts custom logger
  - Config defaults to `undefined` (no logger)
  - No throw when logger is undefined (backward compatible)
  - Debug log emitted for `getAccount` call
  - Error log emitted on unexpected `submitTransaction` error
  - No throw when logger is absent during `submitTransaction`
  - Logger interface contract (with and without data argument)

## Usage

```ts
import { CoralSwapClient, Network, Logger } from '@coralswap/sdk';

// Use console as logger
const client = new CoralSwapClient({
  network: Network.TESTNET,
  secretKey: 'S...',
  logger: {
    debug: (msg, data) => console.debug(`[SDK] ${msg}`, data),
    info:  (msg, data) => console.info(`[SDK] ${msg}`, data),
    error: (msg, err)  => console.error(`[SDK] ${msg}`, err),
  },
});

// Or omit logger entirely (default, fully backward compatible)
const silentClient = new CoralSwapClient({
  network: Network.TESTNET,
  secretKey: 'S...',
});