### PR TITLE
fix: add missing Asset import in addresses.ts for native XLM support

### DIFF
--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,4 +1,4 @@
-import { Address, StrKey, hash, xdr } from "@stellar/stellar-sdk";
+import { Address, Asset, StrKey, hash, xdr } from "@stellar/stellar-sdk";
 
 /**
  * Address utilities for Stellar/Soroban address handling.


### PR DESCRIPTION
## Summary

`getNativeAssetContractAddress()` calls `Asset.native()` from `@stellar/stellar-sdk`, but `Asset` was never imported in `addresses.ts`. Every call to this function crashed at runtime with `ReferenceError: Asset is not defined`, breaking all native XLM / SAC swap paths.

**Fix:** Added `Asset` to the existing `@stellar/stellar-sdk` import statement.

- All 28 existing address utility tests pass including native XLM resolution on both testnet and mainnet.

Closes #130

## Related PRs
This is part of a series of bug fixes (all branches are stacked — merging in order avoids conflicts):
- #130 — This PR (Asset import fix in `addresses.ts`)
- See also: fix for #131 (Fraction denominator validation in `math.ts`)
- See also: fix for #132 (safeMul zero-input handling in `amounts.ts`)
- See also: fix for #134 (hardcoded placeholder account in `pair.ts`)