### PR TITLE
feat: add .env-based contract address overrides for CoralSwap SDK (#158)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# CoralSwap SDK contract overrides
+#
+# Set these to override the default factory and router contract addresses
+# for the current network when using the SDK in a local or environment-driven setup.
+
+CORALSWAP_FACTORY_ADDRESS=
+CORALSWAP_ROUTER_ADDRESS=

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ import {
   Transaction,
   xdr,
 } from '@stellar/stellar-sdk';
-import { CoralSwapConfig, NetworkConfig, NETWORK_CONFIGS, DEFAULTS } from '@/config';
+import { CoralSwapConfig, NetworkConfig, NETWORK_CONFIGS, getNetworkConfig, DEFAULTS } from '@/config';
 import { Network, Result, Logger, Signer, SimulateTransactionOptions, SimulateTransactionResult } from '@/types/common';
 import { SignerError } from '@/errors';
 import { FactoryClient } from '@/contracts/factory';
@@ -150,9 +150,7 @@ export class CoralSwapClient {
     };
 
     this.network = config.network;
-    this.networkConfig = {
-      ...NETWORK_CONFIGS[config.network],
-    };
+    this.networkConfig = getNetworkConfig(config.network, config.logger);
 
     // Handle custom RPC URL(s)
     if (config.rpcUrl) {
@@ -286,9 +284,7 @@ export class CoralSwapClient {
    */
   setNetwork(network: Network, rpcUrl?: string): void {
     this.network = network;
-    this.networkConfig = {
-      ...NETWORK_CONFIGS[network],
-    };
+    this.networkConfig = getNetworkConfig(network, this.logger);
 
     if (rpcUrl) {
       this._rpcUrls = Array.isArray(rpcUrl) ? rpcUrl : [rpcUrl];

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,43 @@ export const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
 };
 
 /**
+ * Load a network configuration with optional environment variable overrides.
+ */
+export function getNetworkConfig(network: Network, logger?: Logger): NetworkConfig {
+  const baseConfig = NETWORK_CONFIGS[network];
+  const factoryEnv = process.env.CORALSWAP_FACTORY_ADDRESS?.trim();
+  const routerEnv = process.env.CORALSWAP_ROUTER_ADDRESS?.trim();
+
+  if (factoryEnv && baseConfig.factoryAddress) {
+    logger?.info(
+      `CORALSWAP_FACTORY_ADDRESS override detected for network ${network}`,
+      {
+        network,
+        configuredFactoryAddress: baseConfig.factoryAddress,
+        envFactoryAddress: factoryEnv,
+      },
+    );
+  }
+
+  if (routerEnv && baseConfig.routerAddress) {
+    logger?.info(
+      `CORALSWAP_ROUTER_ADDRESS override detected for network ${network}`,
+      {
+        network,
+        configuredRouterAddress: baseConfig.routerAddress,
+        envRouterAddress: routerEnv,
+      },
+    );
+  }
+
+  return {
+    ...baseConfig,
+    factoryAddress: factoryEnv || baseConfig.factoryAddress,
+    routerAddress: routerEnv || baseConfig.routerAddress,
+  };
+}
+
+/**
  * Default SDK configuration values.
  */
 export const DEFAULTS = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,85 @@
+import { getNetworkConfig, NETWORK_CONFIGS } from '../src/config';
+import { Network, Logger } from '../src/types/common';
+
+const createMockLogger = (): jest.Mocked<Logger> => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('Config env overrides', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+  });
+
+  it('uses base network config when no env vars are set', () => {
+    delete process.env.CORALSWAP_FACTORY_ADDRESS;
+    delete process.env.CORALSWAP_ROUTER_ADDRESS;
+
+    expect(getNetworkConfig(Network.TESTNET)).toEqual(
+      NETWORK_CONFIGS[Network.TESTNET],
+    );
+  });
+
+  it('overrides factory address from CORALSWAP_FACTORY_ADDRESS', () => {
+    process.env.CORALSWAP_FACTORY_ADDRESS = 'CENVFACTORYADDRESS';
+    delete process.env.CORALSWAP_ROUTER_ADDRESS;
+
+    const result = getNetworkConfig(Network.MAINNET);
+
+    expect(result.factoryAddress).toBe('CENVFACTORYADDRESS');
+    expect(result.routerAddress).toBe(NETWORK_CONFIGS[Network.MAINNET].routerAddress);
+  });
+
+  it('applies partial override and preserves routerAddress', () => {
+    process.env.CORALSWAP_FACTORY_ADDRESS = 'CENVFACTORYONLY';
+    delete process.env.CORALSWAP_ROUTER_ADDRESS;
+
+    const result = getNetworkConfig(Network.STAGING);
+
+    expect(result.factoryAddress).toBe('CENVFACTORYONLY');
+    expect(result.routerAddress).toBe(NETWORK_CONFIGS[Network.STAGING].routerAddress);
+  });
+
+  it('logs a warning when env overrides replace configured addresses', () => {
+    const originalFactory = NETWORK_CONFIGS[Network.TESTNET].factoryAddress;
+    const originalRouter = NETWORK_CONFIGS[Network.TESTNET].routerAddress;
+
+    try {
+      NETWORK_CONFIGS[Network.TESTNET].factoryAddress = 'CGLOBALFACTORYADDRESS';
+      NETWORK_CONFIGS[Network.TESTNET].routerAddress = 'CGLOBALROUTERADDRESS';
+
+      process.env.CORALSWAP_FACTORY_ADDRESS = 'CENVFACTORYADDRESS';
+      process.env.CORALSWAP_ROUTER_ADDRESS = 'CENVROUTERADDRESS';
+
+      const logger = createMockLogger();
+      getNetworkConfig(Network.TESTNET, logger);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('CORALSWAP_FACTORY_ADDRESS override detected'),
+        expect.objectContaining({
+          network: Network.TESTNET,
+          configuredFactoryAddress: 'CGLOBALFACTORYADDRESS',
+          envFactoryAddress: 'CENVFACTORYADDRESS',
+        }),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('CORALSWAP_ROUTER_ADDRESS override detected'),
+        expect.objectContaining({
+          network: Network.TESTNET,
+          configuredRouterAddress: 'CGLOBALROUTERADDRESS',
+          envRouterAddress: 'CENVROUTERADDRESS',
+        }),
+      );
+    } finally {
+      NETWORK_CONFIGS[Network.TESTNET].factoryAddress = originalFactory;
+      NETWORK_CONFIGS[Network.TESTNET].routerAddress = originalRouter;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)


Closes #158