### PR TITLE
feat: add npm run docs script for API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 *.sh
 .DS_Store
 *.tsbuildinfo
+docs/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prepublishOnly": "npm test && npm run lint",
     "examples:simple-swap": "ts-node examples/simple-swap.ts",
     "examples:provide-liquidity": "ts-node examples/provide-liquidity.ts",
-    "examples:read-reserves": "ts-node examples/read-reserves.ts"
+    "examples:read-reserves": "ts-node examples/read-reserves.ts",
+    "docs": "typedoc"
   },
   "keywords": [
     "coralswap",
@@ -53,6 +54,7 @@
     "rimraf": "^6.0.0",
     "ts-jest": "^29.2.0",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.27.0",
     "typescript": "^5.6.0"
   },
   "engines": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "name": "@coralswap/sdk",
+  "readme": "README.md",
+  "tsconfig": "tsconfig.json",
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "includeVersion": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/CoralSwap-Finance/coralswap-sdk"
+  },
+  "plugin": [],
+  "categorizeByGroup": true,
+  "sort": ["source-order"]
+}


### PR DESCRIPTION
   generation

   Add TypeDoc configuration and
> @coralswap/sdk@0.1.0 docs
> typedoc script to
    auto-generate
   API documentation from JSDoc/TSDoc comments. Includes
   typedoc.json
   config with project entry point, and docs/ added to
   .gitignore.

   Closes #76

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
