### PR TITLE
feat: enhance simulateTransaction with typed result and simulation options

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import {
   xdr,
 } from '@stellar/stellar-sdk';
 import { CoralSwapConfig, NetworkConfig, NETWORK_CONFIGS, DEFAULTS } from '@/config';
-import { Network, Result, Logger, Signer } from '@/types/common';
+import { Network, Result, Logger, Signer, SimulateTransactionOptions, SimulateTransactionResult } from '@/types/common';
 import { SignerError } from '@/errors';
 import { FactoryClient } from '@/contracts/factory';
 import { PairClient } from '@/contracts/pair';
@@ -16,6 +16,7 @@ import { TokenListModule } from '@/modules/tokens';
 import { FactoryModule } from '@/modules/factory';
 import { KeypairSigner } from '@/utils/signer';
 import { TransactionPoller, PollingStrategy, PollingOptions } from '@/utils/polling';
+import { buildSimulationResult } from '@/utils/simulation';
 export { KeypairSigner, PollingStrategy, PollingOptions };
 
 /**
@@ -404,28 +405,98 @@ export class CoralSwapClient {
   /**
    * Simulate a transaction without submitting (dry-run).
    *
+   * **Legacy form** — returns the raw `SorobanRpc.Api.SimulateTransactionResponse`
+   * for backward compatibility.
+   *
    * @param operations - Array of operations to simulate
-   * @param source - Optional source account override
-   * @returns Simulation response directly from the RPC
+   * @param source - Optional source account public key override
+   * @returns Raw simulation response from the RPC
    * @example
    * const sim = await client.simulateTransaction([op]);
+   * if (SorobanRpc.Api.isSimulationSuccess(sim)) { ... }
    */
   async simulateTransaction(
     operations: xdr.Operation[],
     source?: string,
-  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse>;
+
+  /**
+   * Simulate a transaction without submitting (enhanced dry-run).
+   *
+   * **Enhanced form** — pass a {@link SimulateTransactionOptions} object as
+   * the second argument to receive a fully-typed {@link SimulateTransactionResult}
+   * with decoded events, auth entries, resource estimates, and the raw response.
+   *
+   * @param operations - Array of operations to simulate
+   * @param options - Simulation environment options (source account, timeout, fee)
+   * @returns Typed `SimulateTransactionResult` with all relevant simulation data
+   *
+   * @example
+   * // Basic enhanced dry-run using the configured signer's account
+   * const result = await client.simulateTransaction([op], {});
+   * if (result.success) {
+   *   console.log('Return value:', result.returnValue);
+   *   console.log('CPU instructions:', result.cost?.cpuInsns);
+   *   console.log('Min resource fee:', result.minResourceFee);
+   *   console.log('Events emitted:', result.events.length);
+   * }
+   *
+   * @example
+   * // Debug a contract call as a custom source account
+   * const result = await client.simulateTransaction([op], {
+   *   source: 'GABC...XYZ',
+   *   timeoutSec: 60,
+   * });
+   * if (!result.success) {
+   *   console.error('Simulation failed:', result.error);
+   * }
+   *
+   * @example
+   * // Inspect authorization entries before signing
+   * const result = await client.simulateTransaction([op], {});
+   * console.log('Auth required:', result.auth.length);
+   */
+  async simulateTransaction(
+    operations: xdr.Operation[],
+    options: SimulateTransactionOptions,
+  ): Promise<SimulateTransactionResult>;
+
+  // Unified implementation — handles both call forms.
+  async simulateTransaction(
+    operations: xdr.Operation[],
+    sourceOrOptions?: string | SimulateTransactionOptions,
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse | SimulateTransactionResult> {
+    // Distinguish enhanced form (options object) from legacy form (string or undefined).
+    const isEnhanced =
+      sourceOrOptions !== undefined && typeof sourceOrOptions !== 'string';
+
+    const source =
+      typeof sourceOrOptions === 'string'
+        ? sourceOrOptions
+        : (sourceOrOptions as SimulateTransactionOptions | undefined)?.source;
+
+    const timeoutSec = isEnhanced
+      ? ((sourceOrOptions as SimulateTransactionOptions).timeoutSec ??
+          this.networkConfig.sorobanTimeout)
+      : 30; // preserve the original hardcoded value for the legacy path
+
+    const fee = isEnhanced
+      ? ((sourceOrOptions as SimulateTransactionOptions).fee ?? '100')
+      : '100';
+
     const sourceKey = source ?? this.publicKey;
 
-    this.logger?.debug("simulateTransaction (dry-run): fetching account", {
+    this.logger?.debug('simulateTransaction (dry-run): fetching account', {
       sourceKey,
+      enhanced: isEnhanced,
     });
     const account = await this.withRetry(
       () => this.server.getAccount(sourceKey),
-      "simulateTransaction_getAccount",
+      'simulateTransaction_getAccount',
     );
 
     let builder = new TransactionBuilder(account, {
-      fee: "100",
+      fee,
       networkPassphrase: this.networkConfig.networkPassphrase,
     });
 
@@ -433,17 +504,25 @@ export class CoralSwapClient {
       builder = builder.addOperation(op);
     }
 
-    const tx = builder.setTimeout(30).build();
+    const tx = builder.setTimeout(timeoutSec).build();
 
-    this.logger?.debug("simulateTransaction (dry-run): simulating", {
+    this.logger?.debug('simulateTransaction (dry-run): simulating', {
       sourceKey,
       operationCount: operations.length,
+      enhanced: isEnhanced,
     });
     const sim = await this.withRetry(
       () => this.server.simulateTransaction(tx),
-      "simulateTransaction_simulate",
+      'simulateTransaction_simulate',
     );
-    this.logger?.debug("simulateTransaction (dry-run): completed");
+    this.logger?.debug('simulateTransaction (dry-run): completed', {
+      success: SorobanRpc.Api.isSimulationSuccess(sim),
+      enhanced: isEnhanced,
+    });
+
+    if (isEnhanced) {
+      return buildSimulationResult(sim);
+    }
     return sim;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,8 @@ export {
   getSimulationReturnValue,
   getResourceEstimate,
   exceedsBudget,
+  decodeDiagnosticEvents,
+  buildSimulationResult,
   withRetry,
   isRetryable,
   sleep,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,5 @@
+import type { SorobanRpc, xdr } from '@stellar/stellar-sdk';
+
 /**
  * Supported Soroban networks for CoralSwap deployment.
  */
@@ -100,4 +102,128 @@ export interface Signer {
   publicKey(): Promise<string>;
   /** Sign a Stellar transaction and return the signed transaction. */
   signTransaction(xdr: string): Promise<string>;
+}
+
+/**
+ * Options for controlling the simulation environment and behavior.
+ *
+ * Pass this as the second argument to the enhanced form of
+ * {@link CoralSwapClient.simulateTransaction} to receive a rich
+ * {@link SimulateTransactionResult} in return.
+ *
+ * @example
+ * const result = await client.simulateTransaction([op], {
+ *   source: 'G...',
+ *   timeoutSec: 60,
+ * });
+ */
+export interface SimulateTransactionOptions {
+  /**
+   * Override the source account public key for the simulated transaction.
+   * Falls back to the configured signer's public key when omitted.
+   */
+  source?: string;
+  /**
+   * Transaction timeout in seconds.
+   * Defaults to the network's `sorobanTimeout` value (30 s).
+   */
+  timeoutSec?: number;
+  /**
+   * Base fee in stroops for the transaction envelope.
+   * Defaults to `"100"`. Does not affect simulation resource estimates.
+   */
+  fee?: string;
+}
+
+/**
+ * A single decoded diagnostic event from a Soroban simulation response.
+ *
+ * The RPC returns events as an array of base64-encoded XDR strings.
+ * This type exposes both the raw string (for serialisation) and the
+ * decoded `xdr.DiagnosticEvent` object (for inspection).
+ */
+export interface SimulationDiagnosticEvent {
+  /** Base64-encoded XDR string exactly as returned by the RPC. */
+  xdr: string;
+  /**
+   * Decoded XDR `DiagnosticEvent` object.
+   * `null` when XDR decoding fails (e.g. unsupported schema version).
+   */
+  decoded: xdr.DiagnosticEvent | null;
+}
+
+/**
+ * Typed result returned by the enhanced form of
+ * {@link CoralSwapClient.simulateTransaction}.
+ *
+ * All fields from the Soroban RPC simulation response are surfaced
+ * in a strongly-typed structure. The `raw` field is always present
+ * as an escape hatch for advanced use cases.
+ *
+ * @example
+ * const result = await client.simulateTransaction([op], { source: 'G...' });
+ * if (result.success) {
+ *   console.log('Return value:', result.returnValue);
+ *   console.log('Events:', result.events.length);
+ *   console.log('Min fee:', result.minResourceFee);
+ * } else {
+ *   console.error('Simulation failed:', result.error);
+ * }
+ */
+export interface SimulateTransactionResult {
+  /** `true` when the RPC reports a successful simulation. */
+  success: boolean;
+
+  /**
+   * Decoded return value from the contract invocation.
+   * `null` when the simulation failed or the invocation produced no return value.
+   */
+  returnValue: xdr.ScVal | null;
+
+  /**
+   * Authorization entries required when assembling the real transaction.
+   * Empty array when the simulation failed.
+   */
+  auth: xdr.SorobanAuthorizationEntry[];
+
+  /**
+   * Minimum resource fee in stroops as a string to avoid precision loss.
+   * Empty string when the simulation failed.
+   */
+  minResourceFee: string;
+
+  /**
+   * Soroban resource cost estimate from the RPC.
+   * `null` when the simulation failed.
+   */
+  cost: { cpuInsns: string; memBytes: string } | null;
+
+  /**
+   * Soroban transaction data needed for fee-bumping or assembling the real tx.
+   * `null` when the simulation failed.
+   */
+  transactionData: xdr.SorobanTransactionData | null;
+
+  /**
+   * Latest ledger sequence number at the time of simulation.
+   * Always populated regardless of success or failure.
+   */
+  latestLedger: number;
+
+  /**
+   * Diagnostic events emitted during the simulation, decoded from XDR.
+   * Empty array when no events were emitted or when the simulation failed.
+   */
+  events: SimulationDiagnosticEvent[];
+
+  /**
+   * Error message from the RPC when `success` is `false`.
+   * `null` when the simulation succeeded.
+   */
+  error: string | null;
+
+  /**
+   * Full, unmodified RPC response for advanced or escape-hatch use.
+   */
+  raw: SorobanRpc.Api.SimulateTransactionResponse;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,6 +30,8 @@ export {
   getSimulationReturnValue,
   getResourceEstimate,
   exceedsBudget,
+  decodeDiagnosticEvents,
+  buildSimulationResult,
 } from "./simulation";
 
 export type { SimulationResult, SimulationResourceEstimate } from './simulation';

--- a/src/utils/simulation.ts
+++ b/src/utils/simulation.ts
@@ -1,4 +1,5 @@
 import { SorobanRpc, xdr } from '@stellar/stellar-sdk';
+import type { SimulateTransactionResult, SimulationDiagnosticEvent } from '@/types/common';
 
 /**
  * Transaction simulation utilities.
@@ -83,6 +84,85 @@ export function getResourceEstimate(
       readBytes: 0,
       writeBytes: 0,
     },
+  };
+}
+
+/**
+ * Decode the raw base64-XDR diagnostic events from a simulation response.
+ *
+ * The `events` field on a successful `SimulateTransactionResponse` is a
+ * `string[]` where each entry is a base64-encoded `xdr.DiagnosticEvent`.
+ * Entries that fail XDR parsing (e.g. due to schema version differences)
+ * are returned with `decoded: null` so the caller can still access the
+ * raw XDR string.
+ *
+ * @param rawEvents - The `events` array from the RPC response (may be undefined)
+ * @returns Array of `SimulationDiagnosticEvent` objects
+ */
+export function decodeDiagnosticEvents(
+  rawEvents: string[] | undefined,
+): SimulationDiagnosticEvent[] {
+  if (!rawEvents || rawEvents.length === 0) return [];
+
+  return rawEvents.map((xdrStr): SimulationDiagnosticEvent => {
+    try {
+      return {
+        xdr: xdrStr,
+        decoded: xdr.DiagnosticEvent.fromXDR(xdrStr, 'base64'),
+      };
+    } catch {
+      return { xdr: xdrStr, decoded: null };
+    }
+  });
+}
+
+/**
+ * Build a structured {@link SimulateTransactionResult} from a raw RPC response.
+ *
+ * Centralises all field extraction so both `client.ts` and any future
+ * callers get a consistent, fully-typed view of the simulation data.
+ *
+ * @param sim - Raw response from `SorobanRpc.Server.simulateTransaction`
+ * @returns A typed `SimulateTransactionResult`
+ */
+export function buildSimulationResult(
+  sim: SorobanRpc.Api.SimulateTransactionResponse,
+): SimulateTransactionResult {
+  const success = SorobanRpc.Api.isSimulationSuccess(sim);
+  const events = decodeDiagnosticEvents(
+    (sim as SorobanRpc.Api.SimulateTransactionSuccessResponse).events,
+  );
+
+  if (!success) {
+    const errorResponse = sim as SorobanRpc.Api.SimulateTransactionErrorResponse;
+    return {
+      success: false,
+      returnValue: null,
+      auth: [],
+      minResourceFee: '',
+      cost: null,
+      transactionData: null,
+      latestLedger: sim.latestLedger,
+      events,
+      error: errorResponse.error ?? 'Simulation failed',
+      raw: sim,
+    };
+  }
+
+  const ok = sim as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+  return {
+    success: true,
+    returnValue: ok.result?.retval ?? null,
+    auth: ok.result?.auth ?? [],
+    minResourceFee: ok.minResourceFee,
+    cost: ok.cost
+      ? { cpuInsns: ok.cost.cpuInsns, memBytes: ok.cost.memBytes }
+      : null,
+    transactionData: ok.transactionData ?? null,
+    latestLedger: ok.latestLedger,
+    events,
+    error: null,
+    raw: sim,
   };
 }
 


### PR DESCRIPTION
Closes CoralSwap-Finance/coralswap-sdk#93

## Summary

- **New types** (`SimulateTransactionOptions`, `SimulationDiagnosticEvent`, `SimulateTransactionResult`) added to `src/types/common.ts` — fully exported on the public SDK surface
- **New helpers** (`decodeDiagnosticEvents`, `buildSimulationResult`) in `src/utils/simulation.ts` for decoding base64-XDR diagnostic events and constructing the typed result from any raw RPC response
- **Overloaded `simulateTransaction`** in `CoralSwapClient`:
  - **Legacy form** `(operations, source?)` → `SorobanRpc.Api.SimulateTransactionResponse` — zero behavioral change, fully backward-compatible
  - **Enhanced form** `(operations, options: SimulateTransactionOptions)` → `SimulateTransactionResult` — returns `returnValue`, `auth` entries, `minResourceFee`, `cost` estimates, `transactionData`, decoded `events`, `error`, and the raw RPC response

## Usage examples

```ts
// Enhanced dry-run with custom source account
const result = await client.simulateTransaction([op], {
  source: 'GABC...XYZ',
  timeoutSec: 60,
});

if (result.success) {
  console.log('Return value:', result.returnValue);
  console.log('Min resource fee:', result.minResourceFee);
  console.log('CPU instructions:', result.cost?.cpuInsns);
  console.log('Events emitted:', result.events.length);
  console.log('Auth entries required:', result.auth.length);
} else {
  console.error('Simulation failed:', result.error);
}

// Inspect decoded diagnostic events
for (const event of result.events) {
  if (event.decoded) {
    const contractEvent = event.decoded.event();
    console.log('Event type:', contractEvent.type().name);
  }
}
```

## Test plan

- [ ] Verify legacy `simulateTransaction(ops)` and `simulateTransaction(ops, 'G...')` still return `SorobanRpc.Api.SimulateTransactionResponse`
- [ ] Verify enhanced `simulateTransaction(ops, {})` returns `SimulateTransactionResult` with all fields populated on success
- [ ] Verify `result.success === false` and `result.error` is set when simulation fails
- [ ] Verify `result.events` contains decoded events from a contract that emits them
- [ ] Verify custom `source`, `timeoutSec`, and `fee` options are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)