### PR TITLE
Revert "fix: Improve error mapping with regex extraction and Soroban …

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,13 +12,9 @@ export class CoralSwapSDKError extends Error {
   readonly code: string;
   readonly details?: Record<string, unknown>;
 
-  constructor(
-    code: string,
-    message: string,
-    details?: Record<string, unknown>,
-  ) {
+  constructor(code: string, message: string, details?: Record<string, unknown>) {
     super(message);
-    this.name = "CoralSwapSDKError";
+    this.name = 'CoralSwapSDKError';
     this.code = code;
     this.details = details;
     Object.setPrototypeOf(this, new.target.prototype);
@@ -30,8 +26,8 @@ export class CoralSwapSDKError extends Error {
  */
 export class NetworkError extends CoralSwapSDKError {
   constructor(message: string, details?: Record<string, unknown>) {
-    super("NETWORK_ERROR", message, details);
-    this.name = "NetworkError";
+    super('NETWORK_ERROR', message, details);
+    this.name = 'NetworkError';
   }
 }
 
@@ -40,8 +36,8 @@ export class NetworkError extends CoralSwapSDKError {
  */
 export class RpcError extends CoralSwapSDKError {
   constructor(message: string, details?: Record<string, unknown>) {
-    super("RPC_ERROR", message, details);
-    this.name = "RpcError";
+    super('RPC_ERROR', message, details);
+    this.name = 'RpcError';
   }
 }
 
@@ -50,8 +46,8 @@ export class RpcError extends CoralSwapSDKError {
  */
 export class SimulationError extends CoralSwapSDKError {
   constructor(message: string, details?: Record<string, unknown>) {
-    super("SIMULATION_ERROR", message, details);
-    this.name = "SimulationError";
+    super('SIMULATION_ERROR', message, details);
+    this.name = 'SimulationError';
   }
 }
 
@@ -61,13 +57,9 @@ export class SimulationError extends CoralSwapSDKError {
 export class TransactionError extends CoralSwapSDKError {
   readonly txHash?: string;
 
-  constructor(
-    message: string,
-    txHash?: string,
-    details?: Record<string, unknown>,
-  ) {
-    super("TRANSACTION_ERROR", message, details);
-    this.name = "TransactionError";
+  constructor(message: string, txHash?: string, details?: Record<string, unknown>) {
+    super('TRANSACTION_ERROR', message, details);
+    this.name = 'TransactionError';
     this.txHash = txHash;
   }
 }
@@ -77,10 +69,10 @@ export class TransactionError extends CoralSwapSDKError {
  */
 export class DeadlineError extends CoralSwapSDKError {
   constructor(deadline: number) {
-    super("DEADLINE_EXCEEDED", `Transaction deadline exceeded: ${deadline}`, {
+    super('DEADLINE_EXCEEDED', `Transaction deadline exceeded: ${deadline}`, {
       deadline,
     });
-    this.name = "DeadlineError";
+    this.name = 'DeadlineError';
   }
 }
 
@@ -92,19 +84,13 @@ export class SlippageError extends CoralSwapSDKError {
     expected: bigint,
     actual: bigint,
     toleranceBps: number,
-    additionalDetails?: Record<string, unknown>,
   ) {
     super(
-      "SLIPPAGE_EXCEEDED",
+      'SLIPPAGE_EXCEEDED',
       `Slippage exceeded: expected ${expected}, got ${actual} (tolerance: ${toleranceBps}bps)`,
-      {
-        expected: expected.toString(),
-        actual: actual.toString(),
-        toleranceBps,
-        ...additionalDetails,
-      },
+      { expected: expected.toString(), actual: actual.toString(), toleranceBps },
     );
-    this.name = "SlippageError";
+    this.name = 'SlippageError';
   }
 }
 
@@ -114,11 +100,11 @@ export class SlippageError extends CoralSwapSDKError {
 export class InsufficientLiquidityError extends CoralSwapSDKError {
   constructor(pairAddress: string, details?: Record<string, unknown>) {
     super(
-      "INSUFFICIENT_LIQUIDITY",
+      'INSUFFICIENT_LIQUIDITY',
       `Insufficient liquidity in pair ${pairAddress}`,
       { pairAddress, ...details },
     );
-    this.name = "InsufficientLiquidityError";
+    this.name = 'InsufficientLiquidityError';
   }
 }
 
@@ -127,11 +113,11 @@ export class InsufficientLiquidityError extends CoralSwapSDKError {
  */
 export class PairNotFoundError extends CoralSwapSDKError {
   constructor(tokenA: string, tokenB: string) {
-    super("PAIR_NOT_FOUND", `No pair found for tokens ${tokenA} / ${tokenB}`, {
+    super('PAIR_NOT_FOUND', `No pair found for tokens ${tokenA} / ${tokenB}`, {
       tokenA,
       tokenB,
     });
-    this.name = "PairNotFoundError";
+    this.name = 'PairNotFoundError';
   }
 }
 
@@ -140,8 +126,8 @@ export class PairNotFoundError extends CoralSwapSDKError {
  */
 export class ValidationError extends CoralSwapSDKError {
   constructor(message: string, details?: Record<string, unknown>) {
-    super("VALIDATION_ERROR", message, details);
-    this.name = "ValidationError";
+    super('VALIDATION_ERROR', message, details);
+    this.name = 'ValidationError';
   }
 }
 
@@ -150,8 +136,8 @@ export class ValidationError extends CoralSwapSDKError {
  */
 export class FlashLoanError extends CoralSwapSDKError {
   constructor(message: string, details?: Record<string, unknown>) {
-    super("FLASH_LOAN_ERROR", message, details);
-    this.name = "FlashLoanError";
+    super('FLASH_LOAN_ERROR', message, details);
+    this.name = 'FlashLoanError';
   }
 }
 
@@ -160,10 +146,12 @@ export class FlashLoanError extends CoralSwapSDKError {
  */
 export class CircuitBreakerError extends CoralSwapSDKError {
   constructor(pairAddress: string) {
-    super("CIRCUIT_BREAKER", `Circuit breaker active on pair ${pairAddress}`, {
-      pairAddress,
-    });
-    this.name = "CircuitBreakerError";
+    super(
+      'CIRCUIT_BREAKER',
+      `Circuit breaker active on pair ${pairAddress}`,
+      { pairAddress },
+    );
+    this.name = 'CircuitBreakerError';
   }
 }
 
@@ -173,247 +161,38 @@ export class CircuitBreakerError extends CoralSwapSDKError {
 export class SignerError extends CoralSwapSDKError {
   constructor() {
     super(
-      "NO_SIGNER",
-      "No signing key configured. Provide secretKey in config or use external signing.",
+      'NO_SIGNER',
+      'No signing key configured. Provide secretKey in config or use external signing.',
     );
-    this.name = "SignerError";
-  }
-}
-
-/**
- * Extract pair address from error details or message.
- */
-function extractPairAddress(err: unknown): string {
-  if (err && typeof err === "object") {
-    const details = (err as any).details;
-    if (details?.pairAddress) return details.pairAddress;
-    if (details?.pair) return details.pair;
-  }
-
-  const message = err instanceof Error ? err.message : String(err);
-  // Try to extract Stellar address pattern (C or G followed by 47-55 alphanumeric chars)
-  // Real Stellar addresses are 56 chars, but we're flexible for test addresses
-  const addressMatch = message.match(/[CG][A-Z0-9]{47,55}/i);
-  if (addressMatch) return addressMatch[0];
-
-  return "unknown";
-}
-
-/**
- * Map Soroban contract error codes to SDK errors.
- *
- * Contract error codes are returned in the format: Error(Contract, #XXX)
- * where XXX is the error code defined in the contract.
- */
-function mapContractError(
-  code: number,
-  message: string,
-  err: unknown,
-): CoralSwapSDKError | null {
-  // Core pair contract errors (100-113)
-  switch (code) {
-    case 100:
-      return new ValidationError("Invalid token pair", {
-        contractErrorCode: code,
-      });
-    case 101:
-      return new InsufficientLiquidityError(extractPairAddress(err), {
-        contractErrorCode: code,
-      });
-    case 102:
-      return new SlippageError(0n, 0n, 0, { contractErrorCode: code });
-    case 103:
-      return new DeadlineError(0);
-    case 104:
-      return new ValidationError("Invalid amount", { contractErrorCode: code });
-    case 105:
-      return new ValidationError("Insufficient input amount", {
-        contractErrorCode: code,
-      });
-    case 106:
-      return new FlashLoanError("Reentrancy detected", {
-        contractErrorCode: code,
-      });
-    case 107:
-      return new FlashLoanError("Flash loan callback failed", {
-        contractErrorCode: code,
-      });
-    case 108:
-      return new FlashLoanError("Flash loan repayment insufficient", {
-        contractErrorCode: code,
-      });
-    case 109:
-      return new CircuitBreakerError(extractPairAddress(err));
-    case 110:
-      return new ValidationError("Unauthorized", { contractErrorCode: code });
-    case 111:
-      return new ValidationError("Invalid recipient", {
-        contractErrorCode: code,
-      });
-    case 112:
-      return new ValidationError("Overflow", { contractErrorCode: code });
-    case 113:
-      return new ValidationError("K invariant violated", {
-        contractErrorCode: code,
-      });
-
-    // Router contract errors (300-306)
-    case 300:
-      return new PairNotFoundError("unknown", "unknown");
-    case 301:
-      return new ValidationError("Invalid path", { contractErrorCode: code });
-    case 302:
-      return new SlippageError(0n, 0n, 0, { contractErrorCode: code });
-    case 303:
-      return new DeadlineError(0);
-    case 304:
-      return new InsufficientLiquidityError(extractPairAddress(err), {
-        contractErrorCode: code,
-      });
-    case 305:
-      return new ValidationError("Excessive input amount", {
-        contractErrorCode: code,
-      });
-    case 306:
-      return new ValidationError("Invalid token", { contractErrorCode: code });
-
-    default:
-      return null;
+    this.name = 'SignerError';
   }
 }
 
 /**
  * Map a raw error to the appropriate typed error class.
- *
- * This function provides intelligent error mapping with:
- * - Soroban contract error code detection
- * - Regex-based data extraction from error messages
- * - Context preservation from error details
- * - Fallback to generic error types
  */
 export function mapError(err: unknown): CoralSwapSDKError {
   if (err instanceof CoralSwapSDKError) return err;
 
   const message = err instanceof Error ? err.message : String(err);
 
-  // Check for Soroban contract error codes: Error(Contract, #XXX)
-  const contractErrorMatch = message.match(/Error\(Contract,\s*#?(\d+)\)/i);
-  if (contractErrorMatch) {
-    const errorCode = parseInt(contractErrorMatch[1], 10);
-    const mappedError = mapContractError(errorCode, message, err);
-    if (mappedError) return mappedError;
+  if (message.includes('EXPIRED') || message.includes('deadline')) {
+    return new DeadlineError(0);
   }
-
-  // Extract deadline value from message - improved regex
-  const deadlineMatch = message.match(/deadline[:\s]*[a-z]*[:\s]*(\d+)/i);
-  if (message.includes("EXPIRED") || message.includes("deadline")) {
-    const deadline = deadlineMatch ? parseInt(deadlineMatch[1], 10) : 0;
-    return new DeadlineError(deadline);
+  if (message.includes('slippage') || message.includes('INSUFFICIENT_OUTPUT')) {
+    return new SlippageError(0n, 0n, 0);
   }
-
-  // Extract slippage amounts from message
-  if (message.includes("slippage") || message.includes("INSUFFICIENT_OUTPUT")) {
-    const expectedMatch = message.match(/expected[:\s]*(\d+)/i);
-    const actualMatch = message.match(/(?:got|actual)[:\s]*(\d+)/i);
-    const toleranceMatch = message.match(/tolerance[:\s]*(\d+)/i);
-
-    const expected = expectedMatch ? BigInt(expectedMatch[1]) : 0n;
-    const actual = actualMatch ? BigInt(actualMatch[1]) : 0n;
-    const tolerance = toleranceMatch ? parseInt(toleranceMatch[1], 10) : 0;
-
-    return new SlippageError(expected, actual, tolerance);
+  if (message.includes('liquidity')) {
+    return new InsufficientLiquidityError('unknown');
   }
-
-  // Extract pair address for liquidity errors
-  if (
-    message.includes("liquidity") ||
-    message.includes("INSUFFICIENT_LIQUIDITY")
-  ) {
-    return new InsufficientLiquidityError(extractPairAddress(err));
+  if (message.includes('circuit') || message.includes('paused')) {
+    return new CircuitBreakerError('unknown');
   }
-
-  // Circuit breaker / paused pool - check before other patterns
-  if (
-    message.toLowerCase().includes("circuit") ||
-    message.toLowerCase().includes("paused")
-  ) {
-    return new CircuitBreakerError(extractPairAddress(err));
-  }
-
-  // Network connectivity errors
-  if (
-    message.includes("ECONNRESET") ||
-    message.includes("ETIMEDOUT") ||
-    message.includes("ENOTFOUND") ||
-    message.includes("ENETUNREACH")
-  ) {
+  if (message.includes('ECONNRESET') || message.includes('ETIMEDOUT')) {
     return new NetworkError(message);
   }
 
-  // RPC-specific errors
-  if (
-    message.includes("rate limit") ||
-    message.includes("too many requests") ||
-    message.includes("RPC") ||
-    message.includes("429")
-  ) {
-    return new RpcError(message);
-  }
-
-  // Signer errors
-  if (
-    message.includes("signing") ||
-    message.includes("signer") ||
-    message.includes("NO_SIGNER") ||
-    message.includes("private key")
-  ) {
-    return new SignerError();
-  }
-
-  // Flash loan errors
-  if (
-    message.includes("flash loan") ||
-    message.includes("flash_loan") ||
-    message.includes("reentrancy") ||
-    message.includes("callback")
-  ) {
-    return new FlashLoanError(message);
-  }
-
-  // Validation errors - be more specific to avoid false matches
-  if (
-    (message.includes("invalid") && !message.includes("active")) ||
-    message.includes("validation") ||
-    message.includes("required") ||
-    message.includes("must be")
-  ) {
-    return new ValidationError(message);
-  }
-
-  // Pair not found
-  if (
-    message.includes("pair not found") ||
-    message.includes("no pair") ||
-    message.includes("PAIR_NOT_FOUND")
-  ) {
-    return new PairNotFoundError("unknown", "unknown");
-  }
-
-  // Simulation errors
-  if (message.includes("simulation") || message.includes("SIMULATION_FAILED")) {
-    return new SimulationError(message);
-  }
-
-  // Transaction errors
-  if (
-    message.includes("transaction") ||
-    message.includes("TX_FAILED") ||
-    message.includes("tx failed")
-  ) {
-    return new TransactionError(message);
-  }
-
-  return new CoralSwapSDKError("UNKNOWN_ERROR", message, {
+  return new CoralSwapSDKError('UNKNOWN_ERROR', message, {
     originalError: err,
   });
 }

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,477 +1,63 @@
 import {
   CoralSwapSDKError,
   NetworkError,
-  RpcError,
-  SimulationError,
-  TransactionError,
   SlippageError,
   DeadlineError,
   PairNotFoundError,
-  InsufficientLiquidityError,
-  CircuitBreakerError,
-  ValidationError,
-  FlashLoanError,
-  SignerError,
   mapError,
-} from "../src/errors";
+} from '../src/errors';
 
-describe("Error Hierarchy", () => {
-  it("CoralSwapSDKError is instanceof Error", () => {
-    const err = new CoralSwapSDKError("TEST", "test message");
+describe('Error Hierarchy', () => {
+  it('CoralSwapSDKError is instanceof Error', () => {
+    const err = new CoralSwapSDKError('TEST', 'test message');
     expect(err).toBeInstanceOf(Error);
     expect(err).toBeInstanceOf(CoralSwapSDKError);
-    expect(err.code).toBe("TEST");
+    expect(err.code).toBe('TEST');
   });
 
-  it("NetworkError carries code", () => {
-    const err = new NetworkError("connection lost");
-    expect(err.code).toBe("NETWORK_ERROR");
-    expect(err.name).toBe("NetworkError");
+  it('NetworkError carries code', () => {
+    const err = new NetworkError('connection lost');
+    expect(err.code).toBe('NETWORK_ERROR');
+    expect(err.name).toBe('NetworkError');
   });
 
-  it("SlippageError includes amounts", () => {
+  it('SlippageError includes amounts', () => {
     const err = new SlippageError(100n, 90n, 50);
-    expect(err.code).toBe("SLIPPAGE_EXCEEDED");
+    expect(err.code).toBe('SLIPPAGE_EXCEEDED');
     expect(err.details?.toleranceBps).toBe(50);
   });
 
-  it("DeadlineError includes timestamp", () => {
+  it('DeadlineError includes timestamp', () => {
     const err = new DeadlineError(1234567890);
-    expect(err.code).toBe("DEADLINE_EXCEEDED");
+    expect(err.code).toBe('DEADLINE_EXCEEDED');
     expect(err.details?.deadline).toBe(1234567890);
   });
 
-  it("PairNotFoundError includes tokens", () => {
-    const err = new PairNotFoundError("TOKEN_A", "TOKEN_B");
-    expect(err.code).toBe("PAIR_NOT_FOUND");
-    expect(err.details?.tokenA).toBe("TOKEN_A");
+  it('PairNotFoundError includes tokens', () => {
+    const err = new PairNotFoundError('TOKEN_A', 'TOKEN_B');
+    expect(err.code).toBe('PAIR_NOT_FOUND');
+    expect(err.details?.tokenA).toBe('TOKEN_A');
   });
 
-  describe("mapError", () => {
-    it("passes through SDK errors", () => {
-      const original = new NetworkError("test");
+  describe('mapError', () => {
+    it('passes through SDK errors', () => {
+      const original = new NetworkError('test');
       expect(mapError(original)).toBe(original);
     });
 
-    describe("Deadline errors", () => {
-      it("maps deadline strings with extracted value", () => {
-        const err = mapError(new Error("Transaction deadline: 1234567890"));
-        expect(err.code).toBe("DEADLINE_EXCEEDED");
-        expect(err).toBeInstanceOf(DeadlineError);
-        expect(err.details?.deadline).toBe(1234567890);
-      });
-
-      it("maps EXPIRED without deadline value", () => {
-        const err = mapError(new Error("Transaction EXPIRED"));
-        expect(err.code).toBe("DEADLINE_EXCEEDED");
-        expect(err.details?.deadline).toBe(0);
-      });
-
-      it("extracts deadline from various formats", () => {
-        const err = mapError(new Error("deadline exceeded: 9876543210"));
-        expect(err.code).toBe("DEADLINE_EXCEEDED");
-        expect(err.details?.deadline).toBe(9876543210);
-      });
+    it('maps deadline strings', () => {
+      const err = mapError(new Error('Transaction EXPIRED'));
+      expect(err.code).toBe('DEADLINE_EXCEEDED');
     });
 
-    describe("Slippage errors", () => {
-      it("maps slippage with extracted amounts", () => {
-        const err = mapError(
-          new Error("slippage exceeded: expected 1000, got 900, tolerance 50"),
-        );
-        expect(err.code).toBe("SLIPPAGE_EXCEEDED");
-        expect(err).toBeInstanceOf(SlippageError);
-        expect(err.details?.expected).toBe("1000");
-        expect(err.details?.actual).toBe("900");
-        expect(err.details?.toleranceBps).toBe(50);
-      });
-
-      it("maps INSUFFICIENT_OUTPUT", () => {
-        const err = mapError(new Error("INSUFFICIENT_OUTPUT"));
-        expect(err.code).toBe("SLIPPAGE_EXCEEDED");
-      });
-
-      it("handles slippage without extractable values", () => {
-        const err = mapError(new Error("slippage exceeded"));
-        expect(err.code).toBe("SLIPPAGE_EXCEEDED");
-        expect(err.details?.expected).toBe("0");
-        expect(err.details?.actual).toBe("0");
-      });
+    it('maps network errors', () => {
+      const err = mapError(new Error('ECONNRESET'));
+      expect(err.code).toBe('NETWORK_ERROR');
     });
 
-    describe("Liquidity errors", () => {
-      it("maps liquidity errors with pair address", () => {
-        const pairAddress =
-          "CDUMMYPAIRADDRESSFORTEST1234567890ABCDEFGHIJKLMNOP";
-        const err = mapError(
-          new Error(`Insufficient liquidity in ${pairAddress}`),
-        );
-        expect(err.code).toBe("INSUFFICIENT_LIQUIDITY");
-        expect(err).toBeInstanceOf(InsufficientLiquidityError);
-        expect(err.details?.pairAddress).toBe(pairAddress);
-      });
-
-      it("maps liquidity errors without address", () => {
-        const err = mapError(new Error("Insufficient liquidity"));
-        expect(err.code).toBe("INSUFFICIENT_LIQUIDITY");
-        expect(err.details?.pairAddress).toBe("unknown");
-      });
-    });
-
-    describe("Circuit breaker errors", () => {
-      it("maps circuit breaker with pair address", () => {
-        const pairAddress =
-          "CDUMMYPAIRADDRESSFORTEST1234567890ABCDEFGHIJKLMNOP";
-        const err = mapError(new Error(`Circuit breaker on ${pairAddress}`));
-        expect(err.code).toBe("CIRCUIT_BREAKER");
-        expect(err).toBeInstanceOf(CircuitBreakerError);
-        expect(err.details?.pairAddress).toBe(pairAddress);
-      });
-
-      it("maps paused pool", () => {
-        const err = mapError(new Error("Pool is paused"));
-        expect(err.code).toBe("CIRCUIT_BREAKER");
-      });
-
-      it("maps PAUSED status", () => {
-        const err = mapError(new Error("PAUSED"));
-        expect(err.code).toBe("CIRCUIT_BREAKER");
-      });
-    });
-
-    describe("Network errors", () => {
-      it("maps ECONNRESET", () => {
-        const err = mapError(new Error("ECONNRESET"));
-        expect(err.code).toBe("NETWORK_ERROR");
-        expect(err).toBeInstanceOf(NetworkError);
-      });
-
-      it("maps ETIMEDOUT", () => {
-        const err = mapError(new Error("ETIMEDOUT"));
-        expect(err.code).toBe("NETWORK_ERROR");
-      });
-
-      it("maps ENOTFOUND", () => {
-        const err = mapError(new Error("ENOTFOUND"));
-        expect(err.code).toBe("NETWORK_ERROR");
-      });
-
-      it("maps ENETUNREACH", () => {
-        const err = mapError(new Error("ENETUNREACH"));
-        expect(err.code).toBe("NETWORK_ERROR");
-      });
-    });
-
-    describe("RPC errors", () => {
-      it("maps rate limit errors", () => {
-        const err = mapError(new Error("rate limit exceeded"));
-        expect(err.code).toBe("RPC_ERROR");
-        expect(err).toBeInstanceOf(RpcError);
-      });
-
-      it("maps too many requests", () => {
-        const err = mapError(new Error("too many requests"));
-        expect(err.code).toBe("RPC_ERROR");
-      });
-
-      it("maps 429 status", () => {
-        const err = mapError(new Error("HTTP 429"));
-        expect(err.code).toBe("RPC_ERROR");
-      });
-
-      it("maps RPC errors", () => {
-        const err = mapError(new Error("RPC endpoint unavailable"));
-        expect(err.code).toBe("RPC_ERROR");
-      });
-    });
-
-    describe("Signer errors", () => {
-      it("maps signing errors", () => {
-        const err = mapError(new Error("signing failed"));
-        expect(err.code).toBe("NO_SIGNER");
-        expect(err).toBeInstanceOf(SignerError);
-      });
-
-      it("maps signer not configured", () => {
-        const err = mapError(new Error("No signer configured"));
-        expect(err.code).toBe("NO_SIGNER");
-      });
-
-      it("maps NO_SIGNER code", () => {
-        const err = mapError(new Error("NO_SIGNER"));
-        expect(err.code).toBe("NO_SIGNER");
-      });
-
-      it("maps private key errors", () => {
-        const err = mapError(new Error("Invalid private key"));
-        expect(err.code).toBe("NO_SIGNER");
-      });
-    });
-
-    describe("Flash loan errors", () => {
-      it("maps flash loan errors", () => {
-        const err = mapError(new Error("flash loan failed"));
-        expect(err.code).toBe("FLASH_LOAN_ERROR");
-        expect(err).toBeInstanceOf(FlashLoanError);
-      });
-
-      it("maps flash_loan with underscore", () => {
-        const err = mapError(new Error("flash_loan callback failed"));
-        expect(err.code).toBe("FLASH_LOAN_ERROR");
-      });
-
-      it("maps reentrancy errors", () => {
-        const err = mapError(new Error("reentrancy detected"));
-        expect(err.code).toBe("FLASH_LOAN_ERROR");
-      });
-
-      it("maps callback errors", () => {
-        const err = mapError(new Error("callback execution failed"));
-        expect(err.code).toBe("FLASH_LOAN_ERROR");
-      });
-    });
-
-    describe("Validation errors", () => {
-      it("maps invalid input", () => {
-        const err = mapError(new Error("invalid amount"));
-        expect(err.code).toBe("VALIDATION_ERROR");
-        expect(err).toBeInstanceOf(ValidationError);
-      });
-
-      it("maps validation failures", () => {
-        const err = mapError(new Error("validation failed"));
-        expect(err.code).toBe("VALIDATION_ERROR");
-      });
-
-      it("maps required field errors", () => {
-        const err = mapError(new Error("field is required"));
-        expect(err.code).toBe("VALIDATION_ERROR");
-      });
-
-      it("maps must be errors", () => {
-        const err = mapError(new Error("amount must be positive"));
-        expect(err.code).toBe("VALIDATION_ERROR");
-      });
-    });
-
-    describe("Pair not found errors", () => {
-      it("maps pair not found", () => {
-        const err = mapError(new Error("pair not found"));
-        expect(err.code).toBe("PAIR_NOT_FOUND");
-        expect(err).toBeInstanceOf(PairNotFoundError);
-      });
-
-      it("maps no pair", () => {
-        const err = mapError(new Error("no pair exists"));
-        expect(err.code).toBe("PAIR_NOT_FOUND");
-      });
-
-      it("maps PAIR_NOT_FOUND code", () => {
-        const err = mapError(new Error("PAIR_NOT_FOUND"));
-        expect(err.code).toBe("PAIR_NOT_FOUND");
-      });
-    });
-
-    describe("Simulation errors", () => {
-      it("maps simulation failures", () => {
-        const err = mapError(new Error("simulation failed"));
-        expect(err.code).toBe("SIMULATION_ERROR");
-        expect(err).toBeInstanceOf(SimulationError);
-      });
-
-      it("maps SIMULATION_FAILED code", () => {
-        const err = mapError(new Error("SIMULATION_FAILED"));
-        expect(err.code).toBe("SIMULATION_ERROR");
-      });
-    });
-
-    describe("Transaction errors", () => {
-      it("maps transaction failures", () => {
-        const err = mapError(new Error("transaction failed"));
-        expect(err.code).toBe("TRANSACTION_ERROR");
-        expect(err).toBeInstanceOf(TransactionError);
-      });
-
-      it("maps TX_FAILED code", () => {
-        const err = mapError(new Error("TX_FAILED"));
-        expect(err.code).toBe("TRANSACTION_ERROR");
-      });
-
-      it("maps tx failed", () => {
-        const err = mapError(new Error("tx failed on-chain"));
-        expect(err.code).toBe("TRANSACTION_ERROR");
-      });
-    });
-
-    describe("Soroban contract error codes", () => {
-      describe("Core pair contract errors (100-113)", () => {
-        it("maps error code 100 - Invalid token pair", () => {
-          const err = mapError(new Error("Error(Contract, #100)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err).toBeInstanceOf(ValidationError);
-          expect(err.details?.contractErrorCode).toBe(100);
-        });
-
-        it("maps error code 101 - Insufficient liquidity", () => {
-          const err = mapError(new Error("Error(Contract, #101)"));
-          expect(err.code).toBe("INSUFFICIENT_LIQUIDITY");
-          expect(err).toBeInstanceOf(InsufficientLiquidityError);
-          expect(err.details?.contractErrorCode).toBe(101);
-        });
-
-        it("maps error code 102 - Slippage exceeded", () => {
-          const err = mapError(new Error("Error(Contract, #102)"));
-          expect(err.code).toBe("SLIPPAGE_EXCEEDED");
-          expect(err).toBeInstanceOf(SlippageError);
-          expect(err.details?.contractErrorCode).toBe(102);
-        });
-
-        it("maps error code 103 - Deadline exceeded", () => {
-          const err = mapError(new Error("Error(Contract, #103)"));
-          expect(err.code).toBe("DEADLINE_EXCEEDED");
-          expect(err).toBeInstanceOf(DeadlineError);
-        });
-
-        it("maps error code 104 - Invalid amount", () => {
-          const err = mapError(new Error("Error(Contract, #104)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(104);
-        });
-
-        it("maps error code 105 - Insufficient input amount", () => {
-          const err = mapError(new Error("Error(Contract, #105)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(105);
-        });
-
-        it("maps error code 106 - Reentrancy detected", () => {
-          const err = mapError(new Error("Error(Contract, #106)"));
-          expect(err.code).toBe("FLASH_LOAN_ERROR");
-          expect(err).toBeInstanceOf(FlashLoanError);
-          expect(err.message).toContain("Reentrancy detected");
-          expect(err.details?.contractErrorCode).toBe(106);
-        });
-
-        it("maps error code 107 - Flash loan callback failed", () => {
-          const err = mapError(new Error("Error(Contract, #107)"));
-          expect(err.code).toBe("FLASH_LOAN_ERROR");
-          expect(err.message).toContain("callback failed");
-          expect(err.details?.contractErrorCode).toBe(107);
-        });
-
-        it("maps error code 108 - Flash loan repayment insufficient", () => {
-          const err = mapError(new Error("Error(Contract, #108)"));
-          expect(err.code).toBe("FLASH_LOAN_ERROR");
-          expect(err.message).toContain("repayment insufficient");
-          expect(err.details?.contractErrorCode).toBe(108);
-        });
-
-        it("maps error code 109 - Circuit breaker", () => {
-          const err = mapError(new Error("Error(Contract, #109)"));
-          expect(err.code).toBe("CIRCUIT_BREAKER");
-          expect(err).toBeInstanceOf(CircuitBreakerError);
-        });
-
-        it("maps error code 110 - Unauthorized", () => {
-          const err = mapError(new Error("Error(Contract, #110)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(110);
-        });
-
-        it("maps error code 111 - Invalid recipient", () => {
-          const err = mapError(new Error("Error(Contract, #111)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(111);
-        });
-
-        it("maps error code 112 - Overflow", () => {
-          const err = mapError(new Error("Error(Contract, #112)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(112);
-        });
-
-        it("maps error code 113 - K invariant violated", () => {
-          const err = mapError(new Error("Error(Contract, #113)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(113);
-        });
-      });
-
-      describe("Router contract errors (300-306)", () => {
-        it("maps error code 300 - Pair not found", () => {
-          const err = mapError(new Error("Error(Contract, #300)"));
-          expect(err.code).toBe("PAIR_NOT_FOUND");
-          expect(err).toBeInstanceOf(PairNotFoundError);
-        });
-
-        it("maps error code 301 - Invalid path", () => {
-          const err = mapError(new Error("Error(Contract, #301)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(301);
-        });
-
-        it("maps error code 302 - Slippage exceeded", () => {
-          const err = mapError(new Error("Error(Contract, #302)"));
-          expect(err.code).toBe("SLIPPAGE_EXCEEDED");
-          expect(err).toBeInstanceOf(SlippageError);
-          expect(err.details?.contractErrorCode).toBe(302);
-        });
-
-        it("maps error code 303 - Deadline exceeded", () => {
-          const err = mapError(new Error("Error(Contract, #303)"));
-          expect(err.code).toBe("DEADLINE_EXCEEDED");
-          expect(err).toBeInstanceOf(DeadlineError);
-        });
-
-        it("maps error code 304 - Insufficient liquidity", () => {
-          const err = mapError(new Error("Error(Contract, #304)"));
-          expect(err.code).toBe("INSUFFICIENT_LIQUIDITY");
-          expect(err).toBeInstanceOf(InsufficientLiquidityError);
-          expect(err.details?.contractErrorCode).toBe(304);
-        });
-
-        it("maps error code 305 - Excessive input amount", () => {
-          const err = mapError(new Error("Error(Contract, #305)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(305);
-        });
-
-        it("maps error code 306 - Invalid token", () => {
-          const err = mapError(new Error("Error(Contract, #306)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(306);
-        });
-      });
-
-      it("handles contract errors without # prefix", () => {
-        const err = mapError(new Error("Error(Contract, 106)"));
-        expect(err.code).toBe("FLASH_LOAN_ERROR");
-        expect(err.details?.contractErrorCode).toBe(106);
-      });
-
-      it("handles unknown contract error codes", () => {
-        const err = mapError(new Error("Error(Contract, #999)"));
-        expect(err.code).toBe("UNKNOWN_ERROR");
-      });
-    });
-
-    describe("Unknown errors", () => {
-      it("maps unknown string errors", () => {
-        const err = mapError("some string error");
-        expect(err.code).toBe("UNKNOWN_ERROR");
-        expect(err.message).toBe("some string error");
-      });
-
-      it("preserves original error in details", () => {
-        const original = new Error("custom error");
-        const err = mapError(original);
-        expect(err.details?.originalError).toBe(original);
-      });
-
-      it("handles non-Error objects", () => {
-        const err = mapError({ custom: "error" });
-        expect(err.code).toBe("UNKNOWN_ERROR");
-      });
+    it('maps unknown errors', () => {
+      const err = mapError('some string error');
+      expect(err.code).toBe('UNKNOWN_ERROR');
     });
   });
 });


### PR DESCRIPTION
…contract…"

This reverts commit 9ac4120e600cfdff1c4b08368f0f2b26f6f3fe66.

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
