### PR TITLE
feat(utils): implement formatLargeNumber utility\n\nAdd formatLargeNu…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export {
   parseTokenAmount,
   fromSorobanAmount,
   formatAmount,
+  formatLargeNumber,
   toBps,
   applyBps,
   percentDiff,

--- a/src/utils/amounts.ts
+++ b/src/utils/amounts.ts
@@ -489,3 +489,98 @@ export function minBigInt(a: bigint, b: bigint): bigint {
 export function maxBigInt(a: bigint, b: bigint): bigint {
   return a > b ? a : b;
 }
+
+/**
+ * Suffix thresholds used by {@link formatLargeNumber} to abbreviate values.
+ *
+ * Each entry maps a human-readable suffix to its corresponding BigInt
+ * threshold.  Entries are ordered from largest to smallest so the first
+ * match wins.
+ */
+const LARGE_NUMBER_SUFFIXES: ReadonlyArray<{ threshold: bigint; suffix: string; divisor: bigint }> = [
+  { threshold: 1_000_000_000_000n, suffix: "T", divisor: 1_000_000_000_000n },
+  { threshold: 1_000_000_000n,     suffix: "B", divisor: 1_000_000_000n },
+  { threshold: 1_000_000n,         suffix: "M", divisor: 1_000_000n },
+  { threshold: 1_000n,             suffix: "K", divisor: 1_000n },
+];
+
+/**
+ * Format a large BigInt value into a human-readable string with an appropriate
+ * suffix (K, M, B, T) based on its magnitude.
+ *
+ * Values below 1,000 are returned as plain strings without a suffix.
+ * Negative values are supported and prefixed with a minus sign.
+ *
+ * @param value - The BigInt value to format
+ * @param precision - The number of decimal places to include (default: 1).
+ *   Must be a non-negative integer.  Trailing zeros are preserved so the
+ *   output width is predictable.
+ * @returns A formatted string such as `"1.5K"`, `"2.3M"`, or `"999"`
+ * @throws {Error} If precision is not a non-negative integer
+ *
+ * @example
+ * // Thousands
+ * formatLargeNumber(1500n)       // => "1.5K"
+ * formatLargeNumber(1500n, 0)    // => "1K"
+ * formatLargeNumber(1500n, 2)    // => "1.50K"
+ *
+ * @example
+ * // Millions
+ * formatLargeNumber(2500000n)    // => "2.5M"
+ *
+ * @example
+ * // Billions
+ * formatLargeNumber(1230000000n) // => "1.2B"
+ *
+ * @example
+ * // Trillions
+ * formatLargeNumber(5_000_000_000_000n) // => "5.0T"
+ *
+ * @example
+ * // Below 1,000 — no suffix
+ * formatLargeNumber(42n)         // => "42"
+ *
+ * @example
+ * // Negative values
+ * formatLargeNumber(-2500000n)   // => "-2.5M"
+ *
+ * @example
+ * // Zero
+ * formatLargeNumber(0n)          // => "0"
+ *
+ * @remarks
+ * - Decimal places are truncated, not rounded, consistent with other
+ *   formatting utilities in this module.
+ * - The function operates entirely on BigInt arithmetic to avoid
+ *   floating-point precision issues with very large numbers.
+ */
+export function formatLargeNumber(value: bigint, precision: number = 1): string {
+  if (!Number.isInteger(precision) || precision < 0) {
+    throw new Error("Precision must be a non-negative integer");
+  }
+
+  const isNegative = value < 0n;
+  const abs = isNegative ? -value : value;
+
+  for (const { threshold, suffix, divisor } of LARGE_NUMBER_SUFFIXES) {
+    if (abs >= threshold) {
+      const precisionMultiplier = 10n ** BigInt(precision);
+      const scaled = (abs * precisionMultiplier) / divisor;
+      const wholePart = scaled / precisionMultiplier;
+      const fracPart = scaled % precisionMultiplier;
+
+      const sign = isNegative ? "-" : "";
+
+      if (precision === 0) {
+        return `${sign}${wholePart}${suffix}`;
+      }
+
+      const fracStr = fracPart.toString().padStart(precision, "0");
+      return `${sign}${wholePart}.${fracStr}${suffix}`;
+    }
+  }
+
+  // Below 1,000 — return plain string without suffix
+  const sign = isNegative ? "-" : "";
+  return `${sign}${abs.toString()}`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ export {
   parseTokenAmount,
   fromSorobanAmount,
   formatAmount,
+  formatLargeNumber,
   toBps,
   applyBps,
   percentDiff,

--- a/tests/amounts.test.ts
+++ b/tests/amounts.test.ts
@@ -3,6 +3,7 @@ import {
   parseTokenAmount,
   fromSorobanAmount,
   formatAmount,
+  formatLargeNumber,
   toBps,
   applyBps,
   safeMul,
@@ -124,6 +125,126 @@ describe('Amount Utilities', () => {
 
     it('returns maximum', () => {
       expect(maxBigInt(100n, 200n)).toBe(200n);
+    });
+  });
+
+  describe('formatLargeNumber', () => {
+    describe('suffix selection', () => {
+      it('formats thousands with K suffix', () => {
+        expect(formatLargeNumber(1500n)).toBe('1.5K');
+      });
+
+      it('formats millions with M suffix', () => {
+        expect(formatLargeNumber(2500000n)).toBe('2.5M');
+      });
+
+      it('formats billions with B suffix', () => {
+        expect(formatLargeNumber(1230000000n)).toBe('1.2B');
+      });
+
+      it('formats trillions with T suffix', () => {
+        expect(formatLargeNumber(5_000_000_000_000n)).toBe('5.0T');
+      });
+    });
+
+    describe('values below 1,000', () => {
+      it('returns plain string for zero', () => {
+        expect(formatLargeNumber(0n)).toBe('0');
+      });
+
+      it('returns plain string for small values', () => {
+        expect(formatLargeNumber(42n)).toBe('42');
+      });
+
+      it('returns plain string for 999', () => {
+        expect(formatLargeNumber(999n)).toBe('999');
+      });
+    });
+
+    describe('boundary values', () => {
+      it('formats exactly 1,000 with K suffix', () => {
+        expect(formatLargeNumber(1000n)).toBe('1.0K');
+      });
+
+      it('formats exactly 1,000,000 with M suffix', () => {
+        expect(formatLargeNumber(1_000_000n)).toBe('1.0M');
+      });
+
+      it('formats exactly 1,000,000,000 with B suffix', () => {
+        expect(formatLargeNumber(1_000_000_000n)).toBe('1.0B');
+      });
+
+      it('formats exactly 1,000,000,000,000 with T suffix', () => {
+        expect(formatLargeNumber(1_000_000_000_000n)).toBe('1.0T');
+      });
+    });
+
+    describe('precision parameter', () => {
+      it('uses default precision of 1', () => {
+        expect(formatLargeNumber(1500n)).toBe('1.5K');
+      });
+
+      it('formats with precision 0 (no decimals)', () => {
+        expect(formatLargeNumber(1500n, 0)).toBe('1K');
+      });
+
+      it('formats with precision 2', () => {
+        expect(formatLargeNumber(1500n, 2)).toBe('1.50K');
+      });
+
+      it('formats with precision 3', () => {
+        expect(formatLargeNumber(1_234_567n, 3)).toBe('1.234M');
+      });
+
+      it('truncates rather than rounds', () => {
+        expect(formatLargeNumber(1999n, 1)).toBe('1.9K');
+      });
+
+      it('truncates with higher precision', () => {
+        expect(formatLargeNumber(1_999_999n, 2)).toBe('1.99M');
+      });
+    });
+
+    describe('negative values', () => {
+      it('formats negative thousands', () => {
+        expect(formatLargeNumber(-2500n)).toBe('-2.5K');
+      });
+
+      it('formats negative millions', () => {
+        expect(formatLargeNumber(-2500000n)).toBe('-2.5M');
+      });
+
+      it('formats negative values below 1,000', () => {
+        expect(formatLargeNumber(-42n)).toBe('-42');
+      });
+
+      it('formats negative billions', () => {
+        expect(formatLargeNumber(-1_500_000_000n)).toBe('-1.5B');
+      });
+    });
+
+    describe('very large values', () => {
+      it('formats values above trillions with T suffix', () => {
+        expect(formatLargeNumber(999_000_000_000_000n)).toBe('999.0T');
+      });
+
+      it('formats quadrillions with T suffix', () => {
+        expect(formatLargeNumber(1_500_000_000_000_000n)).toBe('1500.0T');
+      });
+    });
+
+    describe('error handling', () => {
+      it('throws on negative precision', () => {
+        expect(() => formatLargeNumber(1000n, -1)).toThrow(
+          'Precision must be a non-negative integer',
+        );
+      });
+
+      it('throws on non-integer precision', () => {
+        expect(() => formatLargeNumber(1000n, 1.5)).toThrow(
+          'Precision must be a non-negative integer',
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
…mber to src/utils/amounts.ts to format large BigInt\nvalues into human-readable strings with appropriate suffixes (K, M, B, T)\nbased on magnitude and configurable decimal precision.\n\n- Pure BigInt arithmetic to avoid floating-point precision issues\n- Supports negative values, boundary values, and values above trillions\n- Truncates decimals (consistent with existing formatAmount behavior)\n- Validates precision parameter\n- Comprehensive test suite with 25 test cases\n\nCloses #64"

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
