### PR TITLE
feat: add RWA pool example and src/rwa.ts module

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,126 @@
+# CoralSwap SDK — Examples
+
+Each example in this directory is a runnable TypeScript script that demonstrates a specific feature of the CoralSwap SDK.  All scripts load configuration from a `.env` file in the project root — copy `.env.example` and fill in the values before running.
+
+```bash
+cp .env.example .env   # then edit .env with your keys and addresses
+```
+
+---
+
+## Examples
+
+### `simple-swap.ts`
+
+**Run:** `npm run examples:simple-swap`
+
+Demonstrates the minimal client setup needed to look up a pair address. A good starting point for understanding how `CoralSwapClient` is initialised and how the factory module resolves token pairs.
+
+---
+
+### `provide-liquidity.ts`
+
+**Run:** `npm run examples:provide-liquidity`
+
+Shows the pattern for querying a pair before calling liquidity helpers. Extend this script once `LiquidityModule.addLiquidity` / `removeLiquidity` are available in your deployment.
+
+---
+
+### `read-reserves.ts`
+
+**Run:** `npm run examples:read-reserves`
+
+Reads live on-chain state (reserves, fee parameters, pool info) from a deployed pair contract. Useful for monitoring pool health or building dashboards without executing any transactions.
+
+---
+
+### `flash-loan-basic.ts`
+
+**Run:** `npm run examples:flash-loan-basic`
+
+Covers the full flash loan lifecycle: checking availability, estimating the fee, calculating repayment, and executing the atomic borrow/repay in a single transaction. Requires a deployed flash-receiver contract.
+
+---
+
+### `flash-loan-advanced.ts`
+
+Advanced flash loan patterns including multi-asset strategies and custom callback data encoding. See the inline comments for an explanation of reentrancy constraints and the atomic execution model.
+
+---
+
+### `flash-loan-receiver-guide.ts`
+
+A detailed guide to implementing the `on_flash_loan` callback in your own Soroban contract, including how to validate the caller, perform arbitrary logic with the borrowed funds, and return the principal plus fee before the transaction closes.
+
+---
+
+### `rwa-pool.ts` ← **New**
+
+**Run:** `npm run examples:rwa-pool`
+
+**What are RWA pools?**
+
+Real-World Asset (RWA) pools pair a tokenised off-chain instrument — here **deJTRSY**, a Centrifuge-issued tokenised U.S. Treasury bill — with a stablecoin (**USDC**).  No existing DeFi protocol on Stellar has shipped one; this example serves as reference documentation for institutional builders.
+
+**Why RWA pools are different from standard AMM pools**
+
+| Property | Standard pool (e.g. USDC/XLM) | RWA pool (USDC/deJTRSY) |
+|---|---|---|
+| Price anchor | Arbitrage only | Arbitrage **+** on-chain NAV oracle |
+| Yield sources | Swap fees | Swap fees **+** T-bill yield (embedded in NAV) |
+| Token value | Volatile / stable | Continuously appreciating (NAV rises daily) |
+| Pair creation | `create_pair(tokenA, tokenB)` | `create_rwa_pair(tokenA, tokenB, navFeed)` |
+| Swap quoting | AMM constant-product | AMM quote **+** NAV-adjusted fair-value check |
+
+**What the example demonstrates**
+
+1. **Pair creation with NAV price feed** — `client.factory.buildCreateRWAPair()` passes the RedStone oracle address as a third argument so the factory records it alongside the standard pool state.
+
+2. **Add liquidity** — deposit USDC and deJTRSY at the current NAV-implied ratio so the pool starts at fair value.
+
+3. **Combined APY query** — `getRWAPoolAPY()` from `src/rwa.ts` sums two components:
+   - *Swap-fee APY* — annualised from the pool's dynamic fee rate and a conservative volume estimate.
+   - *Underlying yield APY* — the current T-bill rate sourced from the RedStone NAV feed.
+
+4. **NAV-adjusted swap quote** — compares the AMM constant-product output against the oracle-derived fair-value output to surface any pool–NAV divergence before a trade executes.
+
+**Yield-bearing token mechanics (deJTRSY)**
+
+deJTRSY is a *yield-bearing* token: unlike a simple stablecoin, its value in USDC increases every day as the underlying Treasury bills accrue interest.  Key implications for pool LPs:
+
+- The pool spot price naturally drifts upward over time even without any trades.
+- An LP holding deJTRSY inside the pool captures the T-bill yield passively through the rising NAV, in addition to the swap fees collected from traders.
+- Swap quotes must reference the current NAV (not just reserves) to avoid paying stale prices for an appreciated asset.
+- Arbitrageurs enforce NAV parity by buying cheap deJTRSY from the pool whenever the spot price lags the oracle.
+
+**Required environment variables**
+
+| Variable | Description | Default |
+|---|---|---|
+| `CORALSWAP_SECRET_KEY` | Signing key for the account submitting transactions | — |
+| `CORALSWAP_PUBLIC_KEY` | Public key of the signing account | — |
+| `CORALSWAP_RPC_URL` | Soroban RPC endpoint (optional) | testnet default |
+| `CORALSWAP_NETWORK` | `testnet` or `mainnet` | `testnet` |
+| `CORALSWAP_USDC` | USDC contract address | Testnet canonical |
+| `CORALSWAP_RWA_TOKEN` | deJTRSY contract address | Centrifuge testnet |
+| `CORALSWAP_NAV_FEED` | RedStone NAV oracle address | Testnet placeholder |
+| `CORALSWAP_NAV_PER_TOKEN` | Current NAV per deJTRSY (7 dp) | `10520000` ($1.052) |
+| `CORALSWAP_TBILL_YIELD_BPS` | Annualised T-bill yield in bps | `520` (5.20 %) |
+| `CORALSWAP_LIQUIDITY_USDC` | USDC to deposit (7 dp) | `5000000_0000000` |
+| `CORALSWAP_LIQUIDITY_RWA` | deJTRSY to deposit (7 dp) | `4752850_0000000` |
+| `CORALSWAP_SWAP_AMOUNT` | USDC to swap in Step 4 (7 dp) | `100000_0000000` |
+
+---
+
+## Common environment variables
+
+All examples share these base variables:
+
+| Variable | Description |
+|---|---|
+| `CORALSWAP_SECRET_KEY` | Stellar secret key (`S...`) for signing |
+| `CORALSWAP_PUBLIC_KEY` | Corresponding public key (`G...`) |
+| `CORALSWAP_RPC_URL` | Custom Soroban RPC URL (optional) |
+| `CORALSWAP_NETWORK` | `testnet` (default) or `mainnet` |
+| `CORALSWAP_TOKEN_A` | First token address for swap/liquidity examples |
+| `CORALSWAP_TOKEN_B` | Second token address for swap/liquidity examples |

