### PR TITLE
Implement parseTokenAmount helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@stellar/stellar-sdk": "^12.3.0"
+        "@stellar/stellar-sdk": "^12.3.0",
+        "zod": "^3.23.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
@@ -59,6 +60,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1474,6 +1476,7 @@
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1537,6 +1540,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1741,6 +1745,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2158,6 +2163,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2731,6 +2737,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3761,6 +3768,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5612,6 +5620,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5744,6 +5753,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5844,6 +5854,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6112,6 +6123,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export type { TWAPObservation, TWAPResult } from './modules';
 // Utilities
 export {
   toSorobanAmount,
+  parseTokenAmount,
   fromSorobanAmount,
   formatAmount,
   toBps,

--- a/src/utils/amounts.ts
+++ b/src/utils/amounts.ts
@@ -8,12 +8,30 @@ import { PRECISION } from '../config';
  */
 
 /**
- * Convert a human-readable decimal string to i128 BigInt.
- *
- * @example toSorobanAmount("1.5", 7) => 15000000n
+ * Core implementation for parsing a decimal string into a BigInt with the
+ * given number of decimals. This is used by both `toSorobanAmount` and
+ * `parseTokenAmount` to keep behavior consistent.
  */
-export function toSorobanAmount(amount: string, decimals: number = 7): bigint {
-  const parts = amount.split('.');
+function parseDecimalString(amount: string, decimals: number): bigint {
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new Error('Invalid decimals');
+  }
+
+  const trimmed = amount.trim();
+  if (trimmed === '') {
+    throw new Error('Amount is required');
+  }
+
+  const isNegative = trimmed.startsWith('-');
+  const isPositive = trimmed.startsWith('+');
+  const sign = isNegative ? -1n : 1n;
+  const numeric = isNegative || isPositive ? trimmed.slice(1) : trimmed;
+
+  if (!/^\d+(\.\d+)?$/.test(numeric)) {
+    throw new Error('Invalid amount format');
+  }
+
+  const parts = numeric.split('.');
   const whole = parts[0] ?? '0';
   let frac = parts[1] ?? '';
 
@@ -23,7 +41,30 @@ export function toSorobanAmount(amount: string, decimals: number = 7): bigint {
     frac = frac.padEnd(decimals, '0');
   }
 
-  return BigInt(whole + frac);
+  const parsed = BigInt(whole + frac);
+  return sign * parsed;
+}
+
+/**
+ * Convert a human-readable decimal string to i128 BigInt.
+ *
+ * @example toSorobanAmount("1.5", 7) => 15000000n
+ */
+export function toSorobanAmount(amount: string, decimals: number = 7): bigint {
+  return parseDecimalString(amount, decimals);
+}
+
+/**
+ * Parse a human-readable token amount into the smallest unit BigInt.
+ *
+ * This is a general-purpose helper for converting values like "1.5" with a
+ * given token decimal count into the BigInt representation used for contract
+ * interactions.
+ *
+ * @example parseTokenAmount("1.5", 7) => 15000000n
+ */
+export function parseTokenAmount(amount: string, decimals: number): bigint {
+  return parseDecimalString(amount, decimals);
 }
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export {
   toSorobanAmount,
+  parseTokenAmount,
   fromSorobanAmount,
   formatAmount,
   toBps,

--- a/tests/amounts.test.ts
+++ b/tests/amounts.test.ts
@@ -1,5 +1,6 @@
 import {
   toSorobanAmount,
+  parseTokenAmount,
   fromSorobanAmount,
   formatAmount,
   toBps,
@@ -30,6 +31,33 @@ describe('Amount Utilities', () => {
 
     it('pads short decimals', () => {
       expect(toSorobanAmount('1.5', 7)).toBe(15000000n);
+    });
+  });
+
+  describe('parseTokenAmount', () => {
+    it('parses whole amounts', () => {
+      expect(parseTokenAmount('1', 7)).toBe(10000000n);
+    });
+
+    it('parses decimal amounts', () => {
+      expect(parseTokenAmount('1.5', 7)).toBe(15000000n);
+    });
+
+    it('parses negative amounts', () => {
+      expect(parseTokenAmount('-1.5', 7)).toBe(-15000000n);
+    });
+
+    it('trims whitespace', () => {
+      expect(parseTokenAmount(' 1.5 ', 7)).toBe(15000000n);
+    });
+
+    it('throws on invalid format', () => {
+      expect(() => parseTokenAmount('abc', 7)).toThrow('Invalid amount format');
+    });
+
+    it('throws on invalid decimals', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => parseTokenAmount('1', -1 as any)).toThrow('Invalid decimals');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add  utility in  to convert human-readable token amounts and decimals into BigInt for contract interactions.
- Refactor decimal parsing logic into a shared internal helper used by both  and .
- Export  from the public SDK surface and add unit tests covering positive, negative, whitespace-trimmed, and invalid inputs.

Closes #71
