### PR TITLE
fix: address swap and flash-loan execution correctness issues

### DIFF
--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -9,7 +9,14 @@ import {
   calculateRepayment,
   validateFeeFloor,
 } from "@/contracts/flash-receiver";
-import { FlashLoanError, TransactionError } from "@/errors";
+import {
+  CoralSwapSDKError,
+  FlashLoanError,
+  NetworkError,
+  RpcError,
+  TransactionError,
+  mapError,
+} from "@/errors";
 import { validateAddress, validatePositiveAmount } from "@/utils/validation";
 
 /**
@@ -58,6 +65,15 @@ export class FlashLoanModule {
       );
     }
 
+    const feeFloorBps = Number(config.flashFeeFloor);
+
+    if (!validateFeeFloor(config.flashFeeBps, feeFloorBps)) {
+      throw new FlashLoanError("Flash loan fee below protocol floor", {
+        feeBps: config.flashFeeBps,
+        feeFloor: config.flashFeeFloor,
+      });
+    }
+
     const feeAmount = (amount * BigInt(config.flashFeeBps)) / BigInt(10000);
     const feeFloorAmount = BigInt(config.flashFeeFloor);
     const actualFee = feeAmount > feeFloorAmount ? feeAmount : feeFloorAmount;
@@ -104,7 +120,9 @@ export class FlashLoanModule {
       );
     }
 
-    if (!validateFeeFloor(config.flashFeeBps, config.flashFeeFloor)) {
+    const feeFloorBps = Number(config.flashFeeFloor);
+
+    if (!validateFeeFloor(config.flashFeeBps, feeFloorBps)) {
       throw new FlashLoanError("Flash loan fee below protocol floor", {
         feeBps: config.flashFeeBps,
         feeFloor: config.flashFeeFloor,
@@ -168,9 +186,23 @@ export class FlashLoanModule {
     try {
       const config = await this.getConfig(pairAddress);
       return !config.locked;
-    } catch {
+    } catch (error) {
+      const mappedError = mapError(error);
+
+      if (this.isUnavailableError(mappedError)) {
+        return false;
+      }
+
+      throw mappedError;
+    }
+  }
+
+  private isUnavailableError(error: CoralSwapSDKError): boolean {
+    if (error instanceof NetworkError || error instanceof RpcError) {
       return false;
     }
+
+    return error.code === "PAIR_NOT_FOUND";
   }
 
   /**

--- a/src/modules/swap.ts
+++ b/src/modules/swap.ts
@@ -109,7 +109,7 @@ export class SwapModule {
 
     const rawPath = this.resolvePath(request);
     const path = rawPath.map((t) => resolveTokenIdentifier(t, passphrase));
-    const quote = await this.getQuote(request);
+    const quote = request.quote ?? await this.getQuote(request);
 
     let op: import("@stellar/stellar-sdk").xdr.Operation;
 
@@ -196,7 +196,7 @@ export class SwapModule {
         : await this.computeHops(request.amount, path);
 
     const totalFeeAmount = hops.reduce((acc, h) => acc + h.feeAmount, 0n);
-    const totalFeeBps = hops.reduce((acc, h) => acc + h.feeBps, 0);
+    const totalFeeBps = this.computeCompoundedFeeBps(hops.map((h) => h.feeBps));
     const compoundImpactBps = this.compoundPriceImpact(
       hops.map((h) => h.priceImpactBps),
     );
@@ -460,7 +460,7 @@ export class SwapModule {
 
     // Aggregate totals
     const totalFeeAmount = hops.reduce((acc, h) => acc + h.feeAmount, 0n);
-    const totalFeeBps = hops.reduce((acc, h) => acc + h.feeBps, 0);
+    const totalFeeBps = this.computeCompoundedFeeBps(hops.map((h) => h.feeBps));
 
     // Compound price impact: 1 - product(1 - impact_i)
     const compoundImpactBps = this.compoundPriceImpact(
@@ -646,6 +646,21 @@ export class SwapModule {
       product *= 1 - bps / 10000;
     }
     return Math.round((1 - product) * 10000);
+  }
+
+  /**
+   * Compound fees across all hops and return effective fee in basis points.
+   */
+  computeCompoundedFeeBps(feesBps: number[]): number {
+    let remainingRatio = 10000n;
+
+    for (const feeBps of feesBps) {
+      remainingRatio =
+        (remainingRatio * (PRECISION.BPS_DENOMINATOR - BigInt(feeBps))) /
+        PRECISION.BPS_DENOMINATOR;
+    }
+
+    return Number(PRECISION.BPS_DENOMINATOR - remainingRatio);
   }
 
   /**

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -24,6 +24,8 @@ export interface SwapRequest {
   deadline?: number;
   /** Optional recipient address */
   to?: string;
+  /** Optional pre-fetched quote to execute against without re-fetching reserves */
+  quote?: SwapQuote;
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix multi-hop fee aggregation in `SwapModule` to use compounded fee basis points instead of linear summation for route-level fee accuracy
- add optional pre-fetched `quote` support on swap execute path to avoid re-fetching reserves and remove quote/execute TOCTOU drift
- align flash-loan behavior by validating fee floor in `estimateFee()` and making `isAvailable()` only return false for not-available conditions while rethrowing network/RPC failures

Closes #136
Closes #137
Closes #138
Closes #139