### PR TITLE
feat: add TaxReportingModule for CSV/JSON trade history export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,10 @@ export {
   OracleModule,
   TokenListModule,
   RouterModule,
+  TaxReportingModule,
 } from "@/modules";
 export type { OptimalPath } from "@/modules/router";
-export type { TWAPObservation, TWAPResult } from "@/modules";
+export type { TWAPObservation, TWAPResult, ExportOptions, TaxReportRow } from "@/modules";
 
 // Utilities
 export {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -7,3 +7,5 @@ export { TokenListModule } from './tokens';
 export { FactoryModule } from './factory';
 export { RouterModule } from './router';
 export { GovernanceModule } from './governance';
+export { TaxReportingModule } from './tax-reporting';
+export type { ExportOptions, TaxReportRow } from './tax-reporting';

--- a/src/modules/tax-reporting.ts
+++ b/src/modules/tax-reporting.ts
@@ -1,0 +1,323 @@
+import { CoralSwapClient } from "@/client";
+import { fromSorobanAmount } from "@/utils/amounts";
+import { validateAddress } from "@/utils/validation";
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+/**
+ * Options for exporting trade history.
+ */
+export interface ExportOptions {
+  /** Output format: 'csv' (default) or 'json' */
+  format?: "csv" | "json";
+  /** Filter events from this date (inclusive) */
+  fromDate?: Date;
+  /** Filter events up to this date (inclusive) */
+  toDate?: Date;
+  /** IANA timezone string for date formatting (e.g. 'America/New_York'). Defaults to UTC. */
+  timezone?: string;
+}
+
+/**
+ * A single row in the tax report.
+ */
+export interface TaxReportRow {
+  date: string;
+  type: "swap" | "add_liquidity" | "remove_liquidity";
+  tokenIn: string;
+  amountIn: string;
+  tokenOut: string;
+  amountOut: string;
+  fee: string;
+  usdValue: string;
+  txHash: string;
+}
+
+const CSV_HEADERS = [
+  "Date",
+  "Type",
+  "Token In",
+  "Amount In",
+  "Token Out",
+  "Amount Out",
+  "Fee",
+  "USD Value",
+  "Tx Hash",
+];
+
+const TOKEN_DECIMALS = 7;
+
+/** Default ledger history window when no date range is provided. */
+const DEFAULT_HISTORY_WINDOW = 17280; // ~1 day of ledgers
+
+/**
+ * Tax reporting module for CoralSwap.
+ *
+ * Exports swap and liquidity events as CSV or JSON for use with
+ * CoinTracker, Koinly, TokenTax and similar tax tools.
+ *
+ * All amounts are in human-readable format (not raw stroops).
+ * USD values are approximated at 0 when no price feed is available
+ * (on-chain USD prices are not natively available on Soroban).
+ *
+ * @example
+ * const tax = new TaxReportingModule(client);
+ * const csv = await tax.exportTradeHistory('G...', { format: 'csv', fromDate: new Date('2024-01-01') });
+ */
+export class TaxReportingModule {
+  private client: CoralSwapClient;
+
+  constructor(client: CoralSwapClient) {
+    this.client = client;
+  }
+
+  /**
+   * Export full trade history (swaps + liquidity events) for an address.
+   *
+   * @param address - Stellar account address (G...) or contract address (C...)
+   * @param options - Export format and date range options
+   * @returns CSV string or JSON string depending on `options.format`
+   */
+  async exportTradeHistory(
+    address: string,
+    options: ExportOptions = {},
+  ): Promise<string> {
+    validateAddress(address, "address");
+
+    const { format = "csv", fromDate, toDate, timezone = "UTC" } = options;
+
+    const currentLedger = await this.client.getCurrentLedger();
+    const startLedger = Math.max(0, currentLedger - DEFAULT_HISTORY_WINDOW);
+
+    const [swapEvents, liquidityEvents] = await Promise.all([
+      this.fetchSwapEvents(address, startLedger),
+      this.fetchLiquidityEvents(address, startLedger),
+    ]);
+
+    const rows: TaxReportRow[] = [
+      ...swapEvents,
+      ...liquidityEvents,
+    ].sort((a, b) => a.date.localeCompare(b.date));
+
+    const filtered = rows.filter((row) => {
+      const d = new Date(row.date);
+      if (fromDate && d < fromDate) return false;
+      if (toDate && d > toDate) return false;
+      return true;
+    });
+
+    // Re-format dates using requested timezone
+    const formatted = filtered.map((row) => ({
+      ...row,
+      date: formatDate(new Date(row.date), timezone),
+    }));
+
+    return format === "json"
+      ? JSON.stringify(formatted, null, 2)
+      : toCSV(formatted);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async fetchSwapEvents(
+    address: string,
+    startLedger: number,
+  ): Promise<TaxReportRow[]> {
+    const response = await this.fetchEvents(startLedger, ["swap"]);
+    const rows: TaxReportRow[] = [];
+
+    for (const ev of response) {
+      const data = decodeMapEvent(ev.value);
+      if (!data) continue;
+
+      const sender = readAddress(data, "sender");
+      if (sender && sender !== address) continue;
+
+      const amountIn = readI128(data, "amount_in") ?? 0n;
+      const amountOut = readI128(data, "amount_out") ?? 0n;
+      const feeBps = readU32(data, "fee_bps") ?? 0;
+      const feeAmount = (amountIn * BigInt(feeBps)) / 10000n;
+
+      rows.push({
+        date: new Date(ev.ledgerClosedAt ?? 0).toISOString(),
+        type: "swap",
+        tokenIn: readAddress(data, "token_in") ?? "",
+        amountIn: fromSorobanAmount(amountIn, TOKEN_DECIMALS),
+        tokenOut: readAddress(data, "token_out") ?? "",
+        amountOut: fromSorobanAmount(amountOut, TOKEN_DECIMALS),
+        fee: fromSorobanAmount(feeAmount, TOKEN_DECIMALS),
+        usdValue: "0.00",
+        txHash: ev.txHash ?? "",
+      });
+    }
+
+    return rows;
+  }
+
+  private async fetchLiquidityEvents(
+    address: string,
+    startLedger: number,
+  ): Promise<TaxReportRow[]> {
+    const [addEvents, removeEvents] = await Promise.all([
+      this.fetchEvents(startLedger, ["add_liquidity"]),
+      this.fetchEvents(startLedger, ["remove_liquidity"]),
+    ]);
+
+    const rows: TaxReportRow[] = [];
+
+    for (const ev of [...addEvents, ...removeEvents]) {
+      const isAdd = (ev.topic?.[0] ?? "") === "add_liquidity";
+      const data = decodeMapEvent(ev.value);
+      if (!data) continue;
+
+      const provider = readAddress(data, "provider");
+      if (provider && provider !== address) continue;
+
+      const amountA = readI128(data, "amount_a") ?? 0n;
+      const amountB = readI128(data, "amount_b") ?? 0n;
+      const tokenA = readAddress(data, "token_a") ?? "";
+      const tokenB = readAddress(data, "token_b") ?? "";
+
+      rows.push({
+        date: new Date(ev.ledgerClosedAt ?? 0).toISOString(),
+        type: isAdd ? "add_liquidity" : "remove_liquidity",
+        tokenIn: tokenA,
+        amountIn: fromSorobanAmount(amountA, TOKEN_DECIMALS),
+        tokenOut: tokenB,
+        amountOut: fromSorobanAmount(amountB, TOKEN_DECIMALS),
+        fee: "0.0000000",
+        usdValue: "0.00",
+        txHash: ev.txHash ?? "",
+      });
+    }
+
+    return rows;
+  }
+
+  private async fetchEvents(
+    startLedger: number,
+    topics: string[],
+  ): Promise<RawEvent[]> {
+    const request: SorobanRpc.Server.GetEventsRequest = {
+      startLedger,
+      filters: [{ type: "contract", contractIds: [], topics: [topics] }],
+      limit: 200,
+    };
+
+    const response = await this.client.server.getEvents(request);
+    if (!response || !Array.isArray(response.events)) return [];
+    return response.events as RawEvent[];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal types & helpers
+// ---------------------------------------------------------------------------
+
+interface RawEvent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any;
+  topic?: string[];
+  txHash?: string;
+  ledgerClosedAt?: string | number;
+  ledger?: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function decodeMapEvent(value: any): Map<string, any> | null {
+  const entries: unknown[] =
+    typeof value?.map === "function" ? value.map() : value?._value;
+  if (!Array.isArray(entries)) return null;
+
+  const map = new Map<string, unknown>();
+  for (const entry of entries as Array<{ key: unknown; val: unknown }>) {
+    const k = entry.key as Record<string, () => { toString(): string }>;
+    let key: string | undefined;
+    try {
+      key = k.sym?.().toString() ?? k.str?.().toString();
+    } catch { /* skip */ }
+    if (key) map.set(key, entry.val);
+  }
+  return map as Map<string, unknown>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readAddress(map: Map<string, any>, key: string): string | undefined {
+  const val = map.get(key);
+  if (!val) return undefined;
+  try {
+    if (typeof val.address === "function") return val.address().toString();
+    if (typeof val._value?.toString === "function") return val._value.toString();
+  } catch { /* skip */ }
+  return undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readI128(map: Map<string, any>, key: string): bigint | undefined {
+  const val = map.get(key);
+  if (!val) return undefined;
+  try {
+    if (typeof val.i128 === "function") {
+      const parts = val.i128();
+      return (BigInt(parts.hi().toString()) << 64n) + BigInt(parts.lo().toString());
+    }
+  } catch { /* skip */ }
+  return undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readU32(map: Map<string, any>, key: string): number | undefined {
+  const val = map.get(key);
+  if (!val) return undefined;
+  try {
+    if (typeof val.u32 === "function") return val.u32();
+  } catch { /* skip */ }
+  return undefined;
+}
+
+function formatDate(date: Date, timezone: string): string {
+  try {
+    return date.toLocaleString("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    return date.toISOString();
+  }
+}
+
+function escapeCSV(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCSV(rows: TaxReportRow[]): string {
+  const lines: string[] = [CSV_HEADERS.join(",")];
+  for (const row of rows) {
+    lines.push(
+      [
+        row.date,
+        row.type,
+        row.tokenIn,
+        row.amountIn,
+        row.tokenOut,
+        row.amountOut,
+        row.fee,
+        row.usdValue,
+        row.txHash,
+      ]
+        .map(escapeCSV)
+        .join(","),
+    );
+  }
+  return lines.join("\n");
+}

--- a/tests/tax-reporting.test.ts
+++ b/tests/tax-reporting.test.ts
@@ -1,0 +1,389 @@
+import { CoralSwapClient } from "../src/client";
+import { TaxReportingModule, TaxReportRow } from "../src/modules/tax-reporting";
+import { Network } from "../src/types/common";
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET =
+  "SB6K2AINTGNYBFX4M7TRPGSKQ5RKNOXXWB7UZUHRYOVTM7REDUGECKZU";
+
+const USER = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const TOKEN_A = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+const TOKEN_B = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4";
+const TX_HASH = "abc123txhash";
+
+// ---------------------------------------------------------------------------
+// ScVal-like builder helpers (mirrors swap-history.test.ts)
+// ---------------------------------------------------------------------------
+
+const makeAddr = (addr: string) => ({
+  address: () => ({ toString: () => addr }),
+});
+
+const makeI128 = (n: bigint) => ({
+  i128: () => ({
+    hi: () => ({ toString: () => String(n >> 64n) }),
+    lo: () => ({ toString: () => String(n & 0xffffffffffffffffn) }),
+  }),
+});
+
+const makeU32 = (n: number) => ({ u32: () => n });
+const makeSym = (s: string) => ({ sym: () => ({ toString: () => s }) });
+
+function makeSwapEvent(opts: {
+  sender: string;
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: bigint;
+  amountOut: bigint;
+  feeBps: number;
+  txHash?: string;
+  ledgerClosedAt?: string;
+}): Record<string, unknown> {
+  return {
+    topic: ["swap"],
+    value: {
+      map: () => [
+        { key: makeSym("sender"), val: makeAddr(opts.sender) },
+        { key: makeSym("token_in"), val: makeAddr(opts.tokenIn) },
+        { key: makeSym("token_out"), val: makeAddr(opts.tokenOut) },
+        { key: makeSym("amount_in"), val: makeI128(opts.amountIn) },
+        { key: makeSym("amount_out"), val: makeI128(opts.amountOut) },
+        { key: makeSym("fee_bps"), val: makeU32(opts.feeBps) },
+      ],
+    },
+    txHash: opts.txHash ?? TX_HASH,
+    ledgerClosedAt: opts.ledgerClosedAt ?? new Date(1_700_000_000_000).toISOString(),
+  };
+}
+
+function makeLiquidityEvent(opts: {
+  type: "add_liquidity" | "remove_liquidity";
+  provider: string;
+  tokenA: string;
+  tokenB: string;
+  amountA: bigint;
+  amountB: bigint;
+  txHash?: string;
+  ledgerClosedAt?: string;
+}): Record<string, unknown> {
+  return {
+    topic: [opts.type],
+    value: {
+      map: () => [
+        { key: makeSym("provider"), val: makeAddr(opts.provider) },
+        { key: makeSym("token_a"), val: makeAddr(opts.tokenA) },
+        { key: makeSym("token_b"), val: makeAddr(opts.tokenB) },
+        { key: makeSym("amount_a"), val: makeI128(opts.amountA) },
+        { key: makeSym("amount_b"), val: makeI128(opts.amountB) },
+      ],
+    },
+    txHash: opts.txHash ?? TX_HASH,
+    ledgerClosedAt: opts.ledgerClosedAt ?? new Date(1_700_000_000_000).toISOString(),
+  };
+}
+
+function mockEventsResponse(
+  events: Record<string, unknown>[],
+): SorobanRpc.Api.GetEventsResponse {
+  return {
+    events: events as unknown as SorobanRpc.Api.EventResponse[],
+    latestLedger: 5000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("TaxReportingModule.exportTradeHistory()", () => {
+  let client: CoralSwapClient;
+  let tax: TaxReportingModule;
+
+  beforeEach(() => {
+    client = new CoralSwapClient({
+      network: Network.TESTNET,
+      secretKey: TEST_SECRET,
+    });
+
+    // Stub getCurrentLedger
+    jest.spyOn(client, "getCurrentLedger").mockResolvedValue(5000);
+
+    tax = new TaxReportingModule(client);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // -------------------------------------------------------------------------
+  // CSV format tests
+  // -------------------------------------------------------------------------
+
+  it("returns CSV with correct headers", async () => {
+    jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(mockEventsResponse([]));
+
+    const csv = await tax.exportTradeHistory(USER);
+    const header = csv.split("\n")[0];
+    expect(header).toBe(
+      "Date,Type,Token In,Amount In,Token Out,Amount Out,Fee,USD Value,Tx Hash",
+    );
+  });
+
+  it("returns one CSV row per swap event", async () => {
+    const swapEv = makeSwapEvent({
+      sender: USER,
+      tokenIn: TOKEN_A,
+      tokenOut: TOKEN_B,
+      amountIn: 10_000_000n,
+      amountOut: 9_500_000n,
+      feeBps: 30,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [swapEv] : []);
+    });
+
+    const csv = await tax.exportTradeHistory(USER);
+    const rows = csv.split("\n");
+    expect(rows).toHaveLength(2); // header + 1 data row
+  });
+
+  it("formats amounts in human-readable form (7 decimals)", async () => {
+    const swapEv = makeSwapEvent({
+      sender: USER,
+      tokenIn: TOKEN_A,
+      tokenOut: TOKEN_B,
+      amountIn: 10_000_000n, // 1.0
+      amountOut: 9_500_000n, // 0.95
+      feeBps: 30,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [swapEv] : []);
+    });
+
+    const csv = await tax.exportTradeHistory(USER);
+    expect(csv).toContain("1.0000000"); // amountIn
+    expect(csv).toContain("0.9500000"); // amountOut
+  });
+
+  it("includes fee as human-readable amount", async () => {
+    // amountIn = 10_000_000 stroops, feeBps = 30 → fee = 30_000 / 10000 * 10_000_000 = 30000 stroops = 0.0030000
+    const swapEv = makeSwapEvent({
+      sender: USER,
+      tokenIn: TOKEN_A,
+      tokenOut: TOKEN_B,
+      amountIn: 10_000_000n,
+      amountOut: 9_970_000n,
+      feeBps: 30,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [swapEv] : []);
+    });
+
+    const csv = await tax.exportTradeHistory(USER);
+    expect(csv).toContain("0.0030000");
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON format test
+  // -------------------------------------------------------------------------
+
+  it("returns valid JSON array when format is json", async () => {
+    const swapEv = makeSwapEvent({
+      sender: USER,
+      tokenIn: TOKEN_A,
+      tokenOut: TOKEN_B,
+      amountIn: 10_000_000n,
+      amountOut: 9_000_000n,
+      feeBps: 30,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [swapEv] : []);
+    });
+
+    const json = await tax.exportTradeHistory(USER, { format: "json" });
+    const parsed = JSON.parse(json) as TaxReportRow[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].type).toBe("swap");
+    expect(parsed[0].txHash).toBe(TX_HASH);
+  });
+
+  // -------------------------------------------------------------------------
+  // Liquidity events
+  // -------------------------------------------------------------------------
+
+  it("includes add_liquidity events", async () => {
+    const addEv = makeLiquidityEvent({
+      type: "add_liquidity",
+      provider: USER,
+      tokenA: TOKEN_A,
+      tokenB: TOKEN_B,
+      amountA: 50_000_000n,
+      amountB: 100_000_000n,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      if (topic === "add_liquidity") return mockEventsResponse([addEv]);
+      return mockEventsResponse([]);
+    });
+
+    const json = await tax.exportTradeHistory(USER, { format: "json" });
+    const rows = JSON.parse(json) as TaxReportRow[];
+    const liq = rows.find((r) => r.type === "add_liquidity");
+    expect(liq).toBeDefined();
+    expect(liq!.amountIn).toBe("5.0000000");
+    expect(liq!.amountOut).toBe("10.0000000");
+  });
+
+  it("includes remove_liquidity events", async () => {
+    const removeEv = makeLiquidityEvent({
+      type: "remove_liquidity",
+      provider: USER,
+      tokenA: TOKEN_A,
+      tokenB: TOKEN_B,
+      amountA: 20_000_000n,
+      amountB: 40_000_000n,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      if (topic === "remove_liquidity") return mockEventsResponse([removeEv]);
+      return mockEventsResponse([]);
+    });
+
+    const json = await tax.exportTradeHistory(USER, { format: "json" });
+    const rows = JSON.parse(json) as TaxReportRow[];
+    const liq = rows.find((r) => r.type === "remove_liquidity");
+    expect(liq).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Date filtering
+  // -------------------------------------------------------------------------
+
+  it("filters events by fromDate", async () => {
+    const oldDate = new Date("2023-01-01T00:00:00Z").toISOString();
+    const newDate = new Date("2024-06-01T00:00:00Z").toISOString();
+
+    const oldEv = makeSwapEvent({
+      sender: USER, tokenIn: TOKEN_A, tokenOut: TOKEN_B,
+      amountIn: 1_000_000n, amountOut: 900_000n, feeBps: 30,
+      ledgerClosedAt: oldDate,
+    });
+    const newEv = makeSwapEvent({
+      sender: USER, tokenIn: TOKEN_A, tokenOut: TOKEN_B,
+      amountIn: 2_000_000n, amountOut: 1_800_000n, feeBps: 30,
+      txHash: "newtxhash",
+      ledgerClosedAt: newDate,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [oldEv, newEv] : []);
+    });
+
+    const json = await tax.exportTradeHistory(USER, {
+      format: "json",
+      fromDate: new Date("2024-01-01"),
+    });
+    const rows = JSON.parse(json) as TaxReportRow[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].txHash).toBe("newtxhash");
+  });
+
+  it("filters events by toDate", async () => {
+    const oldDate = new Date("2023-01-01T00:00:00Z").toISOString();
+    const newDate = new Date("2024-06-01T00:00:00Z").toISOString();
+
+    const oldEv = makeSwapEvent({
+      sender: USER, tokenIn: TOKEN_A, tokenOut: TOKEN_B,
+      amountIn: 1_000_000n, amountOut: 900_000n, feeBps: 30,
+      txHash: "oldtxhash",
+      ledgerClosedAt: oldDate,
+    });
+    const newEv = makeSwapEvent({
+      sender: USER, tokenIn: TOKEN_A, tokenOut: TOKEN_B,
+      amountIn: 2_000_000n, amountOut: 1_800_000n, feeBps: 30,
+      ledgerClosedAt: newDate,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [oldEv, newEv] : []);
+    });
+
+    const json = await tax.exportTradeHistory(USER, {
+      format: "json",
+      toDate: new Date("2023-12-31"),
+    });
+    const rows = JSON.parse(json) as TaxReportRow[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].txHash).toBe("oldtxhash");
+  });
+
+  // -------------------------------------------------------------------------
+  // Filters out events from other addresses
+  // -------------------------------------------------------------------------
+
+  it("excludes swap events from other senders", async () => {
+    const OTHER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+    const otherEv = makeSwapEvent({
+      sender: OTHER,
+      tokenIn: TOKEN_A,
+      tokenOut: TOKEN_B,
+      amountIn: 1_000_000n,
+      amountOut: 900_000n,
+      feeBps: 30,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      return mockEventsResponse(topic === "swap" ? [otherEv] : []);
+    });
+
+    const json = await tax.exportTradeHistory(USER, { format: "json" });
+    const rows = JSON.parse(json) as TaxReportRow[];
+    expect(rows).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty response
+  // -------------------------------------------------------------------------
+
+  it("returns only header row in CSV when there are no events", async () => {
+    jest.spyOn(client.server, "getEvents").mockResolvedValue(mockEventsResponse([]));
+
+    const csv = await tax.exportTradeHistory(USER);
+    expect(csv.split("\n")).toHaveLength(1);
+  });
+
+  it("returns empty JSON array when there are no events", async () => {
+    jest.spyOn(client.server, "getEvents").mockResolvedValue(mockEventsResponse([]));
+
+    const json = await tax.exportTradeHistory(USER, { format: "json" });
+    expect(JSON.parse(json)).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  it("throws ValidationError for invalid address", async () => {
+    await expect(
+      tax.exportTradeHistory("NOT_AN_ADDRESS"),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #264

- Add src/modules/tax-reporting.ts with TaxReportingModule
- exportTradeHistory(address, options?) returns CSV or JSON
- Handles swap events and add/remove liquidity events
- Amounts in human-readable format (7-decimal, not raw stroops)
- Date filtering via fromDate/toDate, timezone formatting
- ExportOptions: format, fromDate, toDate, timezone
- TaxReportRow: Date, Type, Token In, Amount In, Token Out, Amount Out, Fee, USD Value, Tx Hash
- Export format compatible with CoinTracker, Koinly, TokenTax
- 13 tests covering all acceptance criteria

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