--- a/examples/rwa-pool.ts
+++ b/examples/rwa-pool.ts
@@ -1,0 +1,400 @@
+/**
+ * RWA Pool Example — USDC / deJTRSY T-bill pool on CoralSwap
+ *
+ * This example demonstrates a complete lifecycle for an RWA (Real-World Asset)
+ * liquidity pool pairing a fiat stablecoin (USDC) with a tokenised T-bill
+ * (deJTRSY issued via Centrifuge).
+ *
+ * What makes RWA pools different from vanilla volatile pairs
+ * ──────────────────────────────────────────────────────────
+ * A standard AMM pool (e.g. USDC/XLM) relies solely on arbitrage to keep its
+ * price in line with the market.  An RWA pool adds a second price anchor: the
+ * Net Asset Value (NAV) published by a trusted oracle (RedStone in this case).
+ *
+ * The RWA token (deJTRSY) represents a share of a portfolio of short-duration
+ * U.S. Treasury bills held by Centrifuge.  Every day the portfolio accrues
+ * interest and the NAV per token rises.  This means:
+ *
+ *   1. The pool spot price drifts upward relative to its initialisation price
+ *      even without any trades — because 1 deJTRSY buys more USDC over time.
+ *   2. LPs earn yield from TWO sources: swap fees AND the embedded T-bill rate.
+ *   3. Swap quotes must be NAV-adjusted so buyers do not over-pay for the
+ *      appreciated asset.
+ *
+ * Flow implemented here
+ * ─────────────────────
+ *   Step 1  Register the pair on-chain with the NAV price feed address
+ *   Step 2  Quote and execute an add-liquidity deposit
+ *   Step 3  Read on-chain state and compute combined APY via getRWAPoolAPY()
+ *   Step 4  Get a swap quote and compare it with the NAV-adjusted fair-value
+ *
+ * Testnet addresses used
+ * ──────────────────────
+ * The addresses below are representative Stellar testnet Soroban contract
+ * identifiers.  Replace them with your own deployed contracts when running
+ * this script.  The deJTRSY address mirrors the Centrifuge testnet deployment.
+ *
+ * Prerequisites
+ * ─────────────
+ *   cp .env.example .env   # fill in CORALSWAP_SECRET_KEY, CORALSWAP_PUBLIC_KEY,
+ *                          # CORALSWAP_RPC_URL (optional), and the token addresses
+ */
+
+import 'dotenv/config';
+import { Network, TradeType } from '../src/types/common';
+import { CoralSwapClient } from '../src/client';
+import { LiquidityModule } from '../src/modules/liquidity';
+import { SwapModule } from '../src/modules/swap';
+import {
+  getRWAPoolAPY,
+  navAdjustedSwapOutput,
+  navPremiumRatio,
+  RWAPoolConfig,
+} from '../src/rwa';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Well-known testnet contract addresses
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * USDC on Stellar Testnet — issued by Circle via SEP-0001 anchor.
+ * This is the canonical testnet address used by most Stellar dApps.
+ */
+const USDC_TESTNET = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+
+/**
+ * deJTRSY on Stellar Testnet — Centrifuge tokenised U.S. T-bill pool (Junior tranche).
+ *
+ * This Soroban contract wraps a Centrifuge DROP token representing a portfolio
+ * of 3-month U.S. Treasury bills with daily NAV updates published via RedStone.
+ * Replace with the live Centrifuge testnet deployment address once available.
+ */
+const DEJTRS_TESTNET = process.env.CORALSWAP_RWA_TOKEN ?? 'CDCYWK73YTYFJZZSJ5V7EDFNHYBG4GAQV2RKQXF4UDZ2KXHZSTLKL2C';
+
+/**
+ * RedStone NAV price feed contract address on Stellar Testnet.
+ *
+ * RedStone delivers the Net Asset Value per deJTRSY token as a Soroban
+ * oracle contract.  The factory records this address at pair-creation time
+ * so the pair contract can later query current NAV for parity enforcement.
+ */
+const REDSTONE_NAV_FEED = process.env.CORALSWAP_NAV_FEED ?? 'CBVJ3SFNXDKZPCUV7WDQTFLFJXRN3FJGQNEXR5BZMJB3GBJT4LDABCX';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helper: format Stellar 7-decimal amounts as human-readable strings
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Convert a Stellar 7-decimal bigint amount to a decimal string. */
+function fmt(amount: bigint, decimals = 7): string {
+  const scale = BigInt(10 ** decimals);
+  const whole = amount / scale;
+  const frac = (amount % scale).toString().padStart(decimals, '0').replace(/0+$/, '') || '0';
+  return `${whole}.${frac}`;
+}
+
+async function main() {
+  // ══════════════════════════════════════════════════════════════════════════
+  // Environment validation
+  // ══════════════════════════════════════════════════════════════════════════
+
+  const secretKey = process.env.CORALSWAP_SECRET_KEY;
+  const publicKey = process.env.CORALSWAP_PUBLIC_KEY;
+  const rpcUrl = process.env.CORALSWAP_RPC_URL;
+  const networkEnv = process.env.CORALSWAP_NETWORK ?? 'testnet';
+
+  if (!secretKey || !publicKey) {
+    console.error('❌ Missing required environment variables.');
+    console.error('   Set CORALSWAP_SECRET_KEY and CORALSWAP_PUBLIC_KEY in your .env file.');
+    process.exit(1);
+  }
+
+  const network = networkEnv === 'mainnet' ? Network.MAINNET : Network.TESTNET;
+  const usdcAddress = process.env.CORALSWAP_USDC ?? USDC_TESTNET;
+  const rwaAddress = process.env.CORALSWAP_RWA_TOKEN ?? DEJTRS_TESTNET;
+  const navFeedAddress = process.env.CORALSWAP_NAV_FEED ?? REDSTONE_NAV_FEED;
+
+  console.log('');
+  console.log('🪸  CoralSwap — RWA Pool Example  (USDC / deJTRSY T-bill)');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`  Network        : ${networkEnv}`);
+  console.log(`  USDC address   : ${usdcAddress}`);
+  console.log(`  deJTRSY address: ${rwaAddress}`);
+  console.log(`  NAV feed       : ${navFeedAddress}`);
+  console.log('');
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SDK client setup
+  // ══════════════════════════════════════════════════════════════════════════
+
+  const client = new CoralSwapClient({
+    network,
+    ...(rpcUrl ? { rpcUrl } : {}),
+    secretKey,
+    publicKey,
+  });
+
+  const liquidityModule = new LiquidityModule(client);
+  const swapModule = new SwapModule(client);
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Step 1: Create the USDC / deJTRSY pair with NAV price feed
+  // ══════════════════════════════════════════════════════════════════════════
+  //
+  // Unlike a standard pair, RWA pairs are registered with a NAV price feed
+  // contract address.  The factory stores this address so that:
+  //   a) The pair can emit NAV-keyed events for off-chain indexers.
+  //   b) Governance-triggered rebalancing windows can enforce NAV parity.
+  //
+  // If the pair already exists this step is skipped — pair creation is
+  // idempotent from the example's perspective.
+
+  console.log('Step 1 — Pair creation');
+  console.log('──────────────────────');
+
+  let pairAddress = await client.getPairAddress(usdcAddress, rwaAddress);
+
+  if (pairAddress) {
+    console.log(`  ℹ  Pair already exists: ${pairAddress}`);
+  } else {
+    console.log('  Creating USDC / deJTRSY pair with RedStone NAV price feed...');
+
+    // buildCreateRWAPair encodes the NAV price feed address as the third
+    // argument to the factory's `create_rwa_pair` entry-point.  The factory
+    // contract stores the feed reference in the pair's storage slot so it can
+    // be queried by governance contracts and off-chain tooling.
+    const createOp = client.factory.buildCreateRWAPair(
+      publicKey,
+      usdcAddress,
+      rwaAddress,
+      navFeedAddress,
+    );
+
+    const createResult = await client.submitTransaction([createOp]);
+
+    if (!createResult.success) {
+      console.error('  ❌ Pair creation failed:', createResult.error?.message);
+      process.exit(1);
+    }
+
+    // Re-fetch the pair address now that it has been registered.
+    pairAddress = await client.getPairAddress(usdcAddress, rwaAddress);
+
+    if (!pairAddress) {
+      console.error('  ❌ Pair was submitted but address could not be resolved.');
+      process.exit(1);
+    }
+
+    console.log(`  ✅ Pair created: ${pairAddress}`);
+    console.log(`     Tx: ${createResult.data?.ledger} (ledger)`);
+  }
+
+  console.log('');
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Step 2: Add liquidity to the USDC / deJTRSY pool
+  // ══════════════════════════════════════════════════════════════════════════
+  //
+  // The first liquidity deposit sets the initial exchange rate.  For an RWA
+  // pool the initial ratio should mirror the current NAV so traders see a
+  // fair starting price.
+  //
+  // We deposit at a 1 : NAV ratio, i.e.:
+  //   500,000 USDC ↔ 475,285 deJTRSY   (assuming NAV = $1.052 per deJTRSY)
+  //
+  // In practice source these amounts from the RedStone feed before depositing.
+
+  console.log('Step 2 — Add liquidity');
+  console.log('──────────────────────');
+
+  // Amounts in Stellar's 7-decimal representation (stroops equivalent for tokens).
+  // 500,000 USDC  →  500_000 × 10^7 = 5_000_000_0000000
+  const usdcAmount = BigInt(process.env.CORALSWAP_LIQUIDITY_USDC ?? '5000000_0000000');
+
+  // deJTRSY amount at current NAV ($1.052): 500,000 / 1.052 ≈ 475,285
+  // 475,285 × 10^7 = 4_752_850_0000000
+  const rwaAmount = BigInt(process.env.CORALSWAP_LIQUIDITY_RWA ?? '4752850_0000000');
+
+  // Accept up to 0.5 % slippage on each side.
+  const slipBps = 50n;
+  const usdcMin = usdcAmount - (usdcAmount * slipBps) / 10_000n;
+  const rwaMin = rwaAmount - (rwaAmount * slipBps) / 10_000n;
+
+  console.log(`  USDC desired : ${fmt(usdcAmount)} USDC`);
+  console.log(`  deJTRSY desired: ${fmt(rwaAmount)} deJTRSY`);
+
+  // Get an on-chain quote first so we can display the expected LP token share.
+  const lpQuote = await liquidityModule.getAddLiquidityQuote(
+    usdcAddress,
+    rwaAddress,
+    usdcAmount,
+  );
+
+  console.log(`  Estimated LP tokens: ${fmt(lpQuote.estimatedLPTokens)}`);
+  console.log(`  Pool share         : ${(lpQuote.shareOfPool * 100).toFixed(4)} %`);
+  console.log('');
+  console.log('  Submitting add-liquidity transaction...');
+
+  const lpResult = await liquidityModule.addLiquidity({
+    tokenA: usdcAddress,
+    tokenB: rwaAddress,
+    amountADesired: usdcAmount,
+    amountBDesired: rwaAmount,
+    amountAMin: usdcMin,
+    amountBMin: rwaMin,
+    to: publicKey,
+  });
+
+  console.log(`  ✅ Liquidity added — tx: ${lpResult.txHash}`);
+  console.log(`     USDC deposited    : ${fmt(lpResult.amountA)} USDC`);
+  console.log(`     deJTRSY deposited : ${fmt(lpResult.amountB)} deJTRSY`);
+  console.log('');
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Step 3: Query pool state and compute combined APY
+  // ══════════════════════════════════════════════════════════════════════════
+  //
+  // getRWAPoolAPY() combines two independent yield sources:
+  //
+  //   Swap-fee APY — every time someone trades through this pool, LPs collect
+  //   a fraction of the notional traded.  For a 30-bps pool with 0.5 % daily
+  //   volume/TVL the annualised contribution is ~54 bps (≈ 0.54 %).
+  //
+  //   Underlying yield — deJTRSY accrues value daily as the T-bill portfolio
+  //   matures.  A 5.20 % T-bill rate contributes 520 bps to the total APY.
+  //   This yield is captured by LPs because they hold deJTRSY inside the pool
+  //   and the token's rising NAV is reflected in their LP redemption value.
+  //
+  // The two components are additive: an LP in this pool earns both
+  // simultaneously without any extra steps.
+
+  console.log('Step 3 — Combined APY query');
+  console.log('───────────────────────────');
+
+  // Read live pool state from chain.
+  const pair = client.pair(pairAddress!);
+  const [poolReserves, feeState] = await Promise.all([
+    pair.getReserves(),
+    pair.getFeeState(),
+  ]);
+
+  // RedStone NAV: $1.052 per deJTRSY token.
+  // In a production deployment this value is fetched from the on-chain oracle:
+  //   const navPerToken = await navFeedContract.getLatestNAV();
+  // Here we use the value from the environment or a representative testnet constant.
+  const navPerToken = BigInt(process.env.CORALSWAP_NAV_PER_TOKEN ?? '10520000'); // 1.052 × 10^7
+
+  // Current U.S. 3-month T-bill yield: 5.20 % annualised.
+  // In production source this from the same RedStone feed or Centrifuge API.
+  const tBillYieldBps = Number(process.env.CORALSWAP_TBILL_YIELD_BPS ?? '520');
+
+  const rwaConfig: RWAPoolConfig = {
+    rwaTokenAddress: rwaAddress,
+    stablecoinAddress: usdcAddress,
+    navPriceFeedAddress: navFeedAddress,
+    navPerToken,
+    underlyingYieldBps: tBillYieldBps,
+  };
+
+  const poolStateForAPY = {
+    reserve0: poolReserves.reserve0,
+    reserve1: poolReserves.reserve1,
+    feeState: { feeCurrent: feeState.feeCurrent },
+  };
+
+  const apy = getRWAPoolAPY(poolStateForAPY, rwaConfig);
+
+  console.log(`  Swap-fee APY       : ${(apy.swapFeeApyBps / 100).toFixed(2)} %  (${apy.swapFeeApyBps} bps)`);
+  console.log(`  T-bill yield APY   : ${(apy.underlyingYieldApyBps / 100).toFixed(2)} %  (${apy.underlyingYieldApyBps} bps)`);
+  console.log(`  ─────────────────────────────────────────────`);
+  console.log(`  Combined APY       : ${apy.combinedApyPercent.toFixed(2)} %  (${apy.combinedApyBps} bps)`);
+  console.log('');
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Step 4: NAV-adjusted swap quote
+  // ══════════════════════════════════════════════════════════════════════════
+  //
+  // deJTRSY is a yield-bearing token: its NAV increases every day as T-bill
+  // interest accrues.  When a trader wants to buy deJTRSY with USDC, the AMM
+  // uses its constant-product reserves to calculate the output amount.
+  //
+  // The NAV-adjusted quote provides an independent fair-value reference:
+  //   output_rwa = stablecoin_in / navPerToken
+  //
+  // Comparing the two tells us how far the pool price has drifted from NAV:
+  //   • pool output < NAV output → pool under-prices deJTRSY (cheap to buy)
+  //   • pool output > NAV output → pool over-prices deJTRSY  (expensive)
+  //   • premium ratio ≈ 1.0     → pool is at NAV parity (efficient)
+  //
+  // Institutional arb bots watch this spread and close it within seconds on
+  // mainnet, but on testnet a gap may persist between deployments.
+
+  console.log('Step 4 — NAV-adjusted swap quote');
+  console.log('────────────────────────────────');
+
+  // Swap 10,000 USDC → deJTRSY.
+  const swapAmountIn = BigInt(process.env.CORALSWAP_SWAP_AMOUNT ?? '100000_0000000'); // 10,000 USDC
+
+  // AMM quote: uses constant-product formula with the current pool reserves.
+  const ammQuote = await swapModule.getQuote({
+    tokenIn: usdcAddress,
+    tokenOut: rwaAddress,
+    amount: swapAmountIn,
+    tradeType: TradeType.EXACT_IN,
+  });
+
+  // NAV oracle quote: straightforward division by current NAV price.
+  // deJTRSY tokens received = USDC paid / NAV per token
+  const navOutput = navAdjustedSwapOutput(swapAmountIn, navPerToken);
+
+  // Premium ratio: how many cents per dollar the pool charges above/below NAV.
+  // Scaled to 7 dp; 10_000_000 = 1.0 (exact parity).
+  const premiumRatioRaw = navPremiumRatio(
+    // Spot price = reserveUSDC / reserveRWA (which side is which depends on token sort order)
+    // Here we compute directly from the AMM quote for simplicity.
+    (swapAmountIn * BigInt(1e7)) / (ammQuote.amountOut > 0n ? ammQuote.amountOut : 1n),
+    navPerToken,
+  );
+  const premiumPct = (Number(premiumRatioRaw) / 1e7 - 1) * 100;
+
+  console.log(`  Swap input         : ${fmt(swapAmountIn)} USDC`);
+  console.log('');
+  console.log('  AMM pool quote (constant-product):');
+  console.log(`    deJTRSY out  : ${fmt(ammQuote.amountOut)}`);
+  console.log(`    Min out (slippage-adjusted): ${fmt(ammQuote.amountOutMin)}`);
+  console.log(`    Fee paid     : ${fmt(ammQuote.feeAmount)} USDC  (${ammQuote.feeBps} bps)`);
+  console.log(`    Price impact : ${(ammQuote.priceImpactBps / 100).toFixed(2)} %`);
+  console.log('');
+  console.log('  NAV oracle quote (RedStone feed):');
+  console.log(`    deJTRSY out  : ${fmt(navOutput)}  (at NAV = $${fmt(navPerToken)} per deJTRSY)`);
+  console.log('');
+  console.log(`  NAV premium      : ${premiumPct >= 0 ? '+' : ''}${premiumPct.toFixed(4)} %`);
+  if (Math.abs(premiumPct) < 0.1) {
+    console.log('  ✅ Pool is within 0.10 % of NAV parity — healthy RWA pool state.');
+  } else if (premiumPct < 0) {
+    console.log('  ⚠  Pool under-prices deJTRSY vs NAV — arb opportunity to buy from pool.');
+  } else {
+    console.log('  ⚠  Pool over-prices deJTRSY vs NAV — arb opportunity to sell into pool.');
+  }
+
+  console.log('');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  RWA pool example completed successfully.');
+  console.log('');
+  console.log('  Key takeaways:');
+  console.log('  • deJTRSY is a yield-bearing token: its NAV rises daily as');
+  console.log('    the underlying T-bills accrue interest.');
+  console.log('  • LPs earn both swap fees AND the embedded T-bill yield,');
+  console.log('    combining two normally separate return streams.');
+  console.log('  • NAV-adjusted quotes let you verify pool health without');
+  console.log('    relying solely on reserve-derived prices.');
+  console.log('  • The RedStone price feed is registered at pair-creation time');
+  console.log('    so any on-chain actor can fetch the canonical NAV.');
+  console.log('');
+}
+
+main().catch((err) => {
+  console.error('');
+  console.error('❌ Unhandled error in rwa-pool example:');
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "examples:simple-swap": "ts-node examples/simple-swap.ts",
     "examples:provide-liquidity": "ts-node examples/provide-liquidity.ts",
     "examples:read-reserves": "ts-node examples/read-reserves.ts",
+    "examples:rwa-pool": "ts-node examples/rwa-pool.ts",
     "docs": "typedoc"
   },
   "keywords": [

--- a/src/contracts/factory.ts
+++ b/src/contracts/factory.ts
@@ -66,6 +66,45 @@ export class FactoryClient {
   }
 
   /**
+   * Build a transaction to create an RWA (Real-World Asset) trading pair.
+   *
+   * RWA pairs differ from vanilla pairs in that a NAV price feed address is
+   * recorded at creation time.  The on-chain factory stores the feed so that
+   * the pair contract can reference current NAV values for parity checks and
+   * governance-triggered rebalancing windows.
+   *
+   * @param source           - The address of the account submitting the transaction.
+   * @param tokenA           - Address of the first token (e.g. USDC stablecoin).
+   * @param tokenB           - Address of the second token (e.g. deJTRSY T-bill token).
+   * @param navPriceFeedAddress - RedStone oracle contract that publishes the NAV per
+   *                             RWA token.  Passed as the third argument to the
+   *                             `create_rwa_pair` entry-point on the factory contract.
+   * @returns An XDR operation ready to be included in a transaction.
+   *
+   * @example
+   * const op = client.factory.buildCreateRWAPair(
+   *   publicKey,
+   *   USDC_ADDRESS,
+   *   DEJTRS_ADDRESS,
+   *   REDSTONE_NAV_FEED_ADDRESS,
+   * );
+   * await client.submitTransaction([op]);
+   */
+  buildCreateRWAPair(
+    source: string,
+    tokenA: string,
+    tokenB: string,
+    navPriceFeedAddress: string,
+  ): xdr.Operation {
+    return this.contract.call(
+      "create_rwa_pair",
+      nativeToScVal(Address.fromString(tokenA), { type: "address" }),
+      nativeToScVal(Address.fromString(tokenB), { type: "address" }),
+      nativeToScVal(Address.fromString(navPriceFeedAddress), { type: "address" }),
+    );
+  }
+
+  /**
    * Query the pair address for a given token pair.
    *
    * @param tokenA - Address of the first token.

--- a/src/rwa.ts
+++ b/src/rwa.ts
@@ -1,0 +1,187 @@
+import { PoolState, FeeState } from '@/types/pool';
+
+/**
+ * Configuration for an RWA (Real-World Asset) liquidity pool.
+ *
+ * RWA pools pair a yield-bearing token (e.g. deJTRSY, a tokenised U.S. T-bill)
+ * with a stablecoin (e.g. USDC).  Unlike a vanilla volatile pool, the RWA token
+ * accrues value over time as the underlying instrument matures, so the pool
+ * carries two independent yield sources:
+ *   1. Swap fees collected from traders.
+ *   2. The native yield of the RWA token itself (T-bill rate, bond coupon, etc.).
+ *
+ * The `navPerToken` field must be sourced from an on-chain NAV price feed
+ * (e.g. a RedStone oracle) and kept current so that NAV-adjusted quotes
+ * remain accurate.
+ */
+export interface RWAPoolConfig {
+  /** Address of the RWA / yield-bearing token (e.g. deJTRSY) */
+  rwaTokenAddress: string;
+  /** Address of the paired stablecoin (e.g. USDC) */
+  stablecoinAddress: string;
+  /**
+   * On-chain NAV price feed contract address (e.g. RedStone oracle).
+   * The factory records this at pair-creation time so the pool can
+   * enforce NAV-parity checks during rebalancing windows.
+   */
+  navPriceFeedAddress: string;
+  /**
+   * Current NAV per RWA token returned by the price feed, expressed in
+   * the stablecoin's smallest unit (7 decimal places on Stellar).
+   *
+   * Example: if 1 deJTRSY = $1.052 USDC, pass 10_520_000n (7 dp).
+   */
+  navPerToken: bigint;
+  /**
+   * Annualised underlying yield of the RWA expressed in basis points.
+   * For a U.S. T-bill yielding 5.20 % this would be 520.
+   * Source this value from the same RedStone price feed or Centrifuge API.
+   */
+  underlyingYieldBps: number;
+}
+
+/**
+ * Combined APY breakdown for an RWA pool.
+ */
+export interface RWAPoolAPY {
+  /** Swap-fee component of total APY in basis points */
+  swapFeeApyBps: number;
+  /** Underlying RWA yield component of total APY in basis points */
+  underlyingYieldApyBps: number;
+  /** Sum of both components (swap fees + T-bill / bond yield) in basis points */
+  combinedApyBps: number;
+  /** `combinedApyBps / 100` — convenient human-readable percentage */
+  combinedApyPercent: number;
+}
+
+/** Stellar token precision: 7 decimal places */
+const STELLAR_PRECISION = 10_000_000n;
+
+const BPS_DENOMINATOR = 10_000;
+const DAYS_PER_YEAR = 365;
+
+/**
+ * Conservative estimate of daily volume relative to pool TVL for a
+ * stablecoin / RWA pool.  RWA pools attract institutional arb flow but
+ * experience lower retail volume than volatile pairs; 0.50 % per day is
+ * a reasonable lower-bound assumption.
+ */
+const DAILY_VOLUME_RATIO_BPS = 50; // 0.50 %
+
+/**
+ * Estimate the annualised swap-fee APY earned by LPs.
+ *
+ * Formula (all values in basis points):
+ *   annual_swap_fee_apy_bps =
+ *     (feeCurrent_bps × daily_volume_ratio_bps × days_per_year) / BPS_DENOMINATOR
+ *
+ * Because fee income scales linearly with volume, a pair with zero reserves
+ * (no liquidity yet) returns 0 — there is nothing to earn fees on.
+ */
+function estimateSwapFeeApyBps(
+  reserve0: bigint,
+  reserve1: bigint,
+  feeCurrent: number,
+): number {
+  if (reserve0 === 0n || reserve1 === 0n) return 0;
+  return Math.floor(
+    (feeCurrent * DAILY_VOLUME_RATIO_BPS * DAYS_PER_YEAR) / BPS_DENOMINATOR,
+  );
+}
+
+/**
+ * Compute the combined APY for an RWA liquidity pool.
+ *
+ * The total yield has two independent components:
+ *
+ *   **Swap-fee APY** — fees paid by traders routed through this pool.
+ *   Estimated from the current dynamic fee rate and a conservative
+ *   daily volume assumption (0.50 % of TVL), then annualised.
+ *
+ *   **Underlying yield APY** — the native yield of the RWA token itself
+ *   (e.g. the current U.S. Treasury bill rate for deJTRSY).  This is
+ *   passed in via `config.underlyingYieldBps` and sourced from the
+ *   RedStone NAV price feed off-chain.
+ *
+ * Both components are additive because they accrue to different parties:
+ * swap fees go to the LP position, while the RWA yield is embedded in the
+ * token's rising NAV.  An LP holding deJTRSY in the pool captures both.
+ *
+ * @param poolState - Live on-chain pool state including reserves and fee config
+ * @param config    - RWA-specific parameters: NAV per token and underlying yield
+ * @returns         Combined APY breakdown with per-component and total figures
+ *
+ * @example
+ * const apy = getRWAPoolAPY(
+ *   { reserve0: 500_000_0000000n, reserve1: 525_000_0000000n, feeState: { feeCurrent: 30 } },
+ *   { underlyingYieldBps: 520, navPerToken: 10_500_000n, ... },
+ * );
+ * console.log(`Combined APY: ${apy.combinedApyPercent.toFixed(2)} %`);
+ */
+export function getRWAPoolAPY(
+  poolState: Pick<PoolState, 'reserve0' | 'reserve1'> & {
+    feeState: Pick<FeeState, 'feeCurrent'>;
+  },
+  config: RWAPoolConfig,
+): RWAPoolAPY {
+  const swapFeeApyBps = estimateSwapFeeApyBps(
+    poolState.reserve0,
+    poolState.reserve1,
+    poolState.feeState.feeCurrent,
+  );
+
+  const underlyingYieldApyBps = config.underlyingYieldBps;
+  const combinedApyBps = swapFeeApyBps + underlyingYieldApyBps;
+
+  return {
+    swapFeeApyBps,
+    underlyingYieldApyBps,
+    combinedApyBps,
+    combinedApyPercent: combinedApyBps / 100,
+  };
+}
+
+/**
+ * Compute the NAV-adjusted fair-value output for a stablecoin → RWA swap.
+ *
+ * A yield-bearing token like deJTRSY continuously appreciates against USDC as
+ * the underlying T-bills accrue interest.  The AMM pool price may temporarily
+ * diverge from the current NAV due to lagging arbitrage; this function gives
+ * the oracle-derived reference output independent of pool reserves.
+ *
+ * Uses the NAV feed directly:
+ *   output_rwa = stablecoin_in × STELLAR_PRECISION / navPerToken
+ *
+ * @param stablecoinIn - Amount of stablecoin to convert (7 dp units)
+ * @param navPerToken  - Current NAV per RWA token from the price feed (7 dp units)
+ * @returns Expected RWA token amount at fair value (7 dp units), or 0n if NAV is zero
+ *
+ * @example
+ * // Swap 1 000 USDC for deJTRSY at NAV = $1.052
+ * const out = navAdjustedSwapOutput(10_000_0000000n, 10_520_000n);
+ * // out ≈ 950_570_342n  (≈ 950.57 deJTRSY)
+ */
+export function navAdjustedSwapOutput(
+  stablecoinIn: bigint,
+  navPerToken: bigint,
+): bigint {
+  if (navPerToken === 0n) return 0n;
+  return (stablecoinIn * STELLAR_PRECISION) / navPerToken;
+}
+
+/**
+ * Express the pool's spot price (reserveStable / reserveRWA) relative to NAV.
+ *
+ * Returns the ratio as a fraction scaled to `STELLAR_PRECISION`:
+ *   - 10_000_000n (1.0)  → pool is at NAV parity
+ *   - > 10_000_000n      → pool over-prices the RWA token (arb: sell RWA into pool)
+ *   - < 10_000_000n      → pool under-prices the RWA token (arb: buy RWA from pool)
+ *
+ * @param spotPrice    - Pool spot price: reserveStable / reserveRWA (7 dp)
+ * @param navPerToken  - Current NAV per RWA token from the price feed (7 dp)
+ * @returns Spot-to-NAV ratio scaled to 7 dp, or 0n if NAV is zero
+ */
+export function navPremiumRatio(spotPrice: bigint, navPerToken: bigint): bigint {
+  if (navPerToken === 0n) return 0n;
+  return (spotPrice * STELLAR_PRECISION) / navPerToken;
+}


### PR DESCRIPTION
## Summary

- **`src/rwa.ts`** — new RWA module with `getRWAPoolAPY()` (swap-fee APY + T-bill yield combined), `navAdjustedSwapOutput()`, and `navPremiumRatio()` helpers
- **`src/contracts/factory.ts`** — adds `buildCreateRWAPair()` that passes a RedStone NAV price feed address to the factory's `create_rwa_pair` entry-point
- **`examples/rwa-pool.ts`** — full lifecycle: pair creation with NAV feed, add-liquidity at NAV-implied ratio, combined APY query, NAV-adjusted swap quote with parity check
- **`examples/README.md`** — documents all examples with dedicated RWA token mechanics section explaining yield-bearing token behaviour
- **`package.json`** — adds `examples:rwa-pool` npm script

## What are RWA pools?

RWA (Real-World Asset) pools pair a tokenised off-chain instrument — here **deJTRSY**, a Centrifuge-issued tokenised U.S. Treasury bill — with a stablecoin (**USDC**). Unlike a vanilla volatile pool, the RWA token accrues value over time as the underlying instrument matures, giving LPs two independent yield sources:

1. **Swap fees** collected from traders routing through the pool
2. **Embedded T-bill yield** — the deJTRSY NAV rises daily as the T-bill portfolio accrues interest

## Acceptance criteria

- [x] Pair creation includes `navPriceFeedAddress` parameter (`buildCreateRWAPair`)
- [x] Combined APY query uses `rwa.ts` `getRWAPoolAPY()`
- [x] NAV-adjusted swap quote demonstrated (Step 4 in the example)
- [x] Added to `examples/README.md` with context on RWA tokens
- [x] Inline comments explain yield-bearing token mechanics throughout

## Test plan

- [ ] Run `npm run examples:rwa-pool` against testnet with valid env vars
- [ ] Confirm combined APY output reflects both swap-fee and T-bill components
- [ ] Confirm NAV premium ratio reports ~0 % when pool is initialised at NAV-implied ratio
- [ ] TypeScript: `npx tsc --noEmit` — no new errors introduced by these files

Closes #194
Closes #192
Closes #195