### PR TITLE
Add shufflePath test utility

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Test helper utilities for the CoralSwap SDK test suite.
+ */
+
+/**
+ * Return a shuffled copy of a valid token path.
+ *
+ * Uses Fisher-Yates shuffle and does not mutate the original array.
+ * If a `random` function is provided, it is used instead of `Math.random`
+ * to enable deterministic shuffles in tests.
+ */
+export function shufflePath<T>(path: readonly T[], random: () => number = Math.random): T[] {
+  const result = [...path];
+
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    const tmp = result[i];
+    result[i] = result[j];
+    result[j] = tmp;
+  }
+
+  return result;
+}
+
+

--- a/tests/multi-hop-routing.test.ts
+++ b/tests/multi-hop-routing.test.ts
@@ -6,6 +6,7 @@ import {
   InsufficientLiquidityError,
   ValidationError,
 } from '../src/errors';
+import { shufflePath } from './helpers';
 
 // ---------------------------------------------------------------------------
 // Mock helpers (same pattern as existing multi-hop-swap.test.ts)
@@ -174,6 +175,19 @@ describe('Multi-hop routing (dedicated methods)', () => {
       expect(quote.tokenIn).toBe(TOKEN_A);
       expect(quote.tokenOut).toBe(TOKEN_C);
       expect(quote.path).toEqual([TOKEN_A, TOKEN_B, TOKEN_C]);
+    });
+
+    it('shufflePath returns a shuffled copy without mutating original', () => {
+      const basePath = [TOKEN_A, TOKEN_B, TOKEN_C, TOKEN_D] as const;
+      const copy = [...basePath];
+
+      const shuffled = shufflePath(basePath, () => 0.42);
+
+      // Original is unchanged
+      expect(basePath).toEqual(copy);
+
+      // Shuffled path contains the same tokens (possibly in different order)
+      expect([...shuffled].sort()).toEqual([...basePath].sort());
     });
 
     it('respects custom slippage tolerance', async () => {


### PR DESCRIPTION
## Summary

- Introduce a  helper in  that returns a shuffled copy of a token path using Fisher–Yates, without mutating the original array.
- Allow tests to optionally pass a custom  function for deterministic shuffles.
- Add usage and assertions in  to verify  behavior.

Closes #69