### PR TITLE
feat: implement getSlippageTolerance calculator (#77)

### DIFF
--- a/src/utils/amounts.ts
+++ b/src/utils/amounts.ts
@@ -72,6 +72,27 @@ export function applyBps(amount: bigint, bps: number): bigint {
 }
 
 /**
+ * Calculate slippage-adjusted amount using basis points.
+ *
+ * - `isInput = false`: returns minimum output amount
+ * - `isInput = true`: returns maximum input amount
+ */
+export function getSlippageTolerance(
+  amount: bigint,
+  slippageBips: bigint,
+  isInput: boolean,
+): bigint {
+  if (slippageBips < 0n || slippageBips > PRECISION.BPS_DENOMINATOR) {
+    throw new Error('Slippage bips must be between 0 and 10000');
+  }
+
+  const bps = PRECISION.BPS_DENOMINATOR;
+  const multiplier = isInput ? bps + slippageBips : bps - slippageBips;
+
+  return (amount * multiplier) / bps;
+}
+
+/**
  * Calculate percentage difference between two amounts.
  */
 export function percentDiff(a: bigint, b: bigint): number {


### PR DESCRIPTION
Closes #77 

Implemented the `getSlippageTolerance` utility in `src/utils/amounts.ts`. The calculator uses basis points for precise integer math to calculate both minimum output amounts (for exact input swaps) and maximum input amounts (for exact output swaps), eliminating floating point precision loss.

Changes:

Added getSlippageTolerance with strict bounds checking for basis points.

Implemented boolean toggle to handle both input and output slippage logic.

All calculations scale against a standard 10,000 basis point denominator.