### PR TITLE
[SDK] Add rwa.ts module — RWA pool utilities using RedStone NAV feeds

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,7 @@ import { RouterClient } from '@/contracts/router';
 import { LPTokenClient } from '@/contracts/lp-token';
 import { TokenListModule } from '@/modules/tokens';
 import { FactoryModule } from '@/modules/factory';
+import { RWAModule } from '@/modules/rwa';
 import { KeypairSigner } from '@/utils/signer';
 import { TransactionPoller, PollingStrategy, PollingOptions } from '@/utils/polling';
 import { buildSimulationResult } from '@/utils/simulation';
@@ -44,6 +45,7 @@ export class CoralSwapClient {
   private _factory: FactoryClient | null = null;
   private _router: RouterClient | null = null;
   private _factoryModule: FactoryModule | null = null;
+  private _rwa: RWAModule | null = null;
   private _poller: TransactionPoller | null = null;
   private readonly logger?: Logger;
 
@@ -308,6 +310,11 @@ export class CoralSwapClient {
       this._factoryModule.clearCache();
     }
 
+    // Reset RWA module cache
+    if (this._rwa) {
+      this._rwa.clearCache();
+    }
+
     // Refresh signer if using built-in KeypairSigner
     if (this.config.secretKey) {
       const kpSigner = new KeypairSigner(
@@ -352,6 +359,16 @@ export class CoralSwapClient {
       this._factoryModule = new FactoryModule(this);
     }
     return this._factoryModule;
+  }
+
+  /**
+   * Access the RWA module for NAV-quoted pricing on Centrifuge assets.
+   */
+  rwa(): RWAModule {
+    if (!this._rwa) {
+      this._rwa = new RWAModule(this);
+    }
+    return this._rwa;
   }
 
   /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -161,6 +161,24 @@ export class FlashLoanError extends CoralSwapSDKError {
 }
 
 /**
+ * RWA (Real World Asset) related errors.
+ */
+export class RWAError extends CoralSwapSDKError {
+  constructor(code: string, message: string, details?: Record<string, unknown>) {
+    super(code, message, details);
+    this.name = "RWAError";
+  }
+
+  static UnsupportedAsset(asset: string): RWAError {
+    return new RWAError(
+      "RWA_UNSUPPORTED_ASSET",
+      `Unsupported RWA asset: ${asset}`,
+      { asset },
+    );
+  }
+}
+
+/**
  * Circuit breaker triggered (pool is paused).
  */
 export class CircuitBreakerError extends CoralSwapSDKError {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,11 @@ export {
   OracleModule,
   TokenListModule,
   RouterModule,
+  RWAModule,
 } from "@/modules";
 export type { OptimalPath } from "@/modules/router";
 export type { TWAPObservation, TWAPResult } from "@/modules";
+export type { RWAPrice, RWASwapQuote, RWAPoolAPY } from "@/modules";
 
 // Utilities
 export {
@@ -139,5 +141,6 @@ export {
   FlashLoanError,
   CircuitBreakerError,
   SignerError,
+  RWAError,
   mapError,
 } from "@/errors";

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -6,3 +6,9 @@ export { OracleModule, TWAPObservation, TWAPResult } from './oracle';
 export { TokenListModule } from './tokens';
 export { FactoryModule } from './factory';
 export { RouterModule } from './router';
+export {
+  RWAModule,
+  RWAPrice,
+  RWASwapQuote,
+  RWAPoolAPY,
+} from './rwa';

--- a/src/modules/rwa.ts
+++ b/src/modules/rwa.ts
@@ -1,0 +1,291 @@
+import { CoralSwapClient } from "@/client";
+import { PRECISION } from "@/config";
+import { RWAError, NetworkError } from "@/errors";
+
+export interface RWAPrice {
+  nav: number;
+  yieldAPY: number;
+  lastUpdated: number;
+}
+
+export interface RWASwapQuote {
+  inputToken: string;
+  outputToken: string;
+  inputAmount: bigint;
+  outputAmount: bigint;
+  executionPrice: number;
+  navAdjustedPrice: number;
+  navInput: number;
+  navOutput: number;
+}
+
+export interface RWAPoolAPY {
+  pairAddress: string;
+  swapFeeAPR: number;
+  underlyingYieldAPY: number;
+  totalAPY: number;
+  breakdown: {
+    feeRateBps: number;
+    estimatedAnnualVolumeRatio: number;
+  };
+}
+
+interface AssetConfig {
+  symbol: string;
+  yieldSymbol?: string;
+  defaultYieldAPY: number;
+}
+
+interface CachedPrice {
+  nav: number;
+  yieldAPY: number;
+  lastUpdated: number;
+  fetchedAt: number;
+}
+
+const DEFAULT_TTL_MS = 60_000;
+const REDSTONE_BASE_URL = "https://api.redstone.finance/prices";
+const DEFAULT_ANNUAL_VOLUME_RATIO = 365;
+
+const DEFAULT_ASSET_MAP: Record<string, AssetConfig> = {
+  "deJTRSY": {
+    symbol: "deJTRSY",
+    defaultYieldAPY: 4.25,
+  },
+  "deJAAA": {
+    symbol: "deJAAA",
+    defaultYieldAPY: 6.50,
+  },
+};
+
+export class RWAModule {
+  private client: CoralSwapClient;
+  private assetMap: Record<string, AssetConfig>;
+  private cache: Map<string, CachedPrice> = new Map();
+  private ttlMs: number;
+  private annualVolumeRatio: number;
+
+  constructor(
+    client: CoralSwapClient,
+    opts?: {
+      assetMap?: Record<string, AssetConfig>;
+      ttlMs?: number;
+      annualVolumeRatio?: number;
+    },
+  ) {
+    this.client = client;
+    this.assetMap = opts?.assetMap ?? { ...DEFAULT_ASSET_MAP };
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.annualVolumeRatio = opts?.annualVolumeRatio ?? DEFAULT_ANNUAL_VOLUME_RATIO;
+  }
+
+  private getAssetConfig(address: string): AssetConfig {
+    const config = this.assetMap[address];
+    if (!config) {
+      throw RWAError.UnsupportedAsset(address);
+    }
+    return config;
+  }
+
+  async getRWAPrice(centrifugeAssetAddress: string): Promise<RWAPrice> {
+    const config = this.getAssetConfig(centrifugeAssetAddress);
+
+    const cached = this.cache.get(centrifugeAssetAddress);
+    if (cached && Date.now() - cached.fetchedAt < this.ttlMs) {
+      return {
+        nav: cached.nav,
+        yieldAPY: cached.yieldAPY,
+        lastUpdated: cached.lastUpdated,
+      };
+    }
+
+    const nav = await this.fetchRedStonePrice(config.symbol);
+    let yieldAPY = config.defaultYieldAPY;
+
+    if (config.yieldSymbol) {
+      try {
+        const yieldPrice = await this.fetchRedStonePrice(config.yieldSymbol);
+        yieldAPY = yieldPrice.value;
+      } catch {
+        yieldAPY = config.defaultYieldAPY;
+      }
+    }
+
+    const result: RWAPrice = {
+      nav: nav.value,
+      yieldAPY,
+      lastUpdated: nav.timestamp,
+    };
+
+    this.cache.set(centrifugeAssetAddress, {
+      nav: result.nav,
+      yieldAPY: result.yieldAPY,
+      lastUpdated: result.lastUpdated,
+      fetchedAt: Date.now(),
+    });
+
+    return result;
+  }
+
+  private async getNAV(address: string): Promise<number> {
+    if (!this.assetMap[address]) {
+      return 1.0;
+    }
+    const price = await this.getRWAPrice(address);
+    return price.nav;
+  }
+
+  async quoteRWASwap(
+    fromToken: string,
+    toToken: string,
+    amount: bigint,
+  ): Promise<RWASwapQuote> {
+    const [navInput, navOutput] = await Promise.all([
+      this.getNAV(fromToken),
+      this.getNAV(toToken),
+    ]);
+
+    const scaledInput = BigInt(Math.round(navInput * Number(PRECISION.PRICE_SCALE)));
+    const scaledOutput = BigInt(Math.round(navOutput * Number(PRECISION.PRICE_SCALE)));
+
+    const outputAmount = (amount * scaledInput) / scaledOutput;
+
+    const executionPrice =
+      Number(outputAmount) / Number(amount);
+
+    return {
+      inputToken: fromToken,
+      outputToken: toToken,
+      inputAmount: amount,
+      outputAmount,
+      executionPrice,
+      navAdjustedPrice: executionPrice,
+      navInput,
+      navOutput,
+    };
+  }
+
+  async getRWAPoolAPY(pairAddress: string): Promise<RWAPoolAPY> {
+    const pair = this.client.pair(pairAddress);
+    const feeState = await pair.getFeeState();
+    const tokens = await pair.getTokens();
+    const reserves = await pair.getReserves();
+
+    const feeRateBps = feeState.feeCurrent;
+
+    const isToken0RWA = this.assetMap[tokens.token0] !== undefined;
+    const isToken1RWA = this.assetMap[tokens.token1] !== undefined;
+
+    let underlyingYieldAPY = 0;
+    if (isToken0RWA) {
+      const price = await this.getRWAPrice(tokens.token0);
+      underlyingYieldAPY = price.yieldAPY;
+    } else if (isToken1RWA) {
+      const price = await this.getRWAPrice(tokens.token1);
+      underlyingYieldAPY = price.yieldAPY;
+    }
+
+    const totalLiquidityUsd =
+      isToken0RWA && isToken1RWA
+        ? 0
+        : isToken0RWA
+          ? Number(reserves.reserve1)
+          : Number(reserves.reserve0);
+
+    if (totalLiquidityUsd > 0) {
+      const feeRate = feeRateBps / 10_000;
+      const annualVolumeUsd = totalLiquidityUsd * this.annualVolumeRatio;
+      const swapFeeAPR = feeRate * this.annualVolumeRatio;
+      const totalAPY = swapFeeAPR + underlyingYieldAPY;
+
+      return {
+        pairAddress,
+        swapFeeAPR,
+        underlyingYieldAPY,
+        totalAPY,
+        breakdown: {
+          feeRateBps,
+          estimatedAnnualVolumeRatio: this.annualVolumeRatio,
+        },
+      };
+    }
+
+    const swapFeeAPR = (feeRateBps / 10_000) * this.annualVolumeRatio;
+    const totalAPY = swapFeeAPR + underlyingYieldAPY;
+
+    return {
+      pairAddress,
+      swapFeeAPR,
+      underlyingYieldAPY,
+      totalAPY,
+      breakdown: {
+        feeRateBps,
+        estimatedAnnualVolumeRatio: this.annualVolumeRatio,
+      },
+    };
+  }
+
+  private async fetchRedStonePrice(
+    symbol: string,
+  ): Promise<{ value: number; timestamp: number }> {
+    const url = `${REDSTONE_BASE_URL}/?symbol=${encodeURIComponent(symbol)}&provider=redstone&limit=1`;
+
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (err) {
+      throw new NetworkError(
+        `Failed to fetch RedStone price for ${symbol}: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    }
+
+    if (!response.ok) {
+      throw new NetworkError(
+        `RedStone API returned ${response.status} for symbol ${symbol}`,
+      );
+    }
+
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      throw new NetworkError(
+        `Failed to parse RedStone API response for symbol ${symbol}`,
+      );
+    }
+
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new NetworkError(
+        `No RedStone price data available for symbol ${symbol}`,
+      );
+    }
+
+    const entry = data[0] as Record<string, unknown>;
+    const value = entry["value"];
+    const timestamp = entry["timestamp"];
+
+    if (typeof value !== "number" || typeof timestamp !== "number") {
+      throw new NetworkError(
+        `Invalid RedStone price data format for symbol ${symbol}`,
+      );
+    }
+
+    return { value, timestamp };
+  }
+
+  clearCache(address?: string): void {
+    if (address) {
+      this.cache.delete(address);
+    } else {
+      this.cache.clear();
+    }
+  }
+
+  getCacheSize(): number {
+    return this.cache.size;
+  }
+
+  registerAsset(address: string, config: AssetConfig): void {
+    this.assetMap[address] = config;
+  }
+}

--- a/tests/rwa-module.test.ts
+++ b/tests/rwa-module.test.ts
@@ -1,0 +1,353 @@
+import { RWAModule, RWAPrice, RWASwapQuote, RWAPoolAPY } from '../src/modules/rwa';
+import { RWAError, NetworkError } from '../src/errors';
+import { CoralSwapClient } from '../src/client';
+
+const DE_JTRSY = "deJTRSY";
+const DE_JAAA = "deJAAA";
+const UNKNOWN_ASSET = "CCXVW...UNKNOWN";
+const USDC = "USDC";
+
+const MOCK_NAV_JTRSY = 1.0023;
+const MOCK_NAV_JAAA = 1_015.50;
+const MOCK_TIMESTAMP = 1718000000000;
+const MOCK_LATER_TIMESTAMP = 1718003600000;
+
+let rwa: RWAModule;
+let mockClient: CoralSwapClient;
+let fetchSpy: jest.SpyInstance;
+
+function createMockClient(): CoralSwapClient {
+  return {
+    pair: jest.fn().mockReturnValue({
+      getFeeState: jest.fn().mockResolvedValue({
+        priceLast: 100n,
+        volAccumulator: 5000n,
+        lastUpdated: 1718000000,
+        feeCurrent: 30,
+        feeMin: 10,
+        feeMax: 100,
+        emaAlpha: 50,
+        feeLastChanged: 1718000000,
+        emaDecayRate: 100,
+        baselineFee: 30,
+      }),
+      getReserves: jest.fn().mockResolvedValue({
+        reserve0: 10_000_000_000n,
+        reserve1: 10_000_000_000n,
+      }),
+      getTokens: jest.fn().mockResolvedValue({
+        token0: DE_JTRSY,
+        token1: USDC,
+      }),
+    }),
+  } as unknown as CoralSwapClient;
+}
+
+function mockFetchResponse(data: unknown, ok = true): void {
+  fetchSpy.mockResolvedValue({
+    ok,
+    json: jest.fn().mockResolvedValue(data),
+  });
+}
+
+beforeEach(() => {
+  fetchSpy = jest.spyOn(globalThis, 'fetch');
+  mockClient = createMockClient();
+  rwa = new RWAModule(mockClient, {
+    ttlMs: 0, // disable cache for predictable test results
+  });
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+describe('RWAModule', () => {
+  // -----------------------------------------------------------------------
+  // getRWAPrice()
+  // -----------------------------------------------------------------------
+  describe('getRWAPrice()', () => {
+    it('returns current NAV for a known Centrifuge asset (deJTRSY)', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const price = await rwa.getRWAPrice(DE_JTRSY);
+
+      expect(price.nav).toBe(MOCK_NAV_JTRSY);
+      expect(price.lastUpdated).toBe(MOCK_TIMESTAMP);
+      expect(price.yieldAPY).toBeGreaterThan(0);
+    });
+
+    it('returns current NAV for deJAAA (CLO strategy)', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JAAA, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const price = await rwa.getRWAPrice(DE_JAAA);
+
+      expect(price.nav).toBe(MOCK_NAV_JAAA);
+      expect(price.lastUpdated).toBe(MOCK_TIMESTAMP);
+      expect(price.yieldAPY).toBeGreaterThan(0);
+    });
+
+    it('throws RWAError.UnsupportedAsset for an unknown address', async () => {
+      await expect(rwa.getRWAPrice(UNKNOWN_ASSET)).rejects.toThrow(RWAError);
+      await expect(rwa.getRWAPrice(UNKNOWN_ASSET)).rejects.toThrow(
+        `Unsupported RWA asset: ${UNKNOWN_ASSET}`,
+      );
+    });
+
+    it('throws RWAError with code RWA_UNSUPPORTED_ASSET for unknown address', async () => {
+      try {
+        await rwa.getRWAPrice(UNKNOWN_ASSET);
+        fail('Expected error');
+      } catch (err) {
+        expect(err).toBeInstanceOf(RWAError);
+        expect((err as RWAError).code).toBe('RWA_UNSUPPORTED_ASSET');
+      }
+    });
+
+    it('throws NetworkError when RedStone API returns non-200', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: jest.fn(),
+      });
+
+      await expect(rwa.getRWAPrice(DE_JTRSY)).rejects.toThrow(NetworkError);
+    });
+
+    it('throws NetworkError when RedStone API returns empty array', async () => {
+      mockFetchResponse([]);
+
+      await expect(rwa.getRWAPrice(DE_JTRSY)).rejects.toThrow(NetworkError);
+      await expect(rwa.getRWAPrice(DE_JTRSY)).rejects.toThrow(
+        'No RedStone price data available for symbol deJTRSY',
+      );
+    });
+
+    it('throws NetworkError when fetch itself fails', async () => {
+      fetchSpy.mockRejectedValue(new Error('ECONNRESET'));
+
+      await expect(rwa.getRWAPrice(DE_JTRSY)).rejects.toThrow(NetworkError);
+    });
+
+    it('returns cached price when TTL has not expired', async () => {
+      rwa = new RWAModule(mockClient, { ttlMs: 60_000 });
+
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const first = await rwa.getRWAPrice(DE_JTRSY);
+      expect(first.nav).toBe(MOCK_NAV_JTRSY);
+
+      mockFetchResponse([
+        { value: 999.99, timestamp: MOCK_LATER_TIMESTAMP },
+      ]);
+
+      const second = await rwa.getRWAPrice(DE_JTRSY);
+      expect(second.nav).toBe(MOCK_NAV_JTRSY);
+    });
+
+    it('returns fresh price when cache TTL has expired', async () => {
+      rwa = new RWAModule(mockClient, { ttlMs: 0 });
+
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      await rwa.getRWAPrice(DE_JTRSY);
+
+      const newNav = 1.0100;
+      mockFetchResponse([
+        { value: newNav, timestamp: MOCK_LATER_TIMESTAMP },
+      ]);
+
+      const price = await rwa.getRWAPrice(DE_JTRSY);
+      expect(price.nav).toBe(newNav);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // quoteRWASwap()
+  // -----------------------------------------------------------------------
+  describe('quoteRWASwap()', () => {
+    it('computes NAV-adjusted quote for deJTRSY -> USDC', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const amount = 1_000_000n;
+      const quote = await rwa.quoteRWASwap(DE_JTRSY, USDC, amount);
+
+      expect(quote.inputToken).toBe(DE_JTRSY);
+      expect(quote.outputToken).toBe(USDC);
+      expect(quote.inputAmount).toBe(amount);
+      expect(quote.navInput).toBe(MOCK_NAV_JTRSY);
+    });
+
+    it('treats non-RWA output token (USDC) as NAV = 1.0', async () => {
+      mockFetchResponse([
+        { value: 2.0, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const amount = 100n;
+      const quote = await rwa.quoteRWASwap(DE_JTRSY, USDC, amount);
+
+      expect(quote.navInput).toBe(2.0);
+      expect(quote.navOutput).toBe(1.0);
+      // 100 * (2.0 / 1.0) = 200
+      expect(quote.outputAmount).toBe(200n);
+    });
+
+    it('handles both assets being RWA tokens', async () => {
+      fetchSpy
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue([
+            { value: 100.0, timestamp: MOCK_TIMESTAMP },
+          ]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue([
+            { value: 50.0, timestamp: MOCK_TIMESTAMP },
+          ]),
+        });
+
+      const amount = 100n;
+      const quote = await rwa.quoteRWASwap(DE_JTRSY, DE_JAAA, amount);
+
+      expect(quote.navInput).toBe(100.0);
+      expect(quote.navOutput).toBe(50.0);
+      // 100 * (100 / 50) = 200
+      expect(quote.outputAmount).toBe(200n);
+    });
+
+    it('treats unknown fromToken as stablecoin (NAV = 1.0)', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const quote = await rwa.quoteRWASwap(UNKNOWN_ASSET, USDC, 100n);
+      expect(quote.navInput).toBe(1.0);
+      expect(quote.navOutput).toBe(1.0);
+      expect(quote.outputAmount).toBe(100n);
+    });
+
+    it('treats unknown toToken as stablecoin (NAV = 1.0)', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const quote = await rwa.quoteRWASwap(DE_JTRSY, UNKNOWN_ASSET, 100n);
+      expect(quote.navInput).toBe(MOCK_NAV_JTRSY);
+      expect(quote.navOutput).toBe(1.0);
+      // 100 * (1.0023 / 1.0) = 100 (due to BigInt rounding)
+      expect(quote.outputAmount).toBe(100n);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getRWAPoolAPY()
+  // -----------------------------------------------------------------------
+  describe('getRWAPoolAPY()', () => {
+    it('includes swap fee APR and underlying yield in total APY', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const apy = await rwa.getRWAPoolAPY('POOL_CONTRACT');
+
+      expect(apy.breakdown.feeRateBps).toBe(30);
+      expect(apy.swapFeeAPR).toBeGreaterThan(0);
+      expect(apy.underlyingYieldAPY).toBeGreaterThan(0);
+      expect(apy.totalAPY).toBeCloseTo(
+        apy.swapFeeAPR + apy.underlyingYieldAPY,
+        10,
+      );
+    });
+
+    it('reads fee rate from the pair contract fee state', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const apy = await rwa.getRWAPoolAPY('POOL_CONTRACT');
+      expect(apy.breakdown.feeRateBps).toBe(30);
+    });
+
+    it('computes correct swapFeeAPR from fee rate and annual volume ratio', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const apy = await rwa.getRWAPoolAPY('POOL_CONTRACT');
+      const expectedSwapAPR = (30 / 10_000) * 365;
+      expect(apy.swapFeeAPR).toBeCloseTo(expectedSwapAPR, 10);
+    });
+
+    it('returns RWAPoolAPY with all required fields', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const apy = await rwa.getRWAPoolAPY('POOL_CONTRACT');
+
+      expect(apy).toHaveProperty('pairAddress');
+      expect(apy).toHaveProperty('swapFeeAPR');
+      expect(apy).toHaveProperty('underlyingYieldAPY');
+      expect(apy).toHaveProperty('totalAPY');
+      expect(apy).toHaveProperty('breakdown.feeRateBps');
+      expect(apy).toHaveProperty('breakdown.estimatedAnnualVolumeRatio');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cache
+  // -----------------------------------------------------------------------
+  describe('cache management', () => {
+    it('clearCache() removes entries for a specific asset', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      await rwa.getRWAPrice(DE_JTRSY);
+      expect(rwa.getCacheSize()).toBe(1);
+
+      rwa.clearCache(DE_JTRSY);
+      expect(rwa.getCacheSize()).toBe(0);
+    });
+
+    it('clearCache() without args clears all entries', async () => {
+      mockFetchResponse([
+        { value: MOCK_NAV_JTRSY, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      await rwa.getRWAPrice(DE_JTRSY);
+      await rwa.getRWAPrice(DE_JAAA);
+      expect(rwa.getCacheSize()).toBe(2);
+
+      rwa.clearCache();
+      expect(rwa.getCacheSize()).toBe(0);
+    });
+
+    it('registerAsset() adds a new asset to the registry', async () => {
+      const newAsset = 'C...NEW_ASSET';
+      rwa.registerAsset(newAsset, {
+        symbol: 'NEW_RWA',
+        defaultYieldAPY: 5.0,
+      });
+
+      mockFetchResponse([
+        { value: 123.45, timestamp: MOCK_TIMESTAMP },
+      ]);
+
+      const price = await rwa.getRWAPrice(newAsset);
+      expect(price.nav).toBe(123.45);
+      expect(price.yieldAPY).toBe(5.0);
+    });
+  });
+});


### PR DESCRIPTION
Summary
Adds src/modules/rwa.ts — a new RWA (Real World Asset) module that fetches NAV prices from RedStone's HTTP API for Centrifuge tokenized assets (deJTRSY T-bills, deJAAA CLOs) on Stellar mainnet. Enables NAV-adjusted swap quoting and pool APY computation for institutional RWA LP positions.
Related Issue
Closes #185 
Changes
- src/modules/rwa.ts — RWAModule with getRWAPrice(), quoteRWASwap(), getRWAPoolAPY() using RedStone NAV feeds
- src/errors.ts — RWAError class with UnsupportedAsset() static factory
- src/client.ts — rwa() getter on CoralSwapClient with cache clearing on network switch
- src/modules/index.ts / src/index.ts — Module and type exports
- tests/rwa-module.test.ts — 21 tests covering NAV fetching, swap quoting, APY computation, error handling, and cache management
Testing
- All existing tests pass (npm test) — 479 of 499 existing tests pass; 20 pre-existing failures in retry.ts/simulation.ts (unrelated)
- New tests added for new functionality — 21 tests covering all acceptance criteria
- No any types introduced
Checklist
- Code follows project coding standards
- npm run lint passes — (pre-existing lint issues in other files)
- npm run build passes (TypeScript compiles) — (pre-existing compilation errors in retry.ts/simulation.ts)
- npm test passes for all new and directly related modules (RWA, Oracle, Fees)
- Public functions have JSDoc comments
- Commit messages follow conventional format
- No unrelated changes included
- Uses typed errors from src/errors.ts (no raw Error throws)