### PR TITLE
feat(tokens): add on-chain balance & allowance fetch utilities

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -173,6 +173,16 @@ export class CircuitBreakerError extends CoralSwapSDKError {
 }
 
 /**
+ * Failure while fetching on-chain token data (balance, allowance) via RPC.
+ */
+export class TokenFetchError extends CoralSwapSDKError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super("TOKEN_FETCH_ERROR", message, details);
+    this.name = "TokenFetchError";
+  }
+}
+
+/**
  * No signing key configured.
  */
 export class SignerError extends CoralSwapSDKError {

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,5 +143,6 @@ export {
   FlashLoanError,
   CircuitBreakerError,
   SignerError,
+  TokenFetchError,
   mapError,
 } from "@/errors";

--- a/src/modules/tokens.ts
+++ b/src/modules/tokens.ts
@@ -1,8 +1,25 @@
 import { z } from 'zod';
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Address,
+  nativeToScVal,
+  xdr,
+} from '@stellar/stellar-sdk';
 import { CoralSwapClient } from '@/client';
 import { Network } from '@/types/common';
 import { Token, TokenList } from '@/types/tokens';
-import { NetworkError, ValidationError } from '@/errors';
+import { DEFAULTS } from '@/config';
+import { withRetry, RetryOptions } from '@/utils/retry';
+import { NetworkError, ValidationError, TokenFetchError } from '@/errors';
+
+/**
+ * Well-known zero account used as the source for read-only simulations.
+ * Holds no funds, so no signer is required to read on-chain token state.
+ */
+const READ_ONLY_SOURCE_ACCOUNT =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
 // ---------------------------------------------------------------------------
 // Zod schemas — validates token list JSON against Stellar token list standard
@@ -167,8 +184,166 @@ export class TokenListModule {
   }
 
   // -------------------------------------------------------------------------
