### PR TITLE
feat: add gas estimation, named network exports, formatLargeNumber, a…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,31 +49,40 @@ export interface CoralSwapConfig {
   maxPollingIntervalMs?: number;
 }
 
+/** Network configuration for the Stellar testnet. */
+export const TESTNET_NETWORK: NetworkConfig = {
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  factoryAddress: "",
+  routerAddress: "",
+  sorobanTimeout: 30,
+};
+
+/** Network configuration for the Stellar mainnet. */
+export const MAINNET_NETWORK: NetworkConfig = {
+  rpcUrl: "https://soroban.stellar.org",
+  networkPassphrase: "Public Global Stellar Network ; September 2015",
+  factoryAddress: "",
+  routerAddress: "",
+  sorobanTimeout: 30,
+};
+
+/** Network configuration for the CoralSwap staging environment (runs on testnet RPC). */
+export const STAGING_NETWORK: NetworkConfig = {
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  factoryAddress: "",
+  routerAddress: "",
+  sorobanTimeout: 30,
+};
+
 /**
  * Known contract addresses for each network.
  */
 export const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
-  [Network.TESTNET]: {
-    rpcUrl: "https://soroban-testnet.stellar.org",
-    networkPassphrase: "Test SDF Network ; September 2015",
-    factoryAddress: "",
-    routerAddress: "",
-    sorobanTimeout: 30,
-  },
-  [Network.MAINNET]: {
-    rpcUrl: "https://soroban.stellar.org",
-    networkPassphrase: "Public Global Stellar Network ; September 2015",
-    factoryAddress: "",
-    routerAddress: "",
-    sorobanTimeout: 30,
-  },
-  [Network.STAGING]: {
-    rpcUrl: "https://soroban-testnet.stellar.org",
-    networkPassphrase: "Test SDF Network ; September 2015",
-    factoryAddress: "",
-    routerAddress: "",
-    sorobanTimeout: 30,
-  },
+  [Network.TESTNET]: TESTNET_NETWORK,
+  [Network.MAINNET]: MAINNET_NETWORK,
+  [Network.STAGING]: STAGING_NETWORK,
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,9 @@ export {
   CoralSwapConfig,
   NetworkConfig,
   NETWORK_CONFIGS,
+  TESTNET_NETWORK,
+  MAINNET_NETWORK,
+  STAGING_NETWORK,
   DEFAULTS,
   DEFAULT_SLIPPAGE,
   PRECISION,
@@ -99,6 +102,7 @@ export {
   exceedsBudget,
   decodeDiagnosticEvents,
   buildSimulationResult,
+  estimateGas,
   withRetry,
   isRetryable,
   sleep,
@@ -107,7 +111,6 @@ export {
   validateNonNegativeAmount,
   validateSlippage,
   validateDistinctTokens,
-
   isValidPath,
   EventParser,
   EVENT_TOPICS,
@@ -122,6 +125,7 @@ export type {
   SimulationResourceEstimate,
   WaitNextLedgerOptions,
   DecodeEventsOptions,
+  SimulateFn,
 } from "./utils";
 
 // Errors

--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -6,6 +6,7 @@ import {
   FlashLoanFeeEstimate,
 } from "@/types/flash-loan";
 import { FlashLoanConfig } from "@/types/pool";
+import { GasEstimate } from "@/types/gas";
 import {
   calculateRepayment,
   validateFeeFloor,
@@ -19,6 +20,7 @@ import {
   mapError,
 } from "@/errors";
 import { validateAddress, validatePositiveAmount } from "@/utils/validation";
+import { estimateGas } from "@/utils/gas";
 
 /**
  * Flash Loan module -- first-class flash loan support for CoralSwap.
@@ -89,21 +91,23 @@ export class FlashLoanModule {
   }
 
   /**
-   * Execute a flash loan transaction.
+   * Execute a flash loan transaction, or estimate its fee.
    *
-   * The receiver contract at receiverAddress must implement the
-   * on_flash_loan(sender, token, amount, fee, data) callback.
+   * Pass `{ estimateOnly: true }` to dry-run the simulation and return a
+   * {@link GasEstimate} without submitting.
    *
    * @param request - Parameters required to execute the flash loan
-   * @returns Receipt containing the transaction hash and flash loan details
+   * @param options.estimateOnly - When true, returns a fee estimate instead of submitting
+   * @returns Receipt containing the transaction hash and flash loan details, or a GasEstimate
    * @throws {FlashLoanError} If flash loans are locked or if fee config is invalid
    * @throws {TransactionError} If the execution on-chain fails
    * @example
-   * const result = await client.flashLoans.execute({
-   *   pairAddress: 'C...', token: 'C...', amount: 1000n, receiverAddress: 'C...', callbackData: Buffer.from('')
-   * });
+   * const result = await client.flashLoans.execute({ pairAddress: 'C...', ... });
+   * const gas = await client.flashLoans.execute({ pairAddress: 'C...', ... }, { estimateOnly: true });
    */
-  async execute(request: FlashLoanRequest): Promise<FlashLoanResult> {
+  async execute(request: FlashLoanRequest, options: { estimateOnly: true }): Promise<GasEstimate>;
+  async execute(request: FlashLoanRequest, options?: { estimateOnly?: false }): Promise<FlashLoanResult>;
+  async execute(request: FlashLoanRequest, options?: { estimateOnly?: boolean }): Promise<FlashLoanResult | GasEstimate> {
     validateAddress(request.pairAddress, "pairAddress");
     validateAddress(request.token, "token");
     validatePositiveAmount(request.amount, "amount");
@@ -143,6 +147,10 @@ export class FlashLoanModule {
       request.receiverAddress,
       request.callbackData,
     );
+
+    if (options?.estimateOnly) {
+      return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
+    }
 
     const result = await this.client.submitTransaction([op]);
 

--- a/src/modules/liquidity.ts
+++ b/src/modules/liquidity.ts
@@ -6,6 +6,7 @@ import {
   AddLiquidityQuote,
 } from "@/types/liquidity";
 import { LPPosition } from "@/types/pool";
+import { GasEstimate } from "@/types/gas";
 import { PRECISION } from "@/config";
 import { TransactionError, ValidationError } from "@/errors";
 import {
@@ -14,6 +15,7 @@ import {
   validateNonNegativeAmount,
   validateDistinctTokens,
 } from "@/utils/validation";
+import { estimateGas } from "@/utils/gas";
 
 /**
  * Liquidity module -- manages LP positions in CoralSwap pools.
@@ -98,18 +100,23 @@ export class LiquidityModule {
   }
 
   /**
-   * Execute an add-liquidity transaction via the Router.
+   * Execute an add-liquidity transaction via the Router, or estimate its fee.
+   *
+   * Pass `{ estimateOnly: true }` to dry-run the simulation and return a
+   * {@link GasEstimate} without submitting.
    *
    * @param request - Parameters for adding liquidity
-   * @returns The execution result containing the transaction hash and added amounts
+   * @param options.estimateOnly - When true, returns a fee estimate instead of submitting
+   * @returns The execution result, or a GasEstimate when estimateOnly is true
    * @throws {ValidationError} If minimum amounts exceed desired amounts or inputs are invalid
    * @throws {TransactionError} If the transaction execution fails
    * @example
-   * const result = await client.liquidity.addLiquidity({
-   *   tokenA: 'C...', tokenB: 'C...', amountADesired: 100n, amountBDesired: 100n, amountAMin: 99n, amountBMin: 99n, to: 'C...'
-   * });
+   * const result = await client.liquidity.addLiquidity({ tokenA: 'C...', ... });
+   * const gas = await client.liquidity.addLiquidity({ tokenA: 'C...', ... }, { estimateOnly: true });
    */
-  async addLiquidity(request: AddLiquidityRequest): Promise<LiquidityResult> {
+  async addLiquidity(request: AddLiquidityRequest, options: { estimateOnly: true }): Promise<GasEstimate>;
+  async addLiquidity(request: AddLiquidityRequest, options?: { estimateOnly?: false }): Promise<LiquidityResult>;
+  async addLiquidity(request: AddLiquidityRequest, options?: { estimateOnly?: boolean }): Promise<LiquidityResult | GasEstimate> {
     validateAddress(request.tokenA, "tokenA");
     validateAddress(request.tokenB, "tokenB");
     validateDistinctTokens(request.tokenA, request.tokenB);
@@ -144,6 +151,10 @@ export class LiquidityModule {
       deadline,
     );
 
+    if (options?.estimateOnly) {
+      return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
+    }
+
     const result = await this.client.submitTransaction([op]);
 
     if (!result.success) {
@@ -163,19 +174,25 @@ export class LiquidityModule {
   }
 
   /**
-   * Execute a remove-liquidity transaction via the Router.
+   * Execute a remove-liquidity transaction via the Router, or estimate its fee.
+   *
+   * Pass `{ estimateOnly: true }` to dry-run the simulation and return a
+   * {@link GasEstimate} without submitting.
    *
    * @param request - Parameters for removing liquidity
-   * @returns The execution result containing the withdrawn token amounts
+   * @param options.estimateOnly - When true, returns a fee estimate instead of submitting
+   * @returns The execution result, or a GasEstimate when estimateOnly is true
    * @throws {TransactionError} If the transaction execution fails
    * @example
-   * const result = await client.liquidity.removeLiquidity({
-   *   tokenA: 'C...', tokenB: 'C...', liquidity: 50n, amountAMin: 49n, amountBMin: 49n, to: 'C...'
-   * });
+   * const result = await client.liquidity.removeLiquidity({ tokenA: 'C...', ... });
+   * const gas = await client.liquidity.removeLiquidity({ tokenA: 'C...', ... }, { estimateOnly: true });
    */
+  async removeLiquidity(request: RemoveLiquidityRequest, options: { estimateOnly: true }): Promise<GasEstimate>;
+  async removeLiquidity(request: RemoveLiquidityRequest, options?: { estimateOnly?: false }): Promise<LiquidityResult>;
   async removeLiquidity(
     request: RemoveLiquidityRequest,
-  ): Promise<LiquidityResult> {
+    options?: { estimateOnly?: boolean },
+  ): Promise<LiquidityResult | GasEstimate> {
     validateAddress(request.tokenA, "tokenA");
     validateAddress(request.tokenB, "tokenB");
     validateDistinctTokens(request.tokenA, request.tokenB);
@@ -195,6 +212,10 @@ export class LiquidityModule {
       request.amountBMin,
       deadline,
     );
+
+    if (options?.estimateOnly) {
+      return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
+    }
 
     const result = await this.client.submitTransaction([op]);
 

--- a/src/modules/swap.ts
+++ b/src/modules/swap.ts
@@ -9,6 +9,7 @@ import {
   MultiHopSwapRequest,
   MultiHopSwapQuote,
 } from "@/types/swap";
+import { GasEstimate } from "@/types/gas";
 import { PRECISION, DEFAULTS } from "@/config";
 import {
   TransactionError,
@@ -24,6 +25,7 @@ import {
   isValidPath,
 } from '@/utils/validation';
 import { resolveTokenIdentifier } from '@/utils/addresses';
+import { estimateGas } from '@/utils/gas';
 
 
 /**
@@ -84,19 +86,23 @@ export class SwapModule {
   }
 
   /**
-   * Execute a swap transaction on-chain.
+   * Execute a swap transaction on-chain, or estimate its fee.
    *
-   * For multi-hop paths, invokes the router's swap_exact_tokens_for_tokens
-   * with the full path vector. For direct swaps, uses swap_exact_in /
-   * swap_exact_out as before.
+   * Pass `{ estimateOnly: true }` to run a dry-run simulation and receive a
+   * {@link GasEstimate} without submitting the transaction.
    *
    * @param request - The swap request configuration
-   * @returns Receipt containing the transaction hash and swap details
+   * @param options.estimateOnly - When true, returns a fee estimate instead of submitting
+   * @returns Receipt containing the transaction hash and swap details, or a GasEstimate
    * @throws {TransactionError} If the execution on-chain fails
+   * @throws {SimulationError} If estimateOnly simulation fails
    * @example
    * const result = await client.swap.execute({ tokenIn: 'C...', tokenOut: 'C...', amount: 100n, tradeType: TradeType.EXACT_IN });
+   * const gas = await client.swap.execute({ ... }, { estimateOnly: true });
    */
-  async execute(request: SwapRequest): Promise<SwapResult> {
+  async execute(request: SwapRequest, options: { estimateOnly: true }): Promise<GasEstimate>;
+  async execute(request: SwapRequest, options?: { estimateOnly?: false }): Promise<SwapResult>;
+  async execute(request: SwapRequest, options?: { estimateOnly?: boolean }): Promise<SwapResult | GasEstimate> {
     validatePositiveAmount(request.amount, 'amount');
 
     const passphrase = this.client.networkConfig.networkPassphrase;
@@ -141,6 +147,10 @@ export class SwapModule {
               quote.amountIn,
               quote.deadline,
             );
+    }
+
+    if (options?.estimateOnly) {
+      return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
     }
 
     const result = await this.client.submitTransaction([op]);

--- a/src/types/gas.ts
+++ b/src/types/gas.ts
@@ -1,0 +1,11 @@
+/**
+ * Gas / fee estimate returned by estimateGas() and the estimateOnly option.
+ */
+export interface GasEstimate {
+  /** Raw fee in stroops (the smallest XLM unit). */
+  fee: number;
+  /** Human-readable fee string, e.g. "0.00001 XLM". */
+  feeXLM: string;
+  /** Optional USD equivalent of the fee (requires a price feed). */
+  feeUSD?: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './flash-loan';
 export * from './fee';
 export * from './events';
 export * from './tokens';
+export * from './gas';

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -1,0 +1,45 @@
+import { xdr } from '@stellar/stellar-sdk';
+import { SimulateTransactionResult } from '@/types/common';
+import { GasEstimate } from '@/types/gas';
+import { SimulationError } from '@/errors';
+
+const STROOPS_PER_XLM = 10_000_000;
+
+/**
+ * A function that simulates a set of operations and returns a typed result.
+ * Matches the enhanced form of CoralSwapClient.simulateTransaction.
+ */
+export type SimulateFn = (
+  operations: xdr.Operation[],
+) => Promise<SimulateTransactionResult>;
+
+/**
+ * Estimate the network fee for a set of operations by running a dry-run simulation.
+ *
+ * @param simulate - Async function that simulates the given operations.
+ *   Pass `(ops) => client.simulateTransaction(ops, {})` from a module or client context.
+ * @param operations - The operations whose fee should be estimated.
+ * @returns A {@link GasEstimate} with the fee in stroops and human-readable XLM string.
+ * @throws {SimulationError} If the simulation reports failure.
+ *
+ * @example
+ * const gas = await estimateGas(
+ *   (ops) => client.simulateTransaction(ops, {}),
+ *   [swapOp],
+ * );
+ * console.log(gas.feeXLM); // "0.00001 XLM"
+ */
+export async function estimateGas(
+  simulate: SimulateFn,
+  operations: xdr.Operation[],
+): Promise<GasEstimate> {
+  const sim = await simulate(operations);
+  if (!sim.success) {
+    throw new SimulationError(sim.error ?? 'Simulation failed', {
+      simulation: sim.raw,
+    });
+  }
+  const fee = parseInt(sim.minResourceFee, 10) || 0;
+  const feeXLM = `${(fee / STROOPS_PER_XLM).toFixed(5)} XLM`;
+  return { fee, feeXLM };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -60,6 +60,9 @@ export {
   isValidPath,
 } from './validation';
 
+export { estimateGas } from './gas';
+export type { SimulateFn } from './gas';
+
 export { waitNextLedger } from './ledger';
 export type { WaitNextLedgerOptions } from './ledger';
 

--- a/tests/gas-estimation.test.ts
+++ b/tests/gas-estimation.test.ts
@@ -1,0 +1,279 @@
+import { estimateGas } from '../src/utils/gas';
+import { SimulationError } from '../src/errors';
+import { SwapModule } from '../src/modules/swap';
+import { LiquidityModule } from '../src/modules/liquidity';
+import { FlashLoanModule } from '../src/modules/flash-loan';
+import { TradeType } from '../src/types/common';
+import { CoralSwapClient } from '../src/client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TOKEN_A = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const TOKEN_B = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4';
+const PAIR_ADDR = 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526';
+const USER_ADDR = TOKEN_A;
+
+function makeSuccessSimResult(minResourceFee = '100') {
+  return {
+    success: true,
+    returnValue: null,
+    auth: [],
+    minResourceFee,
+    cost: null,
+    transactionData: null,
+    latestLedger: 1,
+    events: [],
+    error: null,
+    raw: {} as any,
+  };
+}
+
+function makeFailSimResult(error = 'contract trapped') {
+  return {
+    success: false,
+    returnValue: null,
+    auth: [],
+    minResourceFee: '',
+    cost: null,
+    transactionData: null,
+    latestLedger: 1,
+    events: [],
+    error,
+    raw: {} as any,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// estimateGas utility
+// ---------------------------------------------------------------------------
+
+describe('estimateGas()', () => {
+  it('returns fee and feeXLM from a successful simulation', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessSimResult('100'));
+    const result = await estimateGas(simulate, []);
+    expect(result.fee).toBe(100);
+    expect(result.feeXLM).toBe('0.00001 XLM');
+    expect(result.feeUSD).toBeUndefined();
+  });
+
+  it('converts stroops to XLM correctly (7 decimal places)', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessSimResult('10000000'));
+    const result = await estimateGas(simulate, []);
+    expect(result.fee).toBe(10_000_000);
+    expect(result.feeXLM).toBe('1.00000 XLM');
+  });
+
+  it('handles fee of zero', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessSimResult('0'));
+    const result = await estimateGas(simulate, []);
+    expect(result.fee).toBe(0);
+    expect(result.feeXLM).toBe('0.00000 XLM');
+  });
+
+  it('throws SimulationError when simulation fails', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeFailSimResult('contract trapped'));
+    await expect(estimateGas(simulate, [])).rejects.toBeInstanceOf(SimulationError);
+  });
+
+  it('SimulationError contains the RPC error message', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeFailSimResult('out of budget'));
+    await expect(estimateGas(simulate, [])).rejects.toMatchObject({
+      message: 'out of budget',
+    });
+  });
+
+  it('calls simulate with the provided operations', async () => {
+    const op = { type: 'invokeHostFunction' } as any;
+    const simulate = jest.fn().mockResolvedValue(makeSuccessSimResult('50'));
+    await estimateGas(simulate, [op]);
+    expect(simulate).toHaveBeenCalledWith([op]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SwapModule – estimateOnly
+// ---------------------------------------------------------------------------
+
+function createSwapClient(simResult = makeSuccessSimResult('200')): CoralSwapClient {
+  return {
+    networkConfig: { networkPassphrase: 'Test SDF Network ; September 2015' },
+    config: {},
+    publicKey: USER_ADDR,
+    getPairAddress: jest.fn().mockResolvedValue(PAIR_ADDR),
+    pair: jest.fn().mockReturnValue({
+      getReserves: jest.fn().mockResolvedValue({ reserve0: 1_000_000_000n, reserve1: 1_000_000_000n }),
+      getDynamicFee: jest.fn().mockResolvedValue(30),
+      getTokens: jest.fn().mockResolvedValue({ token0: TOKEN_A, token1: TOKEN_B }),
+    }),
+    router: {
+      buildSwapExactIn: jest.fn().mockReturnValue({ type: 'swapExactIn' }),
+      buildSwapExactOut: jest.fn().mockReturnValue({ type: 'swapExactOut' }),
+      buildSwapExactTokensForTokens: jest.fn().mockReturnValue({ type: 'multiHop' }),
+    },
+    simulateTransaction: jest.fn().mockResolvedValue(simResult),
+    getDeadline: jest.fn().mockReturnValue(9999999999),
+  } as unknown as CoralSwapClient;
+}
+
+describe('SwapModule.execute({ estimateOnly: true })', () => {
+  it('returns GasEstimate without submitting', async () => {
+    const client = createSwapClient(makeSuccessSimResult('200'));
+    const mod = new SwapModule(client);
+    const gas = await mod.execute(
+      { tokenIn: TOKEN_A, tokenOut: TOKEN_B, amount: 1_000_000n, tradeType: TradeType.EXACT_IN },
+      { estimateOnly: true },
+    );
+    expect(gas.fee).toBe(200);
+    expect(gas.feeXLM).toBe('0.00002 XLM');
+    expect((client.simulateTransaction as jest.Mock)).toHaveBeenCalled();
+  });
+
+  it('throws SimulationError when swap dry-run fails', async () => {
+    const client = createSwapClient(makeFailSimResult('trap'));
+    const mod = new SwapModule(client);
+    await expect(
+      mod.execute(
+        { tokenIn: TOKEN_A, tokenOut: TOKEN_B, amount: 1_000_000n, tradeType: TradeType.EXACT_IN },
+        { estimateOnly: true },
+      ),
+    ).rejects.toBeInstanceOf(SimulationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LiquidityModule – estimateOnly (addLiquidity / removeLiquidity)
+// ---------------------------------------------------------------------------
+
+function createLiquidityClient(simResult = makeSuccessSimResult('300')): CoralSwapClient {
+  return {
+    networkConfig: {},
+    config: {},
+    publicKey: USER_ADDR,
+    getPairAddress: jest.fn().mockResolvedValue(PAIR_ADDR),
+    pair: jest.fn().mockReturnValue({
+      getReserves: jest.fn().mockResolvedValue({ reserve0: 1_000_000n, reserve1: 1_000_000n }),
+      getTokens: jest.fn().mockResolvedValue({ token0: TOKEN_A, token1: TOKEN_B }),
+      getLPTokenAddress: jest.fn().mockResolvedValue(PAIR_ADDR),
+    }),
+    lpToken: jest.fn().mockReturnValue({
+      totalSupply: jest.fn().mockResolvedValue(1_000_000n),
+    }),
+    router: {
+      buildAddLiquidity: jest.fn().mockReturnValue({ type: 'addLiquidity' }),
+      buildRemoveLiquidity: jest.fn().mockReturnValue({ type: 'removeLiquidity' }),
+    },
+    simulateTransaction: jest.fn().mockResolvedValue(simResult),
+    getDeadline: jest.fn().mockReturnValue(9999999999),
+  } as unknown as CoralSwapClient;
+}
+
+describe('LiquidityModule.addLiquidity({ estimateOnly: true })', () => {
+  it('returns GasEstimate without submitting', async () => {
+    const client = createLiquidityClient(makeSuccessSimResult('300'));
+    const mod = new LiquidityModule(client);
+    const gas = await mod.addLiquidity(
+      {
+        tokenA: TOKEN_A, tokenB: TOKEN_B,
+        amountADesired: 100_000n, amountBDesired: 100_000n,
+        amountAMin: 99_000n, amountBMin: 99_000n,
+        to: USER_ADDR,
+      },
+      { estimateOnly: true },
+    );
+    expect(gas.fee).toBe(300);
+    expect(gas.feeXLM).toBe('0.00003 XLM');
+  });
+
+  it('throws SimulationError on failed dry-run', async () => {
+    const client = createLiquidityClient(makeFailSimResult('contract error'));
+    const mod = new LiquidityModule(client);
+    await expect(
+      mod.addLiquidity(
+        {
+          tokenA: TOKEN_A, tokenB: TOKEN_B,
+          amountADesired: 100_000n, amountBDesired: 100_000n,
+          amountAMin: 99_000n, amountBMin: 99_000n,
+          to: USER_ADDR,
+        },
+        { estimateOnly: true },
+      ),
+    ).rejects.toBeInstanceOf(SimulationError);
+  });
+});
+
+describe('LiquidityModule.removeLiquidity({ estimateOnly: true })', () => {
+  it('returns GasEstimate without submitting', async () => {
+    const client = createLiquidityClient(makeSuccessSimResult('150'));
+    const mod = new LiquidityModule(client);
+    const gas = await mod.removeLiquidity(
+      {
+        tokenA: TOKEN_A, tokenB: TOKEN_B,
+        liquidity: 50_000n,
+        amountAMin: 49_000n, amountBMin: 49_000n,
+        to: USER_ADDR,
+      },
+      { estimateOnly: true },
+    );
+    expect(gas.fee).toBe(150);
+    expect(gas.feeXLM).toBe('0.00002 XLM');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FlashLoanModule – estimateOnly
+// ---------------------------------------------------------------------------
+
+function createFlashLoanClient(simResult = makeSuccessSimResult('400')): CoralSwapClient {
+  return {
+    networkConfig: {},
+    config: {},
+    publicKey: USER_ADDR,
+    pair: jest.fn().mockReturnValue({
+      getFlashLoanConfig: jest.fn().mockResolvedValue({
+        locked: false,
+        flashFeeBps: 10,
+        flashFeeFloor: 5n,
+      }),
+      buildFlashLoan: jest.fn().mockReturnValue({ type: 'flashLoan' }),
+    }),
+    simulateTransaction: jest.fn().mockResolvedValue(simResult),
+  } as unknown as CoralSwapClient;
+}
+
+describe('FlashLoanModule.execute({ estimateOnly: true })', () => {
+  it('returns GasEstimate without submitting', async () => {
+    const client = createFlashLoanClient(makeSuccessSimResult('400'));
+    const mod = new FlashLoanModule(client);
+    const gas = await mod.execute(
+      {
+        pairAddress: PAIR_ADDR,
+        token: TOKEN_A,
+        amount: 1_000_000n,
+        receiverAddress: USER_ADDR,
+        callbackData: Buffer.from(''),
+      },
+      { estimateOnly: true },
+    );
+    expect(gas.fee).toBe(400);
+    expect(gas.feeXLM).toBe('0.00004 XLM');
+  });
+
+  it('throws SimulationError when flash loan dry-run fails', async () => {
+    const client = createFlashLoanClient(makeFailSimResult('insufficient funds'));
+    const mod = new FlashLoanModule(client);
+    await expect(
+      mod.execute(
+        {
+          pairAddress: PAIR_ADDR,
+          token: TOKEN_A,
+          amount: 1_000_000n,
+          receiverAddress: USER_ADDR,
+          callbackData: Buffer.from(''),
+        },
+        { estimateOnly: true },
+      ),
+    ).rejects.toBeInstanceOf(SimulationError);
+  });
+});


### PR DESCRIPTION
…nd STAGING_NETWORK

Closes #190, 
Closes #62, 
Closes #63, 
Closes #64.

- Add GasEstimate type and estimateGas() utility (utils/gas.ts) that calls simulateTransaction internally and returns fee + feeXLM string
- Add estimateOnly: true option to SwapModule.execute(), LiquidityModule.addLiquidity/removeLiquidity(), and FlashLoanModule.execute() — returns GasEstimate without submitting
- Failed simulation throws typed SimulationError instead of raw RPC error
- Add TESTNET_NETWORK, MAINNET_NETWORK, STAGING_NETWORK as named exports from config.ts (NETWORK_CONFIGS now references them); re-export from the main index so SDK consumers can import them directly
- formatLargeNumber already implemented and exported; issue #64 satisfied
- Add tests/gas-estimation.test.ts covering estimateGas utility and all four transaction types with estimateOnly

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
