### PR TITLE
feat(utils): add getPairAddress helper utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ export {
   sortTokens,
   truncateAddress,
   toScAddress,
+  getPairAddress,
   isSimulationSuccess,
   getSimulationReturnValue,
   getResourceEstimate,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,6 +18,7 @@ export {
   sortTokens,
   truncateAddress,
   toScAddress,
+  getPairAddress,
 } from './addresses';
 
 export {

--- a/tests/addresses.test.ts
+++ b/tests/addresses.test.ts
@@ -4,6 +4,7 @@ import {
   isValidAddress,
   sortTokens,
   truncateAddress,
+  getPairAddress,
 } from '../src/utils/addresses';
 
 describe('Address Utilities', () => {
@@ -68,6 +69,50 @@ describe('Address Utilities', () => {
 
     it('preserves short strings', () => {
       expect(truncateAddress('short')).toBe('short');
+    });
+  });
+
+  describe('getPairAddress', () => {
+    const FACTORY = 'CCVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA463';
+    const TOKEN_A = 'CC5QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4CG';
+    const TOKEN_B = 'CDGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGVG';
+    const TESTNET_PASSPHRASE = 'Test SDF Network ; September 2015';
+    const EXPECTED_PAIR = 'CC4YVLFRDJB3I32FKEHLSP7ZUE5DP73QHB54SQIBO6MXBFP7FIMVTG2I';
+
+    it('derives the correct pair address', () => {
+      const pair = getPairAddress(FACTORY, TOKEN_A, TOKEN_B, TESTNET_PASSPHRASE);
+      expect(pair).toBe(EXPECTED_PAIR);
+    });
+
+    it('returns the same address regardless of token order', () => {
+      const forward = getPairAddress(FACTORY, TOKEN_A, TOKEN_B, TESTNET_PASSPHRASE);
+      const reversed = getPairAddress(FACTORY, TOKEN_B, TOKEN_A, TESTNET_PASSPHRASE);
+      expect(forward).toBe(reversed);
+    });
+
+    it('returns a valid contract address', () => {
+      const pair = getPairAddress(FACTORY, TOKEN_A, TOKEN_B, TESTNET_PASSPHRASE);
+      expect(isValidContractId(pair)).toBe(true);
+    });
+
+    it('produces different addresses for different factory addresses', () => {
+      const otherFactory = 'CAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABDQF';
+      const pair1 = getPairAddress(FACTORY, TOKEN_A, TOKEN_B, TESTNET_PASSPHRASE);
+      const pair2 = getPairAddress(otherFactory, TOKEN_A, TOKEN_B, TESTNET_PASSPHRASE);
+      expect(pair1).not.toBe(pair2);
+    });
+
+    it('produces different addresses for different network passphrases', () => {
+      const mainnetPassphrase = 'Public Global Stellar Network ; September 2015';
+      const testnet = getPairAddress(FACTORY, TOKEN_A, TOKEN_B, TESTNET_PASSPHRASE);
+      const mainnet = getPairAddress(FACTORY, TOKEN_A, TOKEN_B, mainnetPassphrase);
+      expect(testnet).not.toBe(mainnet);
+    });
+
+    it('throws on identical tokens', () => {
+      expect(() =>
+        getPairAddress(FACTORY, TOKEN_A, TOKEN_A, TESTNET_PASSPHRASE),
+      ).toThrow('Identical');
     });
   });
 });


### PR DESCRIPTION
Adds getPairAddress to addresses.ts that derives the deterministic pair contract address off-chain from two token addresses, a factory address, and the network passphrase. Uses Soroban's standard HashIdPreimage contract ID derivation with a salt computed from the sorted token pair.

Closes #65

