### PR TITLE
fix: export DEFAULT_SLIPPAGE from public API surface\n\nRe-export the…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   NetworkConfig,
   NETWORK_CONFIGS,
   DEFAULTS,
+  DEFAULT_SLIPPAGE,
   PRECISION,
 } from "@/config";
 


### PR DESCRIPTION
… DEFAULT_SLIPPAGE constant from src/index.ts so SDK\nconsumers can import it directly. All constants in src/config.ts\nwere already individually exported, but DEFAULT_SLIPPAGE was missing\nfrom the barrel re-export in the package entry point.\n\nCloses #62

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