+  // On-chain reads (SEP-41 token contract)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetch the on-chain token balance for an account.
+   *
+   * Performs a read-only simulation of the SEP-41 `balance` function using the
+   * client's configured RPC endpoint. No signer or funded account is required.
+   *
+   * @param tokenAddress - Contract address of the token (SEP-41/SAC).
+   * @param accountAddress - Stellar address whose balance to query.
+   * @returns The balance in raw stroop units (i128) as a `bigint`.
+   * @throws {TokenFetchError} If the RPC call or simulation fails.
+   *
+   * @example
+   * ```ts
+   * const tokens = client.tokens();
+   * const balance = await tokens.getBalance('CDLZ...', 'GABC...');
+   * ```
+   */
+  async getBalance(
+    tokenAddress: string,
+    accountAddress: string,
+  ): Promise<bigint> {
+    const contract = new Contract(tokenAddress);
+    const op = contract.call(
+      'balance',
+      nativeToScVal(Address.fromString(accountAddress), { type: 'address' }),
+    );
+    const result = await this.simulateRead(op, 'getBalance', {
+      tokenAddress,
+      accountAddress,
+    });
+    return result ? this.scValToBigInt(result) : 0n;
+  }
+
+  /**
+   * Fetch the on-chain allowance a spender has over an owner's tokens.
+   *
+   * Performs a read-only simulation of the SEP-41 `allowance` function using
+   * the client's configured RPC endpoint. No signer is required.
+   *
+   * @param tokenAddress - Contract address of the token (SEP-41/SAC).
+   * @param owner - Address that owns the tokens.
+   * @param spender - Address approved to spend on behalf of `owner`.
+   * @returns The approved allowance in raw stroop units (i128) as a `bigint`.
+   * @throws {TokenFetchError} If the RPC call or simulation fails.
+   *
+   * @example
+   * ```ts
+   * const tokens = client.tokens();
+   * const allowance = await tokens.getAllowance('CDLZ...', 'GOWN...', 'GSPN...');
+   * ```
+   */
+  async getAllowance(
+    tokenAddress: string,
+    owner: string,
+    spender: string,
+  ): Promise<bigint> {
+    const contract = new Contract(tokenAddress);
+    const op = contract.call(
+      'allowance',
+      nativeToScVal(Address.fromString(owner), { type: 'address' }),
+      nativeToScVal(Address.fromString(spender), { type: 'address' }),
+    );
+    const result = await this.simulateRead(op, 'getAllowance', {
+      tokenAddress,
+      owner,
+      spender,
+    });
+    return result ? this.scValToBigInt(result) : 0n;
+  }
+
+  // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /**
+   * Simulate a read-only contract call and return its `ScVal` result.
+   *
+   * Uses a well-known zero-balance account as the source so no funds or signer
+   * are required, and reuses the client's RPC server, network passphrase and
+   * retry configuration. Any failure is wrapped in a {@link TokenFetchError}.
+   *
+   * @param op - The contract operation to simulate.
+   * @param label - A label used for retry/logging context.
+   * @param context - Additional context attached to a thrown error.
+   * @returns The `ScVal` return value, or `null` if the simulation had none.
+   */
+  private async simulateRead(
+    op: xdr.Operation,
+    label: string,
+    context: Record<string, unknown>,
+  ): Promise<xdr.ScVal | null> {
+    const retryOptions = this.getRetryOptions();
+    try {
+      const account = await withRetry(
+        () => this.client.server.getAccount(READ_ONLY_SOURCE_ACCOUNT),
+        retryOptions,
+        undefined,
+        `tokens.${label}_getAccount`,
+      );
+
+      const tx = new TransactionBuilder(account, {
+        fee: '100',
+        networkPassphrase: this.client.networkConfig.networkPassphrase,
+      })
+        .addOperation(op)
+        .setTimeout(30)
+        .build();
+
+      const sim = await withRetry(
+        () => this.client.server.simulateTransaction(tx),
+        retryOptions,
+        undefined,
+        `tokens.${label}_simulate`,
+      );
+
+      if (!SorobanRpc.Api.isSimulationSuccess(sim)) {
+        const errorMessage =
+          (sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error ??
+          'simulation did not succeed';
+        throw new TokenFetchError(
+          `Failed to fetch token data (${label}): ${errorMessage}`,
+          { ...context, simulation: sim },
+        );
+      }
+
+      return sim.result ? sim.result.retval : null;
+    } catch (err) {
+      if (err instanceof TokenFetchError) throw err;
+      throw new TokenFetchError(
+        `Failed to fetch token data (${label}): ${err instanceof Error ? err.message : String(err)}`,
+        { ...context, cause: err },
+      );
+    }
+  }
+
+  /**
+   * Decode an i128 `ScVal` into a `bigint`.
+   */
+  private scValToBigInt(val: xdr.ScVal): bigint {
+    const parts = val.i128();
+    return (
+      BigInt(parts.lo().toString()) + (BigInt(parts.hi().toString()) << 64n)
+    );
+  }
+
+  /**
+   * Build retry options from the client's configuration, falling back to
+   * SDK defaults for any unset values.
+   */
+  private getRetryOptions(): RetryOptions {
+    const config = this.client.config;
+    return {
+      maxRetries: config?.maxRetries ?? DEFAULTS.maxRetries,
+      retryDelayMs: config?.retryDelayMs ?? DEFAULTS.retryDelayMs,
+      maxRetryDelayMs: config?.maxRetryDelayMs ?? DEFAULTS.maxRetryDelayMs,
+    };
+  }
 
   /**
    * Perform a GET request and parse the response as JSON.

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -1,6 +1,7 @@
+import { Account, nativeToScVal, xdr } from '@stellar/stellar-sdk';
 import { TokenListModule } from '../src/modules/tokens';
 import { Network } from '../src/types/common';
-import { ValidationError, NetworkError } from '../src/errors';
+import { ValidationError, NetworkError, TokenFetchError } from '../src/errors';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -288,6 +289,112 @@ describe('TokenListModule', () => {
 
       const list = await mod.fetchAll('https://example.com/tokens.json');
       expect(list.tokens).toHaveLength(3);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getBalance() / getAllowance() — mocked Soroban RPC
+  // -------------------------------------------------------------------------
+
+  describe('on-chain reads', () => {
+    const TOKEN = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+    const OWNER = 'GCZ3MMWYSKUXJL7BG4TLZBRPKJKUAVUH6GMJFSIKHLHAZ4F72ZBLO3DQ';
+    const SPENDER = 'GC3LNOLW6C4LMFW57RADS3JLF44LRIUQ2VOHC5JZYS2YH2RVRYPAJUHF';
+
+    const i128Val = (n: bigint): xdr.ScVal => nativeToScVal(n, { type: 'i128' });
+
+    function makeClient(server: Record<string, jest.Mock>) {
+      return {
+        network: Network.TESTNET,
+        networkConfig: {
+          networkPassphrase: 'Test SDF Network ; September 2015',
+        },
+        // Disable retries so failure-path tests run fast.
+        config: { maxRetries: 0, retryDelayMs: 0 },
+        server: {
+          getAccount: jest
+            .fn()
+            .mockResolvedValue(new Account(SPENDER, '0')),
+          simulateTransaction: jest.fn(),
+          ...server,
+        },
+      } as any;
+    }
+
+    describe('getBalance', () => {
+      it('returns the decoded i128 balance', async () => {
+        const client = makeClient({
+          simulateTransaction: jest.fn().mockResolvedValue({
+            transactionData: {}, result: { retval: i128Val(1_500_000n) },
+          }),
+        });
+        const tokens = new TokenListModule(client);
+
+        const balance = await tokens.getBalance(TOKEN, OWNER);
+        expect(balance).toBe(1_500_000n);
+        expect(client.server.getAccount).toHaveBeenCalled();
+        expect(client.server.simulateTransaction).toHaveBeenCalled();
+      });
+
+      it('returns 0n when the simulation has no return value', async () => {
+        const client = makeClient({
+          simulateTransaction: jest.fn().mockResolvedValue({ transactionData: {}, result: null }),
+        });
+        const tokens = new TokenListModule(client);
+
+        expect(await tokens.getBalance(TOKEN, OWNER)).toBe(0n);
+      });
+
+      it('wraps simulation failures in TokenFetchError', async () => {
+        const client = makeClient({
+          simulateTransaction: jest.fn().mockResolvedValue({
+            error: 'contract trapped',
+          }),
+        });
+        const tokens = new TokenListModule(client);
+
+        await expect(tokens.getBalance(TOKEN, OWNER)).rejects.toThrow(
+          TokenFetchError,
+        );
+      });
+
+      it('wraps RPC errors in TokenFetchError', async () => {
+        const client = makeClient({
+          getAccount: jest.fn().mockRejectedValue(new Error('RPC down')),
+        });
+        const tokens = new TokenListModule(client);
+
+        await expect(tokens.getBalance(TOKEN, OWNER)).rejects.toThrow(
+          TokenFetchError,
+        );
+      });
+    });
+
+    describe('getAllowance', () => {
+      it('returns the decoded i128 allowance', async () => {
+        const client = makeClient({
+          simulateTransaction: jest.fn().mockResolvedValue({
+            transactionData: {}, result: { retval: i128Val(42n) },
+          }),
+        });
+        const tokens = new TokenListModule(client);
+
+        const allowance = await tokens.getAllowance(TOKEN, OWNER, SPENDER);
+        expect(allowance).toBe(42n);
+      });
+
+      it('wraps simulation failures in TokenFetchError', async () => {
+        const client = makeClient({
+          simulateTransaction: jest
+            .fn()
+            .mockResolvedValue({ error: 'no such function' }),
+        });
+        const tokens = new TokenListModule(client);
+
+        await expect(
+          tokens.getAllowance(TOKEN, OWNER, SPENDER),
+        ).rejects.toThrow(TokenFetchError);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds on-chain token read utilities to the tokens module (#172):

- `getBalance(tokenAddress, accountAddress): Promise<bigint>`
- `getAllowance(tokenAddress, owner, spender): Promise<bigint>`

Both perform read-only simulations of the SEP-41 token contract using the existing `CoralSwapClient` RPC configuration (server, network passphrase, retry options) with a zero-balance source account, so no signer or funds are required. Return values are raw stroop units (i128) decoded to `bigint`. RPC/simulation failures are wrapped in a new typed `TokenFetchError`, exported from the package root.

## Changes
- `src/modules/tokens.ts` — `getBalance`, `getAllowance`, private `simulateRead` helper
- `src/errors.ts` — new `TokenFetchError`
- `src/index.ts` — export `TokenFetchError`
- `tests/tokens.test.ts` — unit tests (decoded values, empty-result → `0n`, error wrapping); 28/28 pass

## Issues closed
- Closes #172 — implemented in this PR ✅
- Closes #173, #174, #175 — closed administratively at maintainer request; **not implemented in this PR** (tracked/descoped separately)

> Note: only #172 is implemented here. #173–#175 are referenced for bookkeeping per the maintainer's request and are not delivered by this changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)