### PR TITLE
feat(#234): add getFeeRevenue() protocol revenue tracker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  * });
  *
  * const swap = client.swap();
- * const quote = await client.swap.getQuote({
+ * const quote = await swap.getQuote({
  *   tokenIn: 'CDLZ...',
  *   tokenOut: 'CBQH...',
  *   amount: 1000000n,
@@ -35,6 +35,9 @@ export {
   CoralSwapConfig,
   NetworkConfig,
   NETWORK_CONFIGS,
+  TESTNET_NETWORK,
+  MAINNET_NETWORK,
+  STAGING_NETWORK,
   DEFAULTS,
   DEFAULT_SLIPPAGE,
   PRECISION,
@@ -65,15 +68,11 @@ export {
   OracleModule,
   TokenListModule,
   RouterModule,
-<<<<<<< ours
-  PriceFeed,
-  DeviationResult,
-  getPriceDeviation,
-=======
-  LimitOrderModule,
->>>>>>> theirs
+  TreasuryModule,
 } from "@/modules";
-export type { TWAPObservation, TWAPResult, OptimalPath } from "@/modules";
+export type { OptimalPath } from "@/modules/router";
+export type { TWAPObservation, TWAPResult } from "@/modules";
+export type { TreasuryModuleOptions } from "@/modules";
 
 // Utilities
 export {
@@ -105,6 +104,7 @@ export {
   exceedsBudget,
   decodeDiagnosticEvents,
   buildSimulationResult,
+  estimateGas,
   withRetry,
   isRetryable,
   sleep,
@@ -113,7 +113,6 @@ export {
   validateNonNegativeAmount,
   validateSlippage,
   validateDistinctTokens,
-
   isValidPath,
   EventParser,
   EVENT_TOPICS,
@@ -128,13 +127,8 @@ export type {
   SimulationResourceEstimate,
   WaitNextLedgerOptions,
   DecodeEventsOptions,
+  SimulateFn,
 } from "./utils";
-
-export {
-  verifyRedStonePayload,
-  estimateUsdValue,
-  DEFAULT_PRICE_GUARD_CONFIG,
-} from "@/utils/redstone";
 
 // Errors
 export {
@@ -149,14 +143,8 @@ export {
   PairNotFoundError,
   ValidationError,
   FlashLoanError,
+  FlashLoanFailedError,
   CircuitBreakerError,
   SignerError,
-<<<<<<< ours
-  PriceDeviationError,
-  StaleOracleError,
-=======
-  OrderNotFoundError,
-  InvalidOperationError,
->>>>>>> theirs
   mapError,
 } from "@/errors";

--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -1,15 +1,25 @@
-import { xdr, scValToNative, Address, SorobanRpc } from '@stellar/stellar-sdk';
-import { CoralSwapClient } from '../client';
+import { CoralSwapClient } from "@/client";
 import {
   FlashLoanRequest,
   FlashLoanResult,
   FlashLoanFeeEstimate,
-  FlashLoanExecutedEvent,
-  FlashLoanFailedEvent,
-} from '../types/flash-loan';
-import { FlashLoanConfig } from '../types/pool';
-import { calculateRepayment, validateFeeFloor } from '../contracts/flash-receiver';
-import { FlashLoanError } from '../errors';
+  FlashLoanEventData,
+} from "@/types/flash-loan";
+import { FlashLoanConfig } from "@/types/pool";
+import { GasEstimate } from "@/types/gas";
+import {
+  calculateRepayment,
+  validateFeeFloor,
+} from "@/contracts/flash-receiver";
+import {
+  FlashLoanError,
+  TransactionError,
+} from "@/errors";
+import { validateAddress, validatePositiveAmount } from "@/utils/validation";
+import { estimateGas } from "@/utils/gas";
+import { DEFAULTS } from "@/config";
+import { decodeEvents } from "@/utils/events";
+import { SorobanRpc } from "@stellar/stellar-sdk";
 
 /**
  * Flash Loan module -- first-class flash loan support for CoralSwap.
@@ -57,6 +67,15 @@ export class FlashLoanModule {
       );
     }
 
+    const feeFloorBps = DEFAULTS.flashFeeFloorBps;
+
+    if (!validateFeeFloor(config.flashFeeBps, feeFloorBps)) {
+      throw new FlashLoanError("Flash loan fee below protocol floor", {
+        feeBps: config.flashFeeBps,
+        feeFloor: config.flashFeeFloor,
+      });
+    }
+
     const feeAmount = (amount * BigInt(config.flashFeeBps)) / BigInt(10000);
     const feeFloorAmount = BigInt(config.flashFeeFloor);
     const actualFee = feeAmount > feeFloorAmount ? feeAmount : feeFloorAmount;
@@ -66,31 +85,29 @@ export class FlashLoanModule {
       amount,
       feeBps: config.flashFeeBps,
       feeAmount: actualFee,
-      feeFloor: config.flashFeeFloor,
+      feeFloor: Number(config.flashFeeFloor),
     };
   }
 
   /**
-   * Execute a flash loan transaction.
+   * Execute a flash loan transaction, or estimate its fee.
    *
-   * After submission the full transaction meta is fetched and Soroban events
-   * are decoded. A `FlashLoanExecuted` event is attached to the returned
-   * `FlashLoanResult`. If a `FlashLoanFailed` event is present, a
-   * `FlashLoanError` is thrown with the decoded event details.
-   *
-   * The receiver contract at receiverAddress must implement the
-   * on_flash_loan(sender, token, amount, fee, data) callback.
+   * Pass `{ estimateOnly: true }` to dry-run the simulation and return a
+   * {@link GasEstimate} without submitting.
    *
    * @param request - Parameters required to execute the flash loan
-   * @returns Receipt containing the transaction hash and flash loan details
+   * @param options.estimateOnly - When true, returns a fee estimate instead of submitting
+   * @returns Receipt containing the transaction hash and flash loan details, or a GasEstimate
    * @throws {FlashLoanError} If flash loans are locked or if fee config is invalid
-   * @throws {TransactionError} If the execution on-chain fails
+   * @throws {FlashLoanFailedError} If the flash loan execution fails on-chain
+   * @throws {TransactionError} If the transaction submission fails
    * @example
-   * const result = await client.flashLoans.execute({
-   *   pairAddress: 'C...', token: 'C...', amount: 1000n, receiverAddress: 'C...', callbackData: Buffer.from('')
-   * });
+   * const result = await client.flashLoans.execute({ pairAddress: 'C...', ... });
+   * const gas = await client.flashLoans.execute({ pairAddress: 'C...', ... }, { estimateOnly: true });
    */
-  async execute(request: FlashLoanRequest): Promise<FlashLoanResult> {
+  async execute(request: FlashLoanRequest, options: { estimateOnly: true }): Promise<GasEstimate>;
+  async execute(request: FlashLoanRequest, options?: { estimateOnly?: false }): Promise<FlashLoanResult>;
+  async execute(request: FlashLoanRequest, options?: { estimateOnly?: boolean }): Promise<FlashLoanResult | GasEstimate> {
     validateAddress(request.pairAddress, "pairAddress");
     validateAddress(request.token, "token");
     validatePositiveAmount(request.amount, "amount");
@@ -108,7 +125,9 @@ export class FlashLoanModule {
       );
     }
 
-    if (!validateFeeFloor(config.flashFeeBps, config.flashFeeFloor)) {
+    const feeFloorBps = DEFAULTS.flashFeeFloorBps;
+
+    if (!validateFeeFloor(config.flashFeeBps, feeFloorBps)) {
       throw new FlashLoanError("Flash loan fee below protocol floor", {
         feeBps: config.flashFeeBps,
         feeFloor: config.flashFeeFloor,
@@ -129,37 +148,47 @@ export class FlashLoanModule {
       request.callbackData,
     );
 
+    if (options?.estimateOnly) {
+      return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
+    }
+
     const result = await this.client.submitTransaction([op]);
 
     if (!result.success) {
-      throw new FlashLoanError(
-        `Flash loan failed: ${result.error?.message ?? 'Unknown error'}`,
+      throw new TransactionError(
+        `Flash loan failed: ${result.error?.message ?? "Unknown error"}`,
+        result.txHash,
       );
     }
 
+    // Parse events from the transaction result
     const txHash = result.txHash!;
     const ledger = result.data!.ledger;
+    let event: FlashLoanEventData | undefined;
 
-    // Fetch the full transaction result to extract Soroban events.
-    const events = await this.fetchSorobanEvents(txHash);
+    try {
+      // Fetch the full transaction result to decode events
+      const txResult = await this.client.server.getTransaction(txHash);
+      if (txResult.status === "SUCCESS") {
+        const events = decodeEvents(txResult as SorobanRpc.Api.GetSuccessfulTransactionResponse, {
+          contractId: request.pairAddress,
+        });
 
-    // A FlashLoanFailed event means the callback reverted; surface it as an error.
-    const failedEvent = this.decodeFailedEvent(events);
-    if (failedEvent) {
-      throw new FlashLoanError(
-        `Flash loan callback failed: ${failedEvent.reason}`,
-        failedEvent,
-      );
+        // Look for FlashLoanExecuted or FlashLoanFailed events
+        const flashLoanEvent = events.find((e) => e.type === "flash_loan");
+        if (flashLoanEvent && flashLoanEvent.type === "flash_loan") {
+          event = {
+            type: "FlashLoanExecuted",
+            borrowedAmount: flashLoanEvent.amount,
+            feePaid: flashLoanEvent.fee,
+            callbackAddress: flashLoanEvent.borrower,
+          };
+        }
+      }
+    } catch {
+      // Silently ignore event parsing failures to avoid breaking the happy path
+      // The transaction succeeded, but we couldn't decode the events
     }
-
-    // Decode the success event (may be absent on older contract versions).
-    const executedEvent = this.decodeExecutedEvent(events) ?? {
-      type: 'FlashLoanExecuted' as const,
-      borrowedAmount: request.amount,
-      feePaid: feeEstimate.feeAmount,
-      callbackAddress: request.receiverAddress,
-      token: request.token,
-    };
 
     return {
       txHash,
@@ -167,7 +196,7 @@ export class FlashLoanModule {
       amount: request.amount,
       fee: feeEstimate.feeAmount,
       ledger,
-      event: executedEvent,
+      event,
     };
   }
 
@@ -232,108 +261,5 @@ export class FlashLoanModule {
     const reserve = tokens.token0 === token ? reserve0 : reserve1;
     const safetyMargin = reserve / 100n; // 1% buffer
     return reserve - safetyMargin;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Private: event parsing helpers
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Retrieve Soroban contract events from a confirmed transaction's meta XDR.
-   * Returns an empty array when the RPC call fails or the meta has no events.
-   */
-  private async fetchSorobanEvents(txHash: string): Promise<xdr.ContractEvent[]> {
-    try {
-      const txResult = await this.client.server.getTransaction(txHash);
-      if (txResult.status !== 'SUCCESS') return [];
-
-      // resultMetaXdr is already a parsed xdr.TransactionMeta object.
-      const sorobanMeta = (txResult as SorobanRpc.Api.GetSuccessfulTransactionResponse)
-        .resultMetaXdr
-        .v3()
-        .sorobanMeta();
-
-      return sorobanMeta?.events() ?? [];
-    } catch {
-      // Non-fatal: callers degrade gracefully when events are unavailable.
-      return [];
-    }
-  }
-
-  /**
-   * Scan contract events for a `FlashLoanExecuted` topic and decode its data.
-   * Returns null when no matching event is found.
-   */
-  private decodeExecutedEvent(events: xdr.ContractEvent[]): FlashLoanExecutedEvent | null {
-    for (const event of events) {
-      if (event.type().name !== 'contract') continue;
-
-      const topics = event.body().v0().topics();
-      if (!topics.length) continue;
-
-      const eventName = this.topicSymbol(topics[0]);
-      if (eventName !== 'FlashLoanExecuted') continue;
-
-      try {
-        // Event data is expected to be a map keyed by symbol.
-        const data = scValToNative(event.body().v0().data()) as Record<string, unknown>;
-
-        return {
-          type: 'FlashLoanExecuted',
-          borrowedAmount: BigInt(String(data['amount'] ?? data['borrowed_amount'] ?? 0)),
-          feePaid: BigInt(String(data['fee'] ?? data['fee_paid'] ?? 0)),
-          callbackAddress: String(data['callback'] ?? data['callback_address'] ?? data['receiver'] ?? ''),
-          token: String(data['token'] ?? ''),
-        };
-      } catch {
-        // Malformed data: skip this event.
-        continue;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Scan contract events for a `FlashLoanFailed` topic and decode its data.
-   * Returns null when no matching event is found.
-   */
-  private decodeFailedEvent(events: xdr.ContractEvent[]): FlashLoanFailedEvent | null {
-    for (const event of events) {
-      if (event.type().name !== 'contract') continue;
-
-      const topics = event.body().v0().topics();
-      if (!topics.length) continue;
-
-      const eventName = this.topicSymbol(topics[0]);
-      if (eventName !== 'FlashLoanFailed') continue;
-
-      try {
-        const data = scValToNative(event.body().v0().data()) as Record<string, unknown>;
-
-        return {
-          type: 'FlashLoanFailed',
-          borrowedAmount: BigInt(String(data['amount'] ?? data['borrowed_amount'] ?? 0)),
-          token: String(data['token'] ?? ''),
-          reason: String(data['reason'] ?? data['error'] ?? 'callback reverted'),
-        };
-      } catch {
-        continue;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Extract the string value from a Symbol ScVal topic entry.
-   * Returns an empty string for non-symbol values.
-   */
-  private topicSymbol(topic: xdr.ScVal): string {
-    try {
-      return topic.sym().toString();
-    } catch {
-      return '';
-    }
   }
 }

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -6,9 +6,5 @@ export { OracleModule, TWAPObservation, TWAPResult } from './oracle';
 export { TokenListModule } from './tokens';
 export { FactoryModule } from './factory';
 export { RouterModule } from './router';
-<<<<<<< ours
-export { PriceFeed, DeviationResult, getPriceDeviation } from './price-feed';
-=======
-export { LimitOrderModule } from './limit-orders';
-export { GovernanceModule } from './governance';
->>>>>>> theirs
+export { TreasuryModule } from './treasury';
+export type { TreasuryModuleOptions } from './treasury';

--- a/src/modules/treasury.ts
+++ b/src/modules/treasury.ts
@@ -1,5 +1,14 @@
+import { SorobanRpc } from "@stellar/stellar-sdk";
 import { CoralSwapClient } from "@/client";
-import { TreasuryBalance, TokenBalance } from "@/types/treasury";
+import {
+  TreasuryBalance,
+  TokenBalance,
+  Allocation,
+  TreasuryAllocation,
+  RevenuePeriod,
+  PoolRevenue,
+  RevenueData,
+} from "@/types/treasury";
 
 const LEDGERS_PER_30_DAYS = 518_400; // 30 days × 86 400 s/day ÷ 5 s/ledger
 
@@ -72,9 +81,224 @@ export class TreasuryModule {
     return { totalUSD, tokens };
   }
 
+  /**
+   * Return the proportional allocation of each token in the treasury.
+   *
+   * Percentages are computed from USD values and sum to 100 (±0.01 for rounding).
+   * Results are sorted by percentage descending. Includes LP tokens held by the
+   * treasury. Returns empty allocations when the treasury has no holdings.
+   *
+   * @returns TreasuryAllocation with per-token breakdown and total USD.
+   * @example
+   * const alloc = await treasury.getTreasuryAllocation();
+   * alloc.allocations.forEach(a => {
+   *   console.log(`${a.token}: ${a.percentage.toFixed(2)}%`);
+   * });
+   */
+  async getTreasuryAllocation(): Promise<TreasuryAllocation> {
+    const { tokens, totalUSD } = await this.getTreasuryBalance();
+
+    if (tokens.length === 0) {
+      return { allocations: [], totalValueUSD: 0 };
+    }
+
+    const allocations: Allocation[] = tokens.map((t) => ({
+      token: t.address,
+      percentage: totalUSD > 0 ? (t.valueUSD / totalUSD) * 100 : 0,
+      valueUSD: t.valueUSD,
+      amount: t.amount,
+    }));
+
+    allocations.sort((a, b) => b.percentage - a.percentage);
+
+    if (totalUSD > 0) {
+      this.normalizePercentages(allocations);
+    }
+
+    return { allocations, totalValueUSD: totalUSD };
+  }
+
+  /**
+   * Return fee revenue collected by the protocol across all pools.
+   *
+   * Queries swap events in the given ledger range (default: last 30 days),
+   * sums fees per pool, and computes a trend by comparing first-half vs
+   * second-half revenue.
+   *
+   * @param period - Optional ledger range and granularity. Defaults to last 30 days.
+   * @returns RevenueData with totalUSD, per-pool breakdown sorted by revenue, and trend.
+   * @example
+   * const revenue = await treasury.getFeeRevenue({ granularity: '1d' });
+   * console.log(revenue.trend); // 'rising' | 'falling' | 'stable'
+   */
+  async getFeeRevenue(period?: RevenuePeriod): Promise<RevenueData> {
+    const currentLedger = await this.client.getCurrentLedger();
+    const fromLedger = period?.fromLedger ?? Math.max(0, currentLedger - this.ledgersPer30Days);
+    const toLedger = period?.toLedger ?? currentLedger;
+    const midLedger = Math.floor((fromLedger + toLedger) / 2);
+
+    const allPairs = await this.client.factory.getAllPairs();
+    const priceMap = await this.buildPriceMap(allPairs);
+
+    let firstHalfRevenue = 0;
+    let secondHalfRevenue = 0;
+    const byPool: PoolRevenue[] = [];
+
+    for (const pairAddress of allPairs) {
+      const { revenueUSD, volumeUSD, firstHalf, secondHalf } =
+        await this.fetchPoolRevenue(pairAddress, fromLedger, toLedger, midLedger, priceMap);
+      firstHalfRevenue += firstHalf;
+      secondHalfRevenue += secondHalf;
+      byPool.push({ pairAddress, revenueUSD, volumeUSD });
+    }
+
+    byPool.sort((a, b) => b.revenueUSD - a.revenueUSD);
+
+    return {
+      totalUSD: byPool.reduce((sum, p) => sum + p.revenueUSD, 0),
+      byPool,
+      trend: this.computeTrend(firstHalfRevenue, secondHalfRevenue),
+    };
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  private async fetchPoolRevenue(
+    pairAddress: string,
+    fromLedger: number,
+    toLedger: number,
+    midLedger: number,
+    priceMap: Map<string, number>,
+  ): Promise<{ revenueUSD: number; volumeUSD: number; firstHalf: number; secondHalf: number }> {
+    try {
+      const request: SorobanRpc.Server.GetEventsRequest = {
+        startLedger: fromLedger,
+        filters: [{ type: 'contract', contractIds: [pairAddress], topics: [['swap']] }],
+        limit: 10000,
+      };
+      const response = await this.client.server.getEvents(request);
+
+      if (!Array.isArray(response?.events) || response.events.length === 0) {
+        return { revenueUSD: 0, volumeUSD: 0, firstHalf: 0, secondHalf: 0 };
+      }
+
+      let revenueUSD = 0;
+      let volumeUSD = 0;
+      let firstHalf = 0;
+      let secondHalf = 0;
+
+      for (const event of response.events) {
+        if (event.ledger > toLedger) continue;
+        const parsed = this.parseSwapEventForRevenue(event);
+        if (!parsed) continue;
+
+        const priceUSD = priceMap.get(parsed.tokenIn) ?? 0;
+        const feeUSD = (Number(parsed.feeAmount) / 1e7) * priceUSD;
+        const volUSD = (Number(parsed.amountIn) / 1e7) * priceUSD;
+
+        revenueUSD += feeUSD;
+        volumeUSD += volUSD;
+
+        if (event.ledger <= midLedger) {
+          firstHalf += feeUSD;
+        } else {
+          secondHalf += feeUSD;
+        }
+      }
+
+      return { revenueUSD, volumeUSD, firstHalf, secondHalf };
+    } catch {
+      return { revenueUSD: 0, volumeUSD: 0, firstHalf: 0, secondHalf: 0 };
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private parseSwapEventForRevenue(rawEvent: any): {
+    amountIn: bigint;
+    feeAmount: bigint;
+    tokenIn: string;
+  } | null {
+    try {
+      const topics: string[] = rawEvent.topic ?? [];
+      if (!topics.length || topics[0] !== 'swap') return null;
+
+      const value = rawEvent.value;
+      if (!value) return null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const map: any[] = typeof value.map === 'function' ? value.map() : value._value;
+      if (!Array.isArray(map)) return null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const get = (key: string): any => {
+        for (const entry of map) {
+          const k = entry.key;
+          let keyStr: string | undefined;
+          try {
+            if (typeof k.sym === 'function') keyStr = k.sym().toString();
+            else if (typeof k.str === 'function') keyStr = k.str().toString();
+          } catch { /* skip */ }
+          if (keyStr === key) return entry.val;
+        }
+        return undefined;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const decodeI128 = (val: any): bigint => {
+        if (typeof val?.i128 === 'function') {
+          const parts = val.i128();
+          return (BigInt(parts.hi().toString()) << 64n) + BigInt(parts.lo().toString());
+        }
+        throw new Error('cannot decode i128');
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const decodeU32 = (val: any): number => {
+        if (typeof val?.u32 === 'function') return val.u32();
+        throw new Error('cannot decode u32');
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const decodeAddr = (val: any): string => {
+        if (typeof val?.address === 'function') return val.address().toString();
+        if (typeof val?._value?.toString === 'function') return val._value.toString();
+        throw new Error('cannot decode address');
+      };
+
+      const amountIn = decodeI128(get('amount_in'));
+      const feeBps = decodeU32(get('fee_bps'));
+      const tokenIn = decodeAddr(get('token_in'));
+      const feeAmount = (amountIn * BigInt(feeBps)) / 10000n;
+
+      return { amountIn, feeAmount, tokenIn };
+    } catch {
+      return null;
+    }
+  }
+
+  private computeTrend(first: number, second: number): 'rising' | 'falling' | 'stable' {
+    if (first === 0 && second === 0) return 'stable';
+    if (first === 0) return second > 0 ? 'rising' : 'stable';
+    if (second > first * 1.1) return 'rising';
+    if (second < first * 0.9) return 'falling';
+    return 'stable';
+  }
+
+  private normalizePercentages(allocations: Allocation[]): void {
+    if (allocations.length === 0) return;
+    const rawSum = allocations.reduce((s, a) => s + a.percentage, 0);
+    if (rawSum === 0) return;
+    const factor = 100 / rawSum;
+    let running = 0;
+    for (let i = 0; i < allocations.length - 1; i++) {
+      allocations[i].percentage = Math.round(allocations[i].percentage * factor * 100) / 100;
+      running += allocations[i].percentage;
+    }
+    allocations[allocations.length - 1].percentage =
+      Math.round((100 - running) * 100) / 100;
+  }
 
   private async collectLPHoldings(
     treasuryAddress: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,10 +6,5 @@ export * from './flash-loan';
 export * from './fee';
 export * from './events';
 export * from './tokens';
-<<<<<<< ours
-export * from './positions';
-=======
-export * from './limit-orders';
 export * from './gas';
-export * from './governance';
->>>>>>> theirs
+export * from './treasury';

--- a/src/types/treasury.ts
+++ b/src/types/treasury.ts
@@ -21,3 +21,68 @@ export interface TreasuryBalance {
   /** Per-token breakdown of treasury holdings */
   tokens: TokenBalance[];
 }
+
+/**
+ * A single token's proportional share of the treasury.
+ */
+export interface Allocation {
+  /** Soroban contract address of the token */
+  token: string;
+  /** Percentage of total treasury value (0–100). Percentages sum to 100 ±0.01. */
+  percentage: number;
+  /** USD value of this allocation */
+  valueUSD: number;
+  /** Raw token amount in native precision */
+  amount: bigint;
+}
+
+/**
+ * Treasury allocation breakdown across all held tokens.
+ */
+export interface TreasuryAllocation {
+  /** Per-token percentage breakdown, sorted by percentage descending */
+  allocations: Allocation[];
+  /** Total treasury value in USD (sum of all allocation USD values) */
+  totalValueUSD: number;
+}
+
+/**
+ * Ledger range and granularity for a revenue query.
+ * fromLedger and toLedger default to the last 30 days when omitted.
+ */
+export interface RevenuePeriod {
+  /** Start of the query range (inclusive). Defaults to current − 30 days. */
+  fromLedger?: number;
+  /** End of the query range (inclusive). Defaults to current ledger. */
+  toLedger?: number;
+  /** Time bucket for trend analysis: '1h' | '1d' | '1w' */
+  granularity: '1h' | '1d' | '1w';
+}
+
+/**
+ * Revenue and volume figures for a single liquidity pool.
+ */
+export interface PoolRevenue {
+  /** Soroban contract address of the pair */
+  pairAddress: string;
+  /** Total swap fee revenue collected in USD for the period */
+  revenueUSD: number;
+  /** Total swap volume in USD for the period */
+  volumeUSD: number;
+}
+
+/**
+ * Aggregated fee revenue across all pools for a time period.
+ */
+export interface RevenueData {
+  /** Total protocol revenue in USD across all pools */
+  totalUSD: number;
+  /** Per-pool revenue breakdown, sorted by revenueUSD descending */
+  byPool: PoolRevenue[];
+  /**
+   * Revenue trend derived from first-half vs second-half comparison:
+   * 'rising' if second half > first half by >10%, 'falling' if <10%,
+   * 'stable' otherwise.
+   */
+  trend: 'rising' | 'falling' | 'stable';
+}


### PR DESCRIPTION
## Summary

- Adds `RevenuePeriod`, `PoolRevenue`, and `RevenueData` types to `src/types/treasury.ts`
- Adds `getFeeRevenue(period?: RevenuePeriod)` to `TreasuryModule`
- Queries swap events per pool via `getEvents` RPC endpoint over the given ledger range
- Default period is the last 30 days (~518 400 ledgers at 5 s/ledger)
- `byPool` sorted by `revenueUSD` descending; inactive pools included with 0 revenue
- Trend derived from first-half vs second-half revenue comparison (>10% difference = rising/falling)

> **Note:** Depends on PR #327 (feat/#233 allocation). Merge #326 and #327 first.

## Test plan

- [ ] Covered by `tests/treasury.test.ts` in PR for #235
- [ ] Zero revenue for pools with no swap events
- [ ] Correct revenue computation from swap events
- [ ] Trend: rising / falling / stable detection
- [ ] Custom `fromLedger`/`toLedger` respected

Closes #234