### PR TITLE
[SDK] Add event filtering utilities — filter by type, address, and ledger rangefeat: add filterEvents utility and event-filtering tests (#156)

### DIFF
--- a/Downloads/coralswap-sdk-main/src/index.ts
+++ b/Downloads/coralswap-sdk-main/src/index.ts
@@ -1,0 +1,144 @@
+/**
+ * @coralswap/sdk -- TypeScript SDK for CoralSwap Protocol
+ *
+ * Contract-first AMM SDK for Stellar/Soroban.
+ * Interacts directly with on-chain Soroban contracts without
+ * intermediary APIs, using auto-generated contract bindings.
+ *
+ * @example
+ * ```ts
+ * import { CoralSwapClient, Network, TradeType } from '@coralswap/sdk';
+ *
+ * const client = new CoralSwapClient({
+ *   network: Network.TESTNET,
+ *   secretKey: 'S...',
+ * });
+ *
+ * const swap = client.swap();
+ * const quote = await swap.getQuote({
+ *   tokenIn: 'CDLZ...',
+ *   tokenOut: 'CBQH...',
+ *   amount: 1000000n,
+ *   tradeType: TradeType.EXACT_IN,
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Core client
+export { CoralSwapClient } from "@/client";
+export { KeypairSigner } from "@/utils/signer";
+
+// Configuration
+export {
+  CoralSwapConfig,
+  NetworkConfig,
+  NETWORK_CONFIGS,
+  DEFAULTS,
+  DEFAULT_SLIPPAGE,
+  PRECISION,
+} from "@/config";
+
+// Type exports
+export * from "@/types";
+export type { Logger } from "@/types/common";
+
+// Contract clients
+export {
+  FactoryClient,
+  PairClient,
+  RouterClient,
+  LPTokenClient,
+  encodeFlashLoanData,
+  decodeFlashLoanData,
+  calculateRepayment,
+  validateFeeFloor,
+} from "@/contracts";
+
+// Feature modules
+export {
+  SwapModule,
+  LiquidityModule,
+  FlashLoanModule,
+  FeeModule,
+  OracleModule,
+  TokenListModule,
+  RouterModule,
+} from "@/modules";
+export type { OptimalPath } from "@/modules/router";
+export type { TWAPObservation, TWAPResult } from "@/modules";
+
+// Utilities
+export {
+  toSorobanAmount,
+  parseTokenAmount,
+  fromSorobanAmount,
+  formatAmount,
+  formatLargeNumber,
+  toBps,
+  applyBps,
+  percentDiff,
+  safeMul,
+  safeDiv,
+  minBigInt,
+  maxBigInt,
+  isValidPublicKey,
+  isValidContractId,
+  isValidAddress,
+  isNativeToken,
+  getNativeAssetContractAddress,
+  resolveTokenIdentifier,
+  sortTokens,
+  truncateAddress,
+  toScAddress,
+  getPairAddress,
+  isSimulationSuccess,
+  getSimulationReturnValue,
+  getResourceEstimate,
+  exceedsBudget,
+  decodeDiagnosticEvents,
+  buildSimulationResult,
+  withRetry,
+  isRetryable,
+  sleep,
+  validateAddress,
+  validatePositiveAmount,
+  validateNonNegativeAmount,
+  validateSlippage,
+  validateDistinctTokens,
+
+  isValidPath,
+  EventParser,
+  EVENT_TOPICS,
+  decodeEvents,
+  decodeEventsFromXdr,
+  filterEvents,
+} from './utils';
+
+export type {
+  RetryConfig,
+  SimulationResult,
+  SimulationResourceEstimate,
+  WaitNextLedgerOptions,
+  DecodeEventsOptions,
+  EventFilter,
+} from "./utils";
+
+// Errors
+export {
+  CoralSwapSDKError,
+  NetworkError,
+  RpcError,
+  SimulationError,
+  TransactionError,
+  DeadlineError,
+  SlippageError,
+  InsufficientLiquidityError,
+  PairNotFoundError,
+  ValidationError,
+  FlashLoanError,
+  CircuitBreakerError,
+  SignerError,
+  mapError,
+} from "@/errors";

--- a/Downloads/coralswap-sdk-main/src/utils/events.ts
+++ b/Downloads/coralswap-sdk-main/src/utils/events.ts
@@ -1,0 +1,594 @@
+import { xdr, Address, SorobanRpc } from "@stellar/stellar-sdk";
+import {
+  CoralSwapEvent,
+  ContractEvent,
+  SwapEvent,
+  LiquidityEvent,
+  FlashLoanEvent,
+  MintEvent,
+  BurnEvent,
+  SyncEvent,
+  FeeUpdateEvent,
+} from "@/types/events";
+import { ValidationError } from "@/errors";
+
+/** Response type that may include hash/id for transaction identifier. */
+type TxWithOptionalHash = SorobanRpc.Api.GetSuccessfulTransactionResponse & {
+  hash?: string;
+  id?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Known event topic symbols emitted by CoralSwap Pair contracts
+// ---------------------------------------------------------------------------
+
+/** Recognised event topic identifiers. */
+export const EVENT_TOPICS = {
+  SWAP: "swap",
+  ADD_LIQUIDITY: "add_liquidity",
+  REMOVE_LIQUIDITY: "remove_liquidity",
+  FLASH_LOAN: "flash_loan",
+  MINT: "mint",
+  BURN: "burn",
+  SYNC: "sync",
+  FEE_UPDATE: "fee_update",
+} as const;
+
+const KNOWN_TOPICS = new Set<string>(Object.values(EVENT_TOPICS));
+
+// ---------------------------------------------------------------------------
+// ScVal decoding helpers (safe-guarded against invalid XDR)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode an ScVal i128 to a bigint.
+ */
+function decodeI128(val: xdr.ScVal): bigint {
+  const parts = val.i128();
+  const lo = BigInt(parts.lo().toString());
+  const hi = BigInt(parts.hi().toString());
+  return (hi << 64n) + lo;
+}
+
+/**
+ * Decode an ScVal u32 to a number.
+ */
+function decodeU32(val: xdr.ScVal): number {
+  return val.u32();
+}
+
+/**
+ * Decode an ScVal address to a string.
+ */
+function decodeAddress(val: xdr.ScVal): string {
+  return Address.fromScVal(val).toString();
+}
+
+/**
+ * Decode an ScVal symbol or string to a JS string.
+ */
+function decodeString(val: xdr.ScVal): string {
+  const tag = val.switch().name;
+  if (tag === "scvSymbol") return val.sym().toString();
+  if (tag === "scvString") return val.str().toString();
+  return val.value()?.toString() ?? "";
+}
+
+/**
+ * Safely extract a value from an ScMap by key name.
+ */
+function getMapValue(
+  map: xdr.ScMapEntry[],
+  key: string,
+): xdr.ScVal | undefined {
+  for (const entry of map) {
+    const k = entry.key();
+    const tag = k.switch().name;
+    let keyStr: string | undefined;
+    if (tag === "scvSymbol") keyStr = k.sym().toString();
+    else if (tag === "scvString") keyStr = k.str().toString();
+    if (keyStr === key) return entry.val();
+  }
+  return undefined;
+}
+
+/**
+ * Require a value from an ScMap by key, throwing if absent.
+ */
+function requireMapValue(map: xdr.ScMapEntry[], key: string): xdr.ScVal {
+  const val = getMapValue(map, key);
+  if (!val) {
+    throw new ValidationError(`Missing required event field: ${key}`);
+  }
+  return val;
+}
+
+/**
+ * Extract the contract ID from an xdr.DiagnosticEvent.
+ * Returns an empty string if unavailable.
+ */
+function extractContractId(evt: xdr.DiagnosticEvent): string {
+  try {
+    const ce = evt.event();
+    if (ce.contractId()) {
+      return Address.contract(ce.contractId()!).toString();
+    }
+  } catch {
+    // contractId may be absent for system events
+  }
+  return "";
+}
+
+/**
+ * Extract the topic ScVal array from a DiagnosticEvent.
+ */
+function extractTopics(evt: xdr.DiagnosticEvent): xdr.ScVal[] {
+  const ce = evt.event();
+  const body = ce.body();
+  return body.v0().topics();
+}
+
+/**
+ * Extract the data ScVal from a DiagnosticEvent.
+ */
+function extractData(evt: xdr.DiagnosticEvent): xdr.ScVal {
+  const ce = evt.event();
+  const body = ce.body();
+  return body.v0().data();
+}
+
+// ---------------------------------------------------------------------------
+// EventParser
+// ---------------------------------------------------------------------------
+
+/**
+ * Utility for parsing Soroban contract events emitted by CoralSwap Pair
+ * contracts into typed {@link CoralSwapEvent} objects.
+ *
+ * Supports two primary entry points:
+ * - {@link parse} — accepts an array of `xdr.DiagnosticEvent` (from
+ *   transaction simulation or result meta).
+ * - {@link fromTransaction} — extracts and parses events directly from a
+ *   successful Soroban transaction response.
+ *
+ * Events with unrecognised topics or from non-CoralSwap contracts are
+ * silently skipped. Use {@link parseStrict} to throw on any parse failure.
+ *
+ * @example
+ * ```ts
+ * import { EventParser } from '@coralswap/sdk';
+ *
+ * const parser = new EventParser();
+ *
+ * // From a successful transaction response
+ * const events = parser.fromTransaction(txResponse);
+ *
+ * // From raw DiagnosticEvent array
+ * const parsed = parser.parse(diagnosticEvents);
+ * ```
+ */
+export class EventParser {
+  private readonly contractIds: Set<string>;
+
+  /**
+   * @param contractIds - Optional set of CoralSwap contract addresses. When
+   *   provided, only events from these contracts are parsed; all others are
+   *   ignored. Pass an empty array to parse events from any contract.
+   */
+  constructor(contractIds: string[] = []) {
+    this.contractIds = new Set(contractIds);
+  }
+
+  /**
+   * Parse an array of `xdr.DiagnosticEvent`, skipping unrecognised entries.
+   *
+   * @param events - Diagnostic events from transaction result meta.
+   * @param txHash - Transaction hash to attach to parsed events.
+   * @param ledger - Ledger sequence number.
+   * @returns Array of typed CoralSwapEvent (only successfully parsed events).
+   */
+  parse(
+    events: xdr.DiagnosticEvent[],
+    txHash = "",
+    ledger = 0,
+  ): CoralSwapEvent[] {
+    const parsed: CoralSwapEvent[] = [];
+    for (const evt of events) {
+      try {
+        const result = this.decodeSingle(evt, txHash, ledger);
+        if (result) parsed.push(result);
+      } catch {
+        // Skip malformed events in lenient mode
+      }
+    }
+    return parsed;
+  }
+
+  /**
+   * Parse events, throwing on any decode failure.
+   *
+   * @param events - Diagnostic events from transaction result meta.
+   * @param txHash - Transaction hash to attach to parsed events.
+   * @param ledger - Ledger sequence number.
+   * @returns Array of typed CoralSwapEvent.
+   * @throws {ValidationError} If any recognised event cannot be decoded.
+   */
+  parseStrict(
+    events: xdr.DiagnosticEvent[],
+    txHash = "",
+    ledger = 0,
+  ): CoralSwapEvent[] {
+    const parsed: CoralSwapEvent[] = [];
+    for (const evt of events) {
+      const result = this.decodeSingle(evt, txHash, ledger);
+      if (result) parsed.push(result);
+    }
+    return parsed;
+  }
+
+  /**
+   * Extract and parse events from a successful Soroban transaction response.
+   *
+   * @param response - A successful transaction response from Soroban RPC.
+   * @returns Array of typed CoralSwapEvent.
+   */
+  fromTransaction(
+    response: SorobanRpc.Api.GetSuccessfulTransactionResponse,
+  ): CoralSwapEvent[] {
+    const meta = response.resultMetaXdr;
+    const v3 = meta.v3();
+    const diagnosticEvents = v3.sorobanMeta()?.diagnosticEvents() ?? [];
+    const tx = response as TxWithOptionalHash;
+    const txHash = tx.hash ?? tx.id ?? '';
+
+    const ledger = response.ledger ?? 0;
+    return this.parse(diagnosticEvents, txHash, ledger);
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal decode logic
+  // -------------------------------------------------------------------------
+
+  /**
+   * Decode a single DiagnosticEvent. Returns null when the event is not a
+   * recognised CoralSwap event (unknown topic or filtered contract).
+   */
+  private decodeSingle(
+    evt: xdr.DiagnosticEvent,
+    txHash: string,
+    ledger: number,
+  ): CoralSwapEvent | null {
+    // Only process contract-type events that ran in a successful call
+    if (!evt.inSuccessfulContractCall()) return null;
+
+    const contractId = extractContractId(evt);
+
+    // If contract filter is configured, skip non-matching contracts
+    if (this.contractIds.size > 0 && !this.contractIds.has(contractId)) {
+      return null;
+    }
+
+    let topics: xdr.ScVal[];
+    let data: xdr.ScVal;
+    try {
+      topics = extractTopics(evt);
+      data = extractData(evt);
+    } catch {
+      return null;
+    }
+
+    if (topics.length === 0) return null;
+
+    const topicName = decodeString(topics[0]);
+    if (!KNOWN_TOPICS.has(topicName)) return null;
+
+    const base: Omit<ContractEvent, "type"> = {
+      contractId,
+      ledger,
+      timestamp: ledger,
+      txHash,
+    };
+
+    switch (topicName) {
+      case EVENT_TOPICS.SWAP:
+        return this.parseSwap(data, base);
+      case EVENT_TOPICS.ADD_LIQUIDITY:
+      case EVENT_TOPICS.REMOVE_LIQUIDITY:
+        return this.parseLiquidity(
+          data,
+          base,
+          topicName as "add_liquidity" | "remove_liquidity",
+        );
+      case EVENT_TOPICS.FLASH_LOAN:
+        return this.parseFlashLoan(data, base);
+      case EVENT_TOPICS.MINT:
+        return this.parseMint(data, base);
+      case EVENT_TOPICS.BURN:
+        return this.parseBurn(data, base);
+      case EVENT_TOPICS.SYNC:
+        return this.parseSync(data, base);
+      case EVENT_TOPICS.FEE_UPDATE:
+        return this.parseFeeUpdate(data, base);
+      default:
+        return null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Per-event parsers
+  // -------------------------------------------------------------------------
+
+  private parseSwap(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+  ): SwapEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("Swap event data is not an ScMap");
+
+    return {
+      ...base,
+      type: "swap",
+      sender: decodeAddress(requireMapValue(map, "sender")),
+      tokenIn: decodeAddress(requireMapValue(map, "token_in")),
+      tokenOut: decodeAddress(requireMapValue(map, "token_out")),
+      amountIn: decodeI128(requireMapValue(map, "amount_in")),
+      amountOut: decodeI128(requireMapValue(map, "amount_out")),
+      feeBps: decodeU32(requireMapValue(map, "fee_bps")),
+    };
+  }
+
+  private parseLiquidity(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+    type: "add_liquidity" | "remove_liquidity",
+  ): LiquidityEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("Liquidity event data is not an ScMap");
+
+    return {
+      ...base,
+      type,
+      provider: decodeAddress(requireMapValue(map, "provider")),
+      tokenA: decodeAddress(requireMapValue(map, "token_a")),
+      tokenB: decodeAddress(requireMapValue(map, "token_b")),
+      amountA: decodeI128(requireMapValue(map, "amount_a")),
+      amountB: decodeI128(requireMapValue(map, "amount_b")),
+      liquidity: decodeI128(requireMapValue(map, "liquidity")),
+    };
+  }
+
+  private parseFlashLoan(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+  ): FlashLoanEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("FlashLoan event data is not an ScMap");
+
+    return {
+      ...base,
+      type: "flash_loan",
+      borrower: decodeAddress(requireMapValue(map, "borrower")),
+      token: decodeAddress(requireMapValue(map, "token")),
+      amount: decodeI128(requireMapValue(map, "amount")),
+      fee: decodeI128(requireMapValue(map, "fee")),
+    };
+  }
+
+  private parseMint(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+  ): MintEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("Mint event data is not an ScMap");
+
+    return {
+      ...base,
+      type: "mint",
+      sender: decodeAddress(requireMapValue(map, "sender")),
+      amountA: decodeI128(requireMapValue(map, "amount_a")),
+      amountB: decodeI128(requireMapValue(map, "amount_b")),
+      liquidity: decodeI128(requireMapValue(map, "liquidity")),
+    };
+  }
+
+  private parseBurn(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+  ): BurnEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("Burn event data is not an ScMap");
+
+    return {
+      ...base,
+      type: "burn",
+      sender: decodeAddress(requireMapValue(map, "sender")),
+      amountA: decodeI128(requireMapValue(map, "amount_a")),
+      amountB: decodeI128(requireMapValue(map, "amount_b")),
+      liquidity: decodeI128(requireMapValue(map, "liquidity")),
+      to: decodeAddress(requireMapValue(map, "to")),
+    };
+  }
+
+  private parseSync(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+  ): SyncEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("Sync event data is not an ScMap");
+
+    return {
+      ...base,
+      type: "sync",
+      reserve0: decodeI128(requireMapValue(map, "reserve0")),
+      reserve1: decodeI128(requireMapValue(map, "reserve1")),
+    };
+  }
+
+  private parseFeeUpdate(
+    data: xdr.ScVal,
+    base: Omit<ContractEvent, "type">,
+  ): FeeUpdateEvent {
+    const map = data.map();
+    if (!map) throw new ValidationError("FeeUpdate event data is not an ScMap");
+
+    return {
+      ...base,
+      type: "fee_update",
+      previousFeeBps: decodeU32(requireMapValue(map, "previous_fee_bps")),
+      newFeeBps: decodeU32(requireMapValue(map, "new_fee_bps")),
+      volatility: decodeI128(requireMapValue(map, "volatility")),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// filterEvents utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter criteria for contract events.
+ */
+export interface EventFilter {
+  /** Only return events matching these type names (e.g., 'swap', 'mint'). */
+  types?: string[];
+  /** Only return events from this specific contract address. */
+  contractAddress?: string;
+  /** Only return events at or after this ledger sequence. */
+  fromLedger?: number;
+  /** Only return events at or before this ledger sequence. */
+  toLedger?: number;
+}
+
+/**
+ * Filter an array of decoded events based on type, address, and ledger range.
+ *
+ * @param events - Array of decoded events (e.g. from decodeEvents).
+ * @param options - Filter criteria.
+ * @returns A new array containing only matching events.
+ *
+ * @example
+ * ```ts
+ * const allEvents = decodeEvents(txResponse);
+ * const swaps = filterEvents(allEvents, { types: ['swap'] });
+ * ```
+ */
+export function filterEvents<T extends ContractEvent>(
+  events: T[],
+  options: EventFilter,
+): T[] {
+  return events.filter((event) => {
+    if (options.types && options.types.length > 0) {
+      if (!options.types.includes(event.type)) return false;
+    }
+    if (options.contractAddress) {
+      if (event.contractId !== options.contractAddress) return false;
+    }
+    if (options.fromLedger !== undefined) {
+      if (event.ledger < options.fromLedger) return false;
+    }
+    if (options.toLedger !== undefined) {
+      if (event.ledger > options.toLedger) return false;
+    }
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// decodeEvents utility
+// ---------------------------------------------------------------------------
+
+export interface DecodeEventsOptions {
+  contractId?: string;
+  strict?: boolean;
+}
+
+/**
+ * Decode Pair contract events from a successful Soroban transaction response.
+ *
+ * This utility extracts and parses Swap, Mint, Burn, and Sync events (among
+ * others) from the transaction result meta XDR into strongly-typed objects.
+ *
+ * @param response - A successful transaction response from Soroban RPC.
+ * @param options - Optional configuration for filtering and parsing behavior.
+ * @param options.contractId - If provided, only events from this contract are decoded.
+ * @param options.strict - If true, throws on malformed event data. Defaults to false.
+ * @returns Array of typed CoralSwapEvent objects.
+ *
+ * @example
+ * ```ts
+ * import { decodeEvents } from '@coralswap/sdk';
+ *
+ * const events = decodeEvents(txResponse);
+ * for (const event of events) {
+ *   if (event.type === 'swap') {
+ *     console.log(`Swapped ${event.amountIn} for ${event.amountOut}`);
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Filter events from a specific pair contract
+ * const pairEvents = decodeEvents(txResponse, {
+ *   contractId: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+ * });
+ * ```
+ */
+export function decodeEvents(
+  response: SorobanRpc.Api.GetSuccessfulTransactionResponse,
+  options: DecodeEventsOptions = {},
+): CoralSwapEvent[] {
+  const contractIds = options.contractId ? [options.contractId] : [];
+  const parser = new EventParser(contractIds);
+
+  const meta = response.resultMetaXdr;
+  const v3 = meta.v3();
+  const diagnosticEvents = v3.sorobanMeta()?.diagnosticEvents() ?? [];
+  const tx = response as TxWithOptionalHash;
+  const txHash = tx.hash ?? tx.id ?? "";
+  const ledger = response.ledger ?? 0;
+
+  if (options.strict) {
+    return parser.parseStrict(diagnosticEvents, txHash, ledger);
+  }
+  return parser.parse(diagnosticEvents, txHash, ledger);
+}
+
+/**
+ * Decode Pair contract events from raw XDR diagnostic events.
+ *
+ * Use this when you have direct access to the DiagnosticEvent array from
+ * transaction simulation or result meta, rather than the full transaction
+ * response.
+ *
+ * @param events - Array of xdr.DiagnosticEvent from transaction result meta.
+ * @param options - Optional configuration for filtering and parsing behavior.
+ * @param options.contractId - If provided, only events from this contract are decoded.
+ * @param options.strict - If true, throws on malformed event data. Defaults to false.
+ * @param txHash - Transaction hash to attach to parsed events.
+ * @param ledger - Ledger sequence number.
+ * @returns Array of typed CoralSwapEvent objects.
+ *
+ * @example
+ * ```ts
+ * import { decodeEventsFromXdr } from '@coralswap/sdk';
+ *
+ * const meta = txResponse.resultMetaXdr.v3();
+ * const diagnosticEvents = meta.sorobanMeta()?.diagnosticEvents() ?? [];
+ * const events = decodeEventsFromXdr(diagnosticEvents);
+ * ```
+ */
+export function decodeEventsFromXdr(
+  events: xdr.DiagnosticEvent[],
+  options: DecodeEventsOptions = {},
+  txHash = "",
+  ledger = 0,
+): CoralSwapEvent[] {
+  const contractIds = options.contractId ? [options.contractId] : [];
+  const parser = new EventParser(contractIds);
+
+  if (options.strict) {
+    return parser.parseStrict(events, txHash, ledger);
+  }
+  return parser.parse(events, txHash, ledger);
+}

--- a/Downloads/coralswap-sdk-main/src/utils/index.ts
+++ b/Downloads/coralswap-sdk-main/src/utils/index.ts
@@ -1,0 +1,73 @@
+export {
+  toSorobanAmount,
+  parseTokenAmount,
+  fromSorobanAmount,
+  formatAmount,
+  formatLargeNumber,
+  toBps,
+  applyBps,
+  percentDiff,
+  safeMul,
+  safeDiv,
+  minBigInt,
+  maxBigInt,
+} from "./amounts";
+
+export {
+  isValidPublicKey,
+  isValidContractId,
+  isValidAddress,
+  isNativeToken,
+  getNativeAssetContractAddress,
+  resolveTokenIdentifier,
+  sortTokens,
+  truncateAddress,
+  toScAddress,
+  getPairAddress,
+} from './addresses';
+
+export {
+  isSimulationSuccess,
+  getSimulationReturnValue,
+  getResourceEstimate,
+  exceedsBudget,
+  decodeDiagnosticEvents,
+  buildSimulationResult,
+} from "./simulation";
+
+export type { SimulationResult, SimulationResourceEstimate } from './simulation';
+
+export {
+  withRetry,
+  isRetryable,
+  sleep,
+  RetryConfig,
+  DEFAULT_RETRY_CONFIG,
+  CircuitBreaker,
+  CircuitOpenError,
+  getCircuitBreaker,
+  resetCircuitBreakers,
+} from "./retry";
+
+export { Fraction, Percent, Rounding } from './math';
+
+export {
+  validateAddress,
+  validatePositiveAmount,
+  validateNonNegativeAmount,
+  validateSlippage,
+  validateDistinctTokens,
+  isValidPath,
+} from './validation';
+
+export { waitNextLedger } from './ledger';
+export type { WaitNextLedgerOptions } from './ledger';
+
+export {
+  EventParser,
+  EVENT_TOPICS,
+  decodeEvents,
+  decodeEventsFromXdr,
+  filterEvents,
+} from './events';
+export type { DecodeEventsOptions, EventFilter } from './events';

--- a/Downloads/coralswap-sdk-main/tests/event-filtering.test.ts
+++ b/Downloads/coralswap-sdk-main/tests/event-filtering.test.ts
@@ -1,0 +1,113 @@
+import { filterEvents } from '../src/utils/events';
+import { ContractEvent } from '../src/types/events';
+
+const MOCK_EVENTS: ContractEvent[] = [
+    {
+        type: 'swap',
+        contractId: 'CA111111111111111111111111111111111111111111111111111111',
+        ledger: 100,
+        timestamp: 100,
+        txHash: 'hash1',
+    },
+    {
+        type: 'mint',
+        contractId: 'CA111111111111111111111111111111111111111111111111111111',
+        ledger: 110,
+        timestamp: 110,
+        txHash: 'hash2',
+    },
+    {
+        type: 'swap',
+        contractId: 'CA222222222222222222222222222222222222222222222222222222',
+        ledger: 120,
+        timestamp: 120,
+        txHash: 'hash3',
+    },
+    {
+        type: 'burn',
+        contractId: 'CA222222222222222222222222222222222222222222222222222222',
+        ledger: 130,
+        timestamp: 130,
+        txHash: 'hash4',
+    },
+];
+
+describe('filterEvents', () => {
+    it('returns all events unchanged when filter is empty', () => {
+        const result = filterEvents(MOCK_EVENTS, {});
+        expect(result).toHaveLength(4);
+        expect(result).toEqual(MOCK_EVENTS);
+    });
+
+    it('filters by type (single match)', () => {
+        const result = filterEvents(MOCK_EVENTS, { types: ['swap'] });
+        expect(result).toHaveLength(2);
+        expect(result.every((e) => e.type === 'swap')).toBe(true);
+        expect(result[0].txHash).toBe('hash1');
+        expect(result[1].txHash).toBe('hash3');
+    });
+
+    it('filters by multiple types', () => {
+        const result = filterEvents(MOCK_EVENTS, { types: ['mint', 'burn'] });
+        expect(result).toHaveLength(2);
+        expect(result[0].type).toBe('mint');
+        expect(result[1].type).toBe('burn');
+    });
+
+    it('filters by contract address', () => {
+        const addr = 'CA111111111111111111111111111111111111111111111111111111';
+        const result = filterEvents(MOCK_EVENTS, { contractAddress: addr });
+        expect(result).toHaveLength(2);
+        expect(result.every((e) => e.contractId === addr)).toBe(true);
+    });
+
+    it('filters by fromLedger (inclusive)', () => {
+        const result = filterEvents(MOCK_EVENTS, { fromLedger: 120 });
+        expect(result).toHaveLength(2);
+        expect(result[0].ledger).toBe(120);
+        expect(result[1].ledger).toBe(130);
+    });
+
+    it('filters by toLedger (inclusive)', () => {
+        const result = filterEvents(MOCK_EVENTS, { toLedger: 110 });
+        expect(result).toHaveLength(2);
+        expect(result[0].ledger).toBe(100);
+        expect(result[1].ledger).toBe(110);
+    });
+
+    it('filters by ledger range (both from and to)', () => {
+        const result = filterEvents(MOCK_EVENTS, { fromLedger: 110, toLedger: 120 });
+        expect(result).toHaveLength(2);
+        expect(result[0].ledger).toBe(110);
+        expect(result[1].ledger).toBe(120);
+    });
+
+    it('combines multiple filters (type + address)', () => {
+        const addr = 'CA111111111111111111111111111111111111111111111111111111';
+        const result = filterEvents(MOCK_EVENTS, {
+            types: ['swap'],
+            contractAddress: addr,
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe('swap');
+        expect(result[0].contractId).toBe(addr);
+        expect(result[0].txHash).toBe('hash1');
+    });
+
+    it('returns empty array when no events match', () => {
+        const result = filterEvents(MOCK_EVENTS, { types: ['non_existent'] });
+        expect(result).toHaveLength(0);
+    });
+
+    it('works with open-ended range (from only)', () => {
+        const result = filterEvents(MOCK_EVENTS, { fromLedger: 125 });
+        expect(result).toHaveLength(1);
+        expect(result[0].ledger).toBe(130);
+    });
+
+    it('works with open-ended range (to only)', () => {
+        const result = filterEvents(MOCK_EVENTS, { toLedger: 105 });
+        expect(result).toHaveLength(1);
+        expect(result[0].ledger).toBe(100);
+    });
+});


### PR DESCRIPTION
CLose #156 

## Summary

Adds a structured [filterEvents](cci:1://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/events.ts:461:0-493:1) utility to [src/utils/events.ts](cci:7://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/events.ts:0:0-0:0) so clients can filter decoded `ContractEvent` objects by type, contract address, and ledger range — without writing ad-hoc logic.

## Related Issue

Closes #156

## Changes

- [x] Implemented `filterEvents<T extends ContractEvent>(events, options)` in [src/utils/events.ts](cci:7://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/events.ts:0:0-0:0)
- [x] Added [EventFilter](cci:2://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/events.ts:450:0-459:1) interface supporting `types`, `contractAddress`, `fromLedger`, `toLedger`
- [x] Exported [filterEvents](cci:1://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/events.ts:461:0-493:1) and [EventFilter](cci:2://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/events.ts:450:0-459:1) from [src/utils/index.ts](cci:7://file:///home/gamp/Downloads/coralswap-sdk-main/src/utils/index.ts:0:0-0:0) and [src/index.ts](cci:7://file:///home/gamp/Downloads/coralswap-sdk-main/src/index.ts:0:0-0:0)
- [x] Added 11 test cases in [tests/event-filtering.test.ts](cci:7://file:///home/gamp/Downloads/coralswap-sdk-main/tests/event-filtering.test.ts:0:0-0:0) covering all acceptance criteria

## Testing

- [x] All existing tests pass (`npm test`)
- [x] New tests added for new functionality
- [x] No `any` types introduced

## Checklist

- [x] Code follows project coding standards
- [x] Public functions have JSDoc comments
- [x] Commit messages follow conventional format
- [x] No unrelated changes included
- [x] Uses typed errors from `src/errors.ts` (no raw `Error` throws)