### PR TITLE
feat: Flash loan fee comparison, DCA tests & Stop-Loss module

### DIFF
--- a/src/modules/dca.ts
+++ b/src/modules/dca.ts
@@ -1,0 +1,321 @@
+import { CoralSwapClient } from '@/client';
+import {
+  DCAParams,
+  DCASchedule,
+  DCAPerformance,
+  DCACancellation,
+  DCAStatus,
+} from '@/types/dca';
+import { Signer } from '@/types/common';
+import { ValidationError, TransactionError } from '@/errors';
+import {
+  validateAddress,
+  validatePositiveAmount,
+  validateDistinctTokens,
+} from '@/utils/validation';
+import {
+  Contract,
+  nativeToScVal,
+  Address,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+/** Minimum allowed interval between DCA executions (1 hour, in seconds). */
+const MIN_INTERVAL_SECONDS = 3600;
+
+/** Minimum number of intervals for a schedule to qualify as DCA. */
+const MIN_TOTAL_INTERVALS = 2;
+
+/** Basis-points denominator used for savings calculations. */
+const BPS_DENOMINATOR = 10000n;
+
+/**
+ * DCA module — dollar-cost-averaging schedule creation and management.
+ *
+ * Wraps the on-chain DCA scheduler contract so dApp builders can create
+ * time-spaced swap schedules, inspect their progress, measure performance
+ * against a lump-sum baseline, and cancel with an automatic refund of the
+ * unspent escrow.
+ */
+export class DCAModule {
+  private readonly client: CoralSwapClient;
+  private readonly contractAddress: string;
+
+  constructor(client: CoralSwapClient, contractAddress: string) {
+    this.client = client;
+    this.contractAddress = contractAddress;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write operations (require signing)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a new DCA schedule, escrowing the full budget up front.
+   *
+   * @param params - Schedule parameters (tokens, amount, interval, count, pair)
+   * @param signer - Wallet signer that funds and authorises the schedule
+   * @returns The unique schedule ID assigned by the contract
+   * @throws {ValidationError} If addresses are invalid, tokens are identical,
+   *   the amount is non-positive, the interval is below one hour, or fewer
+   *   than two intervals are requested
+   * @throws {TransactionError} If the transaction is rejected on-chain
+   * @example
+   * const id = await client.dca.createDCA({
+   *   tokenIn: 'C...', tokenOut: 'C...', amountPerInterval: 100_0000000n,
+   *   intervalSeconds: 86400, totalIntervals: 7, pairAddress: 'C...',
+   * }, signer);
+   */
+  async createDCA(params: DCAParams, signer: Signer): Promise<string> {
+    validateAddress(params.tokenIn, 'tokenIn');
+    validateAddress(params.tokenOut, 'tokenOut');
+    validateAddress(params.pairAddress, 'pairAddress');
+    validateDistinctTokens(params.tokenIn, params.tokenOut);
+    validatePositiveAmount(params.amountPerInterval, 'amountPerInterval');
+
+    if (
+      !Number.isInteger(params.intervalSeconds) ||
+      params.intervalSeconds < MIN_INTERVAL_SECONDS
+    ) {
+      throw new ValidationError(
+        `intervalSeconds must be at least ${MIN_INTERVAL_SECONDS} (1 hour), got ${params.intervalSeconds}`,
+        { intervalSeconds: params.intervalSeconds },
+      );
+    }
+
+    if (
+      !Number.isInteger(params.totalIntervals) ||
+      params.totalIntervals < MIN_TOTAL_INTERVALS
+    ) {
+      throw new ValidationError(
+        `totalIntervals must be at least ${MIN_TOTAL_INTERVALS}, got ${params.totalIntervals}`,
+        { totalIntervals: params.totalIntervals },
+      );
+    }
+
+    const signerPublicKey = await signer.publicKey();
+    const contract = new Contract(this.contractAddress);
+
+    const op = contract.call(
+      'create_dca',
+      new Address(params.tokenIn).toScVal(),
+      new Address(params.tokenOut).toScVal(),
+      nativeToScVal(params.amountPerInterval, { type: 'i128' }),
+      nativeToScVal(params.intervalSeconds, { type: 'u32' }),
+      nativeToScVal(params.totalIntervals, { type: 'u32' }),
+      new Address(params.pairAddress).toScVal(),
+      new Address(signerPublicKey).toScVal(),
+    );
+
+    const result = await this.client.submitTransaction([op], signerPublicKey);
+
+    if (!result.success) {
+      throw new TransactionError(
+        `createDCA failed: ${result.error?.message ?? 'Unknown error'}`,
+        result.txHash,
+      );
+    }
+
+    // The contract returns the schedule ID; the txHash is a stable reference
+    // when the return value cannot be extracted from the polling result.
+    return result.txHash!;
+  }
+
+  /**
+   * Cancel an active DCA schedule and refund the unspent escrow.
+   *
+   * The refund equals the escrowed budget for every interval that has not yet
+   * executed (`amountPerInterval * remainingCount`).
+   *
+   * @param scheduleId - ID of the schedule to cancel
+   * @param signer - Wallet signer that owns the schedule
+   * @returns Cancellation details including the computed refund amount
+   * @throws {ValidationError} If `scheduleId` is empty, or the schedule is
+   *   already cancelled or has already completed
+   * @throws {TransactionError} If the transaction is rejected on-chain
+   */
+  async cancelDCA(
+    scheduleId: string,
+    signer: Signer,
+  ): Promise<DCACancellation> {
+    if (!scheduleId || scheduleId.trim().length === 0) {
+      throw new ValidationError('scheduleId must not be empty');
+    }
+
+    // Read current state first so we can reject no-op cancellations before
+    // spending gas, and compute an accurate refund.
+    const schedule = await this.getDCASchedule(scheduleId);
+
+    if (schedule.status === 'cancelled') {
+      throw new ValidationError('DCA schedule is already cancelled', {
+        scheduleId,
+      });
+    }
+    if (schedule.status === 'completed') {
+      throw new ValidationError('Cannot cancel a completed DCA schedule', {
+        scheduleId,
+      });
+    }
+
+    const refundAmount =
+      schedule.amountPerInterval * BigInt(schedule.remainingCount);
+
+    const signerPublicKey = await signer.publicKey();
+    const contract = new Contract(this.contractAddress);
+
+    const op = contract.call(
+      'cancel_dca',
+      nativeToScVal(scheduleId, { type: 'string' }),
+      new Address(signerPublicKey).toScVal(),
+    );
+
+    const result = await this.client.submitTransaction([op], signerPublicKey);
+
+    if (!result.success) {
+      throw new TransactionError(
+        `cancelDCA failed: ${result.error?.message ?? 'Unknown error'}`,
+        result.txHash,
+      );
+    }
+
+    return {
+      scheduleId,
+      txHash: result.txHash!,
+      refundAmount,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch a single DCA schedule by its ID.
+   *
+   * @param scheduleId - Unique schedule identifier
+   * @returns Full schedule state
+   * @throws {ValidationError} If `scheduleId` is empty or no schedule exists
+   */
+  async getDCASchedule(scheduleId: string): Promise<DCASchedule> {
+    if (!scheduleId || scheduleId.trim().length === 0) {
+      throw new ValidationError('scheduleId must not be empty');
+    }
+
+    const contract = new Contract(this.contractAddress);
+    const op = contract.call(
+      'get_schedule',
+      nativeToScVal(scheduleId, { type: 'string' }),
+    );
+
+    const sim = await this.client.simulateTransaction([op], {});
+
+    if (!sim.success || !sim.returnValue) {
+      throw new ValidationError('DCA schedule not found', { scheduleId });
+    }
+
+    return this.decodeSchedule(sim.returnValue);
+  }
+
+  /**
+   * Fetch all DCA schedules owned by an address.
+   *
+   * @param owner - Stellar address to query
+   * @returns Array of schedules (empty for an address with no schedules)
+   * @throws {ValidationError} If `owner` is not a valid Stellar address
+   */
+  async getDCASchedules(owner: string): Promise<DCASchedule[]> {
+    validateAddress(owner, 'owner');
+
+    const contract = new Contract(this.contractAddress);
+    const op = contract.call('get_schedules', new Address(owner).toScVal());
+
+    const sim = await this.client.simulateTransaction([op], {});
+
+    if (!sim.success || !sim.returnValue) {
+      return [];
+    }
+
+    const items = sim.returnValue.vec();
+    if (!items) return [];
+
+    return items.map((v) => this.decodeSchedule(v));
+  }
+
+  /**
+   * Compute performance for a DCA schedule versus a lump-sum baseline.
+   *
+   * The contract returns the realised aggregates (total invested, total
+   * received) plus the `tokenOut` a single lump-sum swap of the same size
+   * would have produced. Savings are derived client-side so the comparison
+   * is transparent and deterministic.
+   *
+   * @param scheduleId - Unique schedule identifier
+   * @returns Performance breakdown including absolute and basis-point savings
+   * @throws {ValidationError} If `scheduleId` is empty or no schedule exists
+   */
+  async getDCAPerformance(scheduleId: string): Promise<DCAPerformance> {
+    if (!scheduleId || scheduleId.trim().length === 0) {
+      throw new ValidationError('scheduleId must not be empty');
+    }
+
+    const contract = new Contract(this.contractAddress);
+    const op = contract.call(
+      'get_performance',
+      nativeToScVal(scheduleId, { type: 'string' }),
+    );
+
+    const sim = await this.client.simulateTransaction([op], {});
+
+    if (!sim.success || !sim.returnValue) {
+      throw new ValidationError('DCA schedule not found', { scheduleId });
+    }
+
+    const native = scValToNative(sim.returnValue) as Record<string, unknown>;
+
+    const totalInvested = BigInt(String(native['total_invested'] ?? '0'));
+    const totalReceived = BigInt(String(native['total_received'] ?? '0'));
+    const lumpSumReceived = BigInt(String(native['lump_sum_received'] ?? '0'));
+
+    const savings = totalReceived - lumpSumReceived;
+    const savingsBps =
+      lumpSumReceived === 0n
+        ? 0
+        : Number((savings * BPS_DENOMINATOR) / lumpSumReceived);
+
+    return {
+      scheduleId,
+      totalInvested,
+      totalReceived,
+      lumpSumReceived,
+      savings,
+      savingsBps,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private decodeSchedule(val: xdr.ScVal): DCASchedule {
+    const native = scValToNative(val) as Record<string, unknown>;
+
+    const totalIntervals = Number(native['total_intervals'] ?? 0);
+    const executedCount = Number(native['executed_count'] ?? 0);
+    const remainingCount = Math.max(totalIntervals - executedCount, 0);
+
+    return {
+      id: String(native['id'] ?? ''),
+      owner: String(native['owner'] ?? ''),
+      tokenIn: String(native['token_in'] ?? ''),
+      tokenOut: String(native['token_out'] ?? ''),
+      amountPerInterval: BigInt(String(native['amount_per_interval'] ?? '0')),
+      intervalSeconds: Number(native['interval_seconds'] ?? 0),
+      totalIntervals,
+      executedCount,
+      remainingCount,
+      nextExecutionAt: Number(native['next_execution_at'] ?? 0),
+      status: (native['status'] as DCAStatus) ?? 'active',
+    };
+  }
+}

--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -3,6 +3,7 @@ import {
   FlashLoanRequest,
   FlashLoanResult,
   FlashLoanFeeEstimate,
+  FlashLoanFeeComparison,
   FlashLoanEventData,
 } from "@/types/flash-loan";
 import { FlashLoanConfig } from "@/types/pool";
@@ -15,6 +16,7 @@ import {
   FlashLoanError,
   TransactionError,
 } from "@/errors";
+import { FeeModule } from "@/modules/fees";
 import { validateAddress, validatePositiveAmount } from "@/utils/validation";
 import { estimateGas } from "@/utils/gas";
 import { DEFAULTS } from "@/config";
@@ -87,6 +89,57 @@ export class FlashLoanModule {
       feeAmount: actualFee,
       feeFloor: Number(config.flashFeeFloor),
     };
+  }
+
+  /**
+   * Compare the flash loan fee against the current dynamic swap fee for a
+   * pair and amount.
+   *
+   * Arbitrageurs use this to decide whether borrowing via a flash loan is
+   * cheaper than routing capital through a direct swap before committing to
+   * a strategy. Both fees are fetched in parallel and reduced to absolute
+   * token amounts using `(amount * feeBps) / 10000n`.
+   *
+   * @param pair - The address of the pair contract to compare fees for
+   * @param amount - The notional amount the strategy would move (must be > 0)
+   * @returns The two effective fees and which option is cheaper
+   * @throws {ValidationError} If `pair` is invalid or `amount` is zero/negative
+   * @example
+   * const cmp = await client.flashLoans.compareFees('C...', 1_000_000n);
+   * if (cmp.cheaperOption === 'flashLoan') {
+   *   // borrow via flash loan
+   * }
+   */
+  async compareFees(
+    pair: string,
+    amount: bigint,
+  ): Promise<FlashLoanFeeComparison> {
+    validateAddress(pair, "pair");
+    validatePositiveAmount(amount, "amount");
+
+    const fees = new FeeModule(this.client);
+
+    // Fetch the flash loan fee (fee_bps) and the dynamic swap fee in parallel.
+    const [config, swapEstimate] = await Promise.all([
+      this.getConfig(pair),
+      fees.estimateSwapFee(pair, amount),
+    ]);
+
+    // Reduce both fees to absolute token amounts on the same basis-points
+    // formula so the comparison is apples-to-apples.
+    const flashLoanFee = (amount * BigInt(config.flashFeeBps)) / 10000n;
+    const swapFee = swapEstimate.feeAmount;
+
+    let cheaperOption: FlashLoanFeeComparison["cheaperOption"];
+    if (flashLoanFee < swapFee) {
+      cheaperOption = "flashLoan";
+    } else if (swapFee < flashLoanFee) {
+      cheaperOption = "swap";
+    } else {
+      cheaperOption = "equal";
+    }
+
+    return { flashLoanFee, swapFee, cheaperOption };
   }
 
   /**

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -10,3 +10,4 @@ export { GovernanceModule } from './governance';
 export { TaxReportingModule } from './tax-reporting';
 export type { ExportOptions, TaxReportRow } from './tax-reporting';
 export { DCAModule } from './dca';
+export { StopLossModule } from './stop-loss';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,3 +9,4 @@ export { RouterModule } from './router';
 export { GovernanceModule } from './governance';
 export { TaxReportingModule } from './tax-reporting';
 export type { ExportOptions, TaxReportRow } from './tax-reporting';
+export { DCAModule } from './dca';

--- a/src/modules/stop-loss.ts
+++ b/src/modules/stop-loss.ts
@@ -1,0 +1,209 @@
+import { CoralSwapClient } from '@/client';
+import {
+  StopLossParams,
+  StopLossOrder,
+  StopLossStatus,
+} from '@/types/stop-loss';
+import { Signer } from '@/types/common';
+import { ValidationError, TransactionError } from '@/errors';
+import {
+  validateAddress,
+  validatePositiveAmount,
+  validateDistinctTokens,
+} from '@/utils/validation';
+import {
+  Contract,
+  nativeToScVal,
+  Address,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Stop-Loss module — automated stop-loss orders with RedStone trigger detection.
+ *
+ * Creates and inspects stop-loss orders that sell a position once the
+ * RedStone-reported market price falls to or below a trigger price. Using an
+ * external oracle (rather than the pool's spot price) makes the trigger
+ * resistant to single-pool price manipulation.
+ *
+ * @example
+ * const stopLoss = new StopLossModule(client, MANAGER_ADDRESS, REDSTONE_ORACLE);
+ * const id = await stopLoss.createStopLoss(params, signer);
+ */
+export class StopLossModule {
+  private readonly client: CoralSwapClient;
+  private readonly contractAddress: string;
+  private readonly oracleAddress: string;
+
+  /**
+   * @param client - Configured CoralSwap client
+   * @param contractAddress - Address of the stop-loss manager contract
+   * @param oracleAddress - Address of the RedStone price-feed oracle contract
+   */
+  constructor(
+    client: CoralSwapClient,
+    contractAddress: string,
+    oracleAddress: string,
+  ) {
+    this.client = client;
+    this.contractAddress = contractAddress;
+    this.oracleAddress = oracleAddress;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write operations (require signing)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a stop-loss order.
+   *
+   * The current market price is read from the RedStone feed and the trigger
+   * price is required to be strictly below it — a stop-loss above market would
+   * fire immediately and is rejected.
+   *
+   * @param params - Order parameters (tokens, amount, trigger, pair, feed)
+   * @param signer - Wallet signer that owns and authorises the order
+   * @returns The unique order ID assigned by the contract
+   * @throws {ValidationError} If addresses are invalid, tokens are identical,
+   *   the amount or trigger price is non-positive, the oracle asset is empty,
+   *   or the trigger price is not below the current market price
+   * @throws {TransactionError} If the transaction is rejected on-chain
+   */
+  async createStopLoss(params: StopLossParams, signer: Signer): Promise<string> {
+    validateAddress(params.tokenIn, 'tokenIn');
+    validateAddress(params.tokenOut, 'tokenOut');
+    validateAddress(params.pairAddress, 'pairAddress');
+    validateDistinctTokens(params.tokenIn, params.tokenOut);
+    validatePositiveAmount(params.amount, 'amount');
+    validatePositiveAmount(params.triggerPrice, 'triggerPrice');
+
+    if (!params.oracleAsset || params.oracleAsset.trim().length === 0) {
+      throw new ValidationError('oracleAsset must not be empty');
+    }
+
+    // A stop-loss only makes sense below the current price; otherwise it would
+    // trigger on creation.
+    const currentPrice = await this.getOraclePrice(params.oracleAsset);
+    if (params.triggerPrice >= currentPrice) {
+      throw new ValidationError(
+        'triggerPrice must be below the current market price',
+        {
+          triggerPrice: params.triggerPrice.toString(),
+          currentPrice: currentPrice.toString(),
+        },
+      );
+    }
+
+    const signerPublicKey = await signer.publicKey();
+    const contract = new Contract(this.contractAddress);
+
+    const op = contract.call(
+      'create_stop_loss',
+      new Address(params.tokenIn).toScVal(),
+      new Address(params.tokenOut).toScVal(),
+      nativeToScVal(params.amount, { type: 'i128' }),
+      nativeToScVal(params.triggerPrice, { type: 'i128' }),
+      new Address(params.pairAddress).toScVal(),
+      nativeToScVal(params.oracleAsset, { type: 'symbol' }),
+      new Address(signerPublicKey).toScVal(),
+    );
+
+    const result = await this.client.submitTransaction([op], signerPublicKey);
+
+    if (!result.success) {
+      throw new TransactionError(
+        `createStopLoss failed: ${result.error?.message ?? 'Unknown error'}`,
+        result.txHash,
+      );
+    }
+
+    // The contract returns the order ID; the txHash is a stable reference when
+    // the return value cannot be extracted from the polling result.
+    return result.txHash!;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch a stop-loss order and evaluate its trigger condition against the
+   * latest RedStone price.
+   *
+   * @param orderId - Unique order identifier
+   * @returns The order state plus the live `currentPrice` and `triggered` flag
+   * @throws {ValidationError} If `orderId` is empty or no order exists
+   */
+  async getStopLoss(orderId: string): Promise<StopLossOrder> {
+    if (!orderId || orderId.trim().length === 0) {
+      throw new ValidationError('orderId must not be empty');
+    }
+
+    const contract = new Contract(this.contractAddress);
+    const op = contract.call(
+      'get_order',
+      nativeToScVal(orderId, { type: 'string' }),
+    );
+
+    const sim = await this.client.simulateTransaction([op], {});
+
+    if (!sim.success || !sim.returnValue) {
+      throw new ValidationError('Stop-loss order not found', { orderId });
+    }
+
+    const order = this.decodeOrder(sim.returnValue);
+
+    // Re-read the live price from RedStone to decide whether the order is
+    // currently eligible to execute.
+    const currentPrice = await this.getOraclePrice(order.oracleAsset);
+    const triggered = currentPrice <= order.triggerPrice;
+
+    return { ...order, currentPrice, triggered };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Read the current price for an asset from the RedStone oracle contract.
+   *
+   * @param asset - RedStone feed identifier (asset symbol)
+   * @returns Current price in the oracle's fixed-point scale
+   * @throws {ValidationError} If the oracle returns no price for the asset
+   */
+  private async getOraclePrice(asset: string): Promise<bigint> {
+    const oracle = new Contract(this.oracleAddress);
+    const op = oracle.call(
+      'get_price',
+      nativeToScVal(asset, { type: 'symbol' }),
+    );
+
+    const sim = await this.client.simulateTransaction([op], {});
+
+    if (!sim.success || !sim.returnValue) {
+      throw new ValidationError(
+        `RedStone oracle returned no price for asset ${asset}`,
+        { asset },
+      );
+    }
+
+    return BigInt(String(scValToNative(sim.returnValue)));
+  }
+
+  private decodeOrder(val: xdr.ScVal): Omit<StopLossOrder, 'currentPrice' | 'triggered'> {
+    const native = scValToNative(val) as Record<string, unknown>;
+
+    return {
+      id: String(native['id'] ?? ''),
+      owner: String(native['owner'] ?? ''),
+      tokenIn: String(native['token_in'] ?? ''),
+      tokenOut: String(native['token_out'] ?? ''),
+      amount: BigInt(String(native['amount'] ?? '0')),
+      triggerPrice: BigInt(String(native['trigger_price'] ?? '0')),
+      oracleAsset: String(native['oracle_asset'] ?? ''),
+      status: (native['status'] as StopLossStatus) ?? 'active',
+    };
+  }
+}

--- a/src/types/dca.ts
+++ b/src/types/dca.ts
@@ -1,0 +1,105 @@
+/**
+ * TypeScript types for the CoralSwap DCAModule.
+ *
+ * Dollar-Cost Averaging (DCA) splits a large position into a series of
+ * smaller, time-spaced swaps to reduce exposure to short-term volatility.
+ * A schedule escrows the input token and executes one swap per interval
+ * until all intervals are consumed or the schedule is cancelled.
+ */
+
+/**
+ * Lifecycle status of a DCA schedule.
+ */
+export type DCAStatus = 'active' | 'completed' | 'cancelled';
+
+/**
+ * Parameters required to create a new DCA schedule.
+ */
+export interface DCAParams {
+  /** Address of the token being spent each interval. */
+  tokenIn: string;
+  /** Address of the token being accumulated. */
+  tokenOut: string;
+  /** Amount of `tokenIn` swapped on every interval (smallest unit). */
+  amountPerInterval: bigint;
+  /**
+   * Seconds between executions. Must be at least `3600` (one hour) so that
+   * schedules cannot be used to grind the pool with sub-hour swaps.
+   */
+  intervalSeconds: number;
+  /** Total number of intervals to execute. Must be at least `2`. */
+  totalIntervals: number;
+  /** Address of the pair the swaps route through. */
+  pairAddress: string;
+}
+
+/**
+ * Full on-chain state of a DCA schedule.
+ */
+export interface DCASchedule {
+  /** Unique schedule identifier. */
+  id: string;
+  /** Stellar address that owns (and funded) the schedule. */
+  owner: string;
+  /** Address of the token being spent. */
+  tokenIn: string;
+  /** Address of the token being accumulated. */
+  tokenOut: string;
+  /** Amount of `tokenIn` swapped per interval. */
+  amountPerInterval: bigint;
+  /** Seconds between executions. */
+  intervalSeconds: number;
+  /** Total number of intervals the schedule will run for. */
+  totalIntervals: number;
+  /** Number of intervals already executed. */
+  executedCount: number;
+  /** Number of intervals still pending (`totalIntervals - executedCount`). */
+  remainingCount: number;
+  /** Unix timestamp (seconds) of the next scheduled execution. */
+  nextExecutionAt: number;
+  /** Current lifecycle status. */
+  status: DCAStatus;
+}
+
+/**
+ * Performance summary for a DCA schedule, comparing the realised DCA outcome
+ * against a hypothetical single lump-sum swap of the same total size.
+ */
+export interface DCAPerformance {
+  /** Schedule the performance figures relate to. */
+  scheduleId: string;
+  /** Total `tokenIn` spent so far (`amountPerInterval * executedCount`). */
+  totalInvested: bigint;
+  /** Total `tokenOut` received across all executed intervals. */
+  totalReceived: bigint;
+  /**
+   * Amount of `tokenOut` a single lump-sum swap of `totalInvested` would
+   * have produced, used as the comparison baseline.
+   */
+  lumpSumReceived: bigint;
+  /**
+   * Extra `tokenOut` gained (positive) or lost (negative) by averaging in
+   * versus the lump-sum baseline: `totalReceived - lumpSumReceived`.
+   */
+  savings: bigint;
+  /**
+   * `savings` expressed in basis points of the lump-sum baseline.
+   * `0` when the baseline is zero (nothing executed yet).
+   */
+  savingsBps: number;
+}
+
+/**
+ * Result of cancelling a DCA schedule.
+ */
+export interface DCACancellation {
+  /** Schedule that was cancelled. */
+  scheduleId: string;
+  /** Transaction hash of the cancellation. */
+  txHash: string;
+  /**
+   * Amount of `tokenIn` refunded to the owner: the escrowed funds for every
+   * interval that had not yet executed (`amountPerInterval * remainingCount`).
+   */
+  refundAmount: bigint;
+}

--- a/src/types/flash-loan.ts
+++ b/src/types/flash-loan.ts
@@ -63,6 +63,22 @@ export interface FlashLoanFeeEstimate {
 }
 
 /**
+ * Result of comparing a flash loan fee against a regular swap fee
+ * for the same pair and amount.
+ *
+ * Both fees are expressed as absolute token amounts (not basis points),
+ * computed as `(amount * feeBps) / 10000n`.
+ */
+export interface FlashLoanFeeComparison {
+  /** Effective flash loan fee for the requested amount. */
+  flashLoanFee: bigint;
+  /** Effective dynamic swap fee for the requested amount. */
+  swapFee: bigint;
+  /** Which option is cheaper for the caller, or `'equal'` when identical. */
+  cheaperOption: 'flashLoan' | 'swap' | 'equal';
+}
+
+/**
  * Interface that flash loan receivers must implement.
  */
 export interface FlashLoanReceiverParams {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,3 +9,4 @@ export * from './tokens';
 export * from './gas';
 export * from './governance';
 export * from './dca';
+export * from './stop-loss';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './events';
 export * from './tokens';
 export * from './gas';
 export * from './governance';
+export * from './dca';

--- a/src/types/stop-loss.ts
+++ b/src/types/stop-loss.ts
@@ -1,0 +1,66 @@
+/**
+ * TypeScript types for the CoralSwap StopLossModule.
+ *
+ * A stop-loss order automatically sells a position when the market price
+ * falls to or below a trigger price, capping downside risk. Trigger detection
+ * relies on an external price feed (RedStone) rather than the pool's own spot
+ * price, so manipulation of a single pool cannot spuriously fire the order.
+ */
+
+/**
+ * Lifecycle status of a stop-loss order.
+ */
+export type StopLossStatus = 'active' | 'triggered' | 'executed' | 'cancelled';
+
+/**
+ * Parameters required to create a stop-loss order.
+ */
+export interface StopLossParams {
+  /** Address of the token held / being sold when triggered. */
+  tokenIn: string;
+  /** Address of the token received on execution. */
+  tokenOut: string;
+  /** Amount of `tokenIn` to sell when the order triggers (smallest unit). */
+  amount: bigint;
+  /**
+   * Price (in the oracle's fixed-point scale) at or below which the order
+   * fires. Must be strictly below the current market price at creation time.
+   */
+  triggerPrice: bigint;
+  /** Address of the pair the protective swap routes through. */
+  pairAddress: string;
+  /**
+   * Identifier of the RedStone price feed used for trigger detection
+   * (e.g. the asset symbol `'XLM'`).
+   */
+  oracleAsset: string;
+}
+
+/**
+ * Full state of a stop-loss order, including a live oracle price reading.
+ */
+export interface StopLossOrder {
+  /** Unique order identifier. */
+  id: string;
+  /** Stellar address that owns the order. */
+  owner: string;
+  /** Address of the token being sold. */
+  tokenIn: string;
+  /** Address of the token received. */
+  tokenOut: string;
+  /** Amount of `tokenIn` to sell on trigger. */
+  amount: bigint;
+  /** Price at or below which the order fires. */
+  triggerPrice: bigint;
+  /** Latest market price from the RedStone feed at query time. */
+  currentPrice: bigint;
+  /** RedStone feed identifier used for this order. */
+  oracleAsset: string;
+  /** Current lifecycle status reported by the contract. */
+  status: StopLossStatus;
+  /**
+   * `true` when `currentPrice <= triggerPrice`, i.e. the stop-loss condition
+   * is currently met and the order is eligible for execution.
+   */
+  triggered: boolean;
+}

--- a/tests/dca.test.ts
+++ b/tests/dca.test.ts
@@ -1,0 +1,460 @@
+import { CoralSwapClient } from '../src/client';
+import { DCAModule } from '../src/modules/dca';
+import { ValidationError, TransactionError } from '../src/errors';
+import { Network } from '../src/types/common';
+import type { DCAParams } from '../src/types/dca';
+import type { SimulateTransactionResult } from '../src/types/common';
+import { nativeToScVal, xdr } from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = 'SB6K2AINTGNYBFX4M7TRPGSKQ5RKNOXXWB7UZUHRYOVTM7REDUGECKZU';
+const DCA_CONTRACT = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const TOKEN_IN = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const TOKEN_OUT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4';
+const PAIR = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM';
+const OWNER = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+const TEST_TX_HASH = 'dca-tx-hash-123';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a valid set of DCA params, allowing per-test overrides. */
+function makeParams(overrides: Partial<DCAParams> = {}): DCAParams {
+  return {
+    tokenIn: TOKEN_IN,
+    tokenOut: TOKEN_OUT,
+    amountPerInterval: 100_0000000n,
+    intervalSeconds: 86400, // 1 day
+    totalIntervals: 7,
+    pairAddress: PAIR,
+    ...overrides,
+  };
+}
+
+/** Build a raw on-chain schedule struct, allowing per-field overrides. */
+function makeScheduleNative(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: 'schedule-1',
+    owner: OWNER,
+    token_in: TOKEN_IN,
+    token_out: TOKEN_OUT,
+    amount_per_interval: '1000000',
+    interval_seconds: 86400,
+    total_intervals: 7,
+    executed_count: 2,
+    next_execution_at: 1_700_000_000,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+/** Wrap a native value as a successful simulation result (struct return). */
+function makeSimResult(native: unknown): SimulateTransactionResult {
+  return {
+    success: true,
+    returnValue: nativeToScVal(native),
+    auth: [],
+    minResourceFee: '100',
+    cost: { cpuInsns: '1000', memBytes: '512' },
+    transactionData: null,
+    latestLedger: 12345,
+    events: [],
+    error: null,
+    raw: {} as never,
+  };
+}
+
+/** Wrap a list of native values as a successful simulation result (vec return). */
+function makeArraySimResult(items: unknown[]): SimulateTransactionResult {
+  const arrayVal = xdr.ScVal.scvVec(items.map((item) => nativeToScVal(item)));
+  return {
+    success: true,
+    returnValue: arrayVal,
+    auth: [],
+    minResourceFee: '100',
+    cost: { cpuInsns: '1000', memBytes: '512' },
+    transactionData: null,
+    latestLedger: 12345,
+    events: [],
+    error: null,
+    raw: {} as never,
+  };
+}
+
+/** A successful simulation that returns no value (e.g. unknown schedule). */
+function makeEmptySimResult(): SimulateTransactionResult {
+  return {
+    success: true,
+    returnValue: null,
+    auth: [],
+    minResourceFee: '100',
+    cost: { cpuInsns: '1000', memBytes: '512' },
+    transactionData: null,
+    latestLedger: 12345,
+    events: [],
+    error: null,
+    raw: {} as never,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('DCAModule', () => {
+  let client: CoralSwapClient;
+  let dca: DCAModule;
+  let mockSigner: { publicKey: jest.Mock; signTransaction: jest.Mock };
+
+  beforeEach(() => {
+    client = new CoralSwapClient({
+      network: Network.TESTNET,
+      secretKey: TEST_SECRET,
+    });
+
+    dca = new DCAModule(client, DCA_CONTRACT);
+
+    mockSigner = {
+      publicKey: jest.fn().mockResolvedValue(OWNER),
+      signTransaction: jest.fn().mockResolvedValue('signed-xdr'),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockSubmitSuccess(): jest.SpyInstance {
+    return jest.spyOn(client, 'submitTransaction').mockResolvedValue({
+      success: true,
+      txHash: TEST_TX_HASH,
+      data: { txHash: TEST_TX_HASH, ledger: 1000 },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // createDCA()
+  // -------------------------------------------------------------------------
+
+  describe('createDCA()', () => {
+    it('returns a schedule ID (tx hash) on valid params', async () => {
+      mockSubmitSuccess();
+
+      const id = await dca.createDCA(makeParams(), mockSigner);
+
+      expect(id).toBe(TEST_TX_HASH);
+      expect(mockSigner.publicKey).toHaveBeenCalled();
+    });
+
+    it('throws ValidationError for an invalid tokenIn address', async () => {
+      await expect(
+        dca.createDCA(makeParams({ tokenIn: 'not-an-address' }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when tokenIn and tokenOut are identical', async () => {
+      await expect(
+        dca.createDCA(makeParams({ tokenOut: TOKEN_IN }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when amountPerInterval is zero', async () => {
+      await expect(
+        dca.createDCA(makeParams({ amountPerInterval: 0n }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when interval is below the 1-hour minimum', async () => {
+      await expect(
+        dca.createDCA(makeParams({ intervalSeconds: 3599 }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+
+      await expect(
+        dca.createDCA(makeParams({ intervalSeconds: 3599 }), mockSigner),
+      ).rejects.toThrow('intervalSeconds must be at least 3600');
+    });
+
+    it('accepts the exact 1-hour interval boundary (3600s)', async () => {
+      mockSubmitSuccess();
+
+      await expect(
+        dca.createDCA(makeParams({ intervalSeconds: 3600 }), mockSigner),
+      ).resolves.toBe(TEST_TX_HASH);
+    });
+
+    it('throws ValidationError when totalIntervals is below 2', async () => {
+      await expect(
+        dca.createDCA(makeParams({ totalIntervals: 1 }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+
+      await expect(
+        dca.createDCA(makeParams({ totalIntervals: 1 }), mockSigner),
+      ).rejects.toThrow('totalIntervals must be at least 2');
+    });
+
+    it('accepts the exact minimum of 2 intervals', async () => {
+      mockSubmitSuccess();
+
+      await expect(
+        dca.createDCA(makeParams({ totalIntervals: 2 }), mockSigner),
+      ).resolves.toBe(TEST_TX_HASH);
+    });
+
+    it('throws ValidationError for a non-integer interval', async () => {
+      await expect(
+        dca.createDCA(makeParams({ intervalSeconds: 3600.5 }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws TransactionError when submitTransaction reports failure', async () => {
+      jest.spyOn(client, 'submitTransaction').mockResolvedValue({
+        success: false,
+        error: { code: 'SIMULATION_FAILED', message: 'Insufficient balance' },
+      });
+
+      await expect(dca.createDCA(makeParams(), mockSigner)).rejects.toThrow(
+        TransactionError,
+      );
+      await expect(dca.createDCA(makeParams(), mockSigner)).rejects.toThrow(
+        'createDCA failed: Insufficient balance',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDCASchedule()
+  // -------------------------------------------------------------------------
+
+  describe('getDCASchedule()', () => {
+    it('returns a decoded schedule by ID', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeSimResult(makeScheduleNative()));
+
+      const schedule = await dca.getDCASchedule('schedule-1');
+
+      expect(schedule.id).toBe('schedule-1');
+      expect(schedule.owner).toBe(OWNER);
+      expect(schedule.amountPerInterval).toBe(1_000_000n);
+      expect(schedule.status).toBe('active');
+    });
+
+    it('derives remainingCount as totalIntervals - executedCount', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult(
+          makeScheduleNative({ total_intervals: 10, executed_count: 4 }),
+        ),
+      );
+
+      const schedule = await dca.getDCASchedule('schedule-1');
+
+      expect(schedule.totalIntervals).toBe(10);
+      expect(schedule.executedCount).toBe(4);
+      expect(schedule.remainingCount).toBe(6);
+    });
+
+    it('throws ValidationError for an empty scheduleId', async () => {
+      await expect(dca.getDCASchedule('')).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when the schedule does not exist', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeEmptySimResult());
+
+      await expect(dca.getDCASchedule('missing')).rejects.toThrow(
+        'DCA schedule not found',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDCASchedules()
+  // -------------------------------------------------------------------------
+
+  describe('getDCASchedules()', () => {
+    it('returns all schedules for an address', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeArraySimResult([
+          makeScheduleNative({ id: 'schedule-1' }),
+          makeScheduleNative({ id: 'schedule-2', status: 'completed' }),
+        ]),
+      );
+
+      const schedules = await dca.getDCASchedules(OWNER);
+
+      expect(schedules).toHaveLength(2);
+      expect(schedules[0].id).toBe('schedule-1');
+      expect(schedules[1].status).toBe('completed');
+    });
+
+    it('returns an empty array for an address with no schedules', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeArraySimResult([]));
+
+      const schedules = await dca.getDCASchedules(OWNER);
+
+      expect(schedules).toEqual([]);
+    });
+
+    it('throws ValidationError for an invalid owner address', async () => {
+      await expect(dca.getDCASchedules('not-an-address')).rejects.toThrow(
+        ValidationError,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDCAPerformance()
+  // -------------------------------------------------------------------------
+
+  describe('getDCAPerformance()', () => {
+    it('computes positive savings when DCA beats the lump-sum baseline', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          total_invested: '1000',
+          total_received: '1100',
+          lump_sum_received: '1000',
+        }),
+      );
+
+      const perf = await dca.getDCAPerformance('schedule-1');
+
+      expect(perf.totalInvested).toBe(1000n);
+      expect(perf.totalReceived).toBe(1100n);
+      expect(perf.lumpSumReceived).toBe(1000n);
+      expect(perf.savings).toBe(100n);
+      // 100 / 1000 = 1000 bps
+      expect(perf.savingsBps).toBe(1000);
+    });
+
+    it('computes negative savings when DCA underperforms the lump sum', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          total_invested: '1000',
+          total_received: '900',
+          lump_sum_received: '1000',
+        }),
+      );
+
+      const perf = await dca.getDCAPerformance('schedule-1');
+
+      expect(perf.savings).toBe(-100n);
+      expect(perf.savingsBps).toBe(-1000);
+    });
+
+    it('reports zero savingsBps when the lump-sum baseline is zero', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          total_invested: '0',
+          total_received: '0',
+          lump_sum_received: '0',
+        }),
+      );
+
+      const perf = await dca.getDCAPerformance('schedule-1');
+
+      expect(perf.savings).toBe(0n);
+      expect(perf.savingsBps).toBe(0);
+    });
+
+    it('throws ValidationError for an empty scheduleId', async () => {
+      await expect(dca.getDCAPerformance('')).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when the schedule does not exist', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeEmptySimResult());
+
+      await expect(dca.getDCAPerformance('missing')).rejects.toThrow(
+        ValidationError,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cancelDCA()
+  // -------------------------------------------------------------------------
+
+  describe('cancelDCA()', () => {
+    it('cancels an active schedule and refunds the unspent escrow', async () => {
+      // remainingCount = 7 - 2 = 5; refund = 1_000_000 * 5 = 5_000_000
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeSimResult(makeScheduleNative()));
+      mockSubmitSuccess();
+
+      const result = await dca.cancelDCA('schedule-1', mockSigner);
+
+      expect(result.scheduleId).toBe('schedule-1');
+      expect(result.txHash).toBe(TEST_TX_HASH);
+      expect(result.refundAmount).toBe(5_000_000n);
+    });
+
+    it('refunds zero when no intervals remain', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult(
+          makeScheduleNative({ total_intervals: 3, executed_count: 3, status: 'active' }),
+        ),
+      );
+      mockSubmitSuccess();
+
+      const result = await dca.cancelDCA('schedule-1', mockSigner);
+
+      expect(result.refundAmount).toBe(0n);
+    });
+
+    it('prevents double cancellation (already cancelled)', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeSimResult(makeScheduleNative({ status: 'cancelled' })));
+      const submitSpy = mockSubmitSuccess();
+
+      await expect(dca.cancelDCA('schedule-1', mockSigner)).rejects.toThrow(
+        'already cancelled',
+      );
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects cancelling a completed schedule', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeSimResult(makeScheduleNative({ status: 'completed' })));
+      const submitSpy = mockSubmitSuccess();
+
+      await expect(dca.cancelDCA('schedule-1', mockSigner)).rejects.toThrow(
+        'Cannot cancel a completed DCA schedule',
+      );
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws ValidationError for an empty scheduleId', async () => {
+      await expect(dca.cancelDCA('', mockSigner)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it('throws TransactionError when the cancellation is rejected on-chain', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeSimResult(makeScheduleNative()));
+      jest.spyOn(client, 'submitTransaction').mockResolvedValue({
+        success: false,
+        error: { code: 'TX_FAILED', message: 'Unauthorized caller' },
+      });
+
+      await expect(dca.cancelDCA('schedule-1', mockSigner)).rejects.toThrow(
+        TransactionError,
+      );
+    });
+  });
+});

--- a/tests/flash-loan-module.test.ts
+++ b/tests/flash-loan-module.test.ts
@@ -1,7 +1,7 @@
 import { CoralSwapClient } from "../src/client";
 import { FlashLoanModule } from "../src/modules/flash-loan";
 import { PairClient } from "../src/contracts/pair";
-import { FlashLoanError, TransactionError, FlashLoanFailedError } from "../src/errors";
+import { FlashLoanError, TransactionError, FlashLoanFailedError, ValidationError } from "../src/errors";
 import { Network } from "../src/types/common";
 import { FlashLoanConfig } from "../src/types/pool";
 import { xdr, Address, nativeToScVal, SorobanRpc } from "@stellar/stellar-sdk";
@@ -1067,6 +1067,82 @@ describe("FlashLoanModule - Event Parsing", () => {
         feePaid: 225n,
         callbackAddress: TEST_BORROWER_ADDRESS,
       });
+    });
+  });
+
+  describe("compareFees()", () => {
+    const AMOUNT = 1_000_000n;
+
+    /** Configure the mocked pair to report a given flash and swap fee (bps). */
+    function mockFees(flashFeeBps: number, swapFeeBps: number): void {
+      mockPairClient.getFlashLoanConfig.mockResolvedValue({
+        flashFeeBps,
+        locked: false,
+        flashFeeFloor: 0n,
+      });
+      mockPairClient.getDynamicFee = jest.fn().mockResolvedValue(swapFeeBps);
+    }
+
+    it("reports 'flashLoan' when the flash loan fee is cheaper", async () => {
+      mockFees(9, 30);
+
+      const result = await flashLoanModule.compareFees(TEST_PAIR_ADDRESS, AMOUNT);
+
+      // flash = 1_000_000 * 9 / 10000 = 900; swap = 1_000_000 * 30 / 10000 = 3000
+      expect(result.flashLoanFee).toBe(900n);
+      expect(result.swapFee).toBe(3000n);
+      expect(result.cheaperOption).toBe("flashLoan");
+    });
+
+    it("reports 'swap' when the swap fee is cheaper", async () => {
+      mockFees(50, 10);
+
+      const result = await flashLoanModule.compareFees(TEST_PAIR_ADDRESS, AMOUNT);
+
+      // flash = 5000; swap = 1000
+      expect(result.flashLoanFee).toBe(5000n);
+      expect(result.swapFee).toBe(1000n);
+      expect(result.cheaperOption).toBe("swap");
+    });
+
+    it("reports 'equal' when both fees match", async () => {
+      mockFees(30, 30);
+
+      const result = await flashLoanModule.compareFees(TEST_PAIR_ADDRESS, AMOUNT);
+
+      expect(result.flashLoanFee).toBe(result.swapFee);
+      expect(result.cheaperOption).toBe("equal");
+    });
+
+    it("fetches both fees in parallel", async () => {
+      mockFees(9, 30);
+
+      await flashLoanModule.compareFees(TEST_PAIR_ADDRESS, AMOUNT);
+
+      expect(mockPairClient.getFlashLoanConfig).toHaveBeenCalledTimes(1);
+      expect(mockPairClient.getDynamicFee).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws ValidationError when the amount is zero", async () => {
+      mockFees(9, 30);
+
+      await expect(
+        flashLoanModule.compareFees(TEST_PAIR_ADDRESS, 0n),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError when the amount is negative", async () => {
+      mockFees(9, 30);
+
+      await expect(
+        flashLoanModule.compareFees(TEST_PAIR_ADDRESS, -5n),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError for an invalid pair address", async () => {
+      await expect(
+        flashLoanModule.compareFees("not-an-address", AMOUNT),
+      ).rejects.toThrow(ValidationError);
     });
   });
 });

--- a/tests/stop-loss.test.ts
+++ b/tests/stop-loss.test.ts
@@ -1,0 +1,262 @@
+import { CoralSwapClient } from '../src/client';
+import { StopLossModule } from '../src/modules/stop-loss';
+import { ValidationError, TransactionError } from '../src/errors';
+import { Network } from '../src/types/common';
+import type { StopLossParams } from '../src/types/stop-loss';
+import type { SimulateTransactionResult } from '../src/types/common';
+import { nativeToScVal } from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = 'SB6K2AINTGNYBFX4M7TRPGSKQ5RKNOXXWB7UZUHRYOVTM7REDUGECKZU';
+const MANAGER = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const ORACLE = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM';
+const TOKEN_IN = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const TOKEN_OUT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4';
+const PAIR = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4';
+const OWNER = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+const TEST_TX_HASH = 'stop-loss-tx-123';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(overrides: Partial<StopLossParams> = {}): StopLossParams {
+  return {
+    tokenIn: TOKEN_IN,
+    tokenOut: TOKEN_OUT,
+    amount: 1000_0000000n,
+    triggerPrice: 900_0000n, // below the mocked current price of 1_000_0000
+    pairAddress: PAIR,
+    oracleAsset: 'XLM',
+    ...overrides,
+  };
+}
+
+function makeOrderNative(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: 'order-1',
+    owner: OWNER,
+    token_in: TOKEN_IN,
+    token_out: TOKEN_OUT,
+    amount: '10000000000',
+    trigger_price: '9000000',
+    oracle_asset: 'XLM',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function makeSimResult(native: unknown): SimulateTransactionResult {
+  return {
+    success: true,
+    returnValue: nativeToScVal(native),
+    auth: [],
+    minResourceFee: '100',
+    cost: { cpuInsns: '1000', memBytes: '512' },
+    transactionData: null,
+    latestLedger: 12345,
+    events: [],
+    error: null,
+    raw: {} as never,
+  };
+}
+
+function makeEmptySimResult(): SimulateTransactionResult {
+  return {
+    success: true,
+    returnValue: null,
+    auth: [],
+    minResourceFee: '100',
+    cost: { cpuInsns: '1000', memBytes: '512' },
+    transactionData: null,
+    latestLedger: 12345,
+    events: [],
+    error: null,
+    raw: {} as never,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('StopLossModule', () => {
+  let client: CoralSwapClient;
+  let stopLoss: StopLossModule;
+  let mockSigner: { publicKey: jest.Mock; signTransaction: jest.Mock };
+
+  beforeEach(() => {
+    client = new CoralSwapClient({
+      network: Network.TESTNET,
+      secretKey: TEST_SECRET,
+    });
+
+    stopLoss = new StopLossModule(client, MANAGER, ORACLE);
+
+    mockSigner = {
+      publicKey: jest.fn().mockResolvedValue(OWNER),
+      signTransaction: jest.fn().mockResolvedValue('signed-xdr'),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Mock the oracle price read (get_price) to return a fixed price. */
+  function mockOraclePrice(price: bigint): jest.SpyInstance {
+    return jest
+      .spyOn(client, 'simulateTransaction')
+      .mockResolvedValue(makeSimResult(price.toString()));
+  }
+
+  function mockSubmitSuccess(): jest.SpyInstance {
+    return jest.spyOn(client, 'submitTransaction').mockResolvedValue({
+      success: true,
+      txHash: TEST_TX_HASH,
+      data: { txHash: TEST_TX_HASH, ledger: 1000 },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // createStopLoss()
+  // -------------------------------------------------------------------------
+
+  describe('createStopLoss()', () => {
+    it('returns an order ID when the trigger is below market price', async () => {
+      mockOraclePrice(1_000_0000n); // current price > trigger (900_0000)
+      mockSubmitSuccess();
+
+      const id = await stopLoss.createStopLoss(makeParams(), mockSigner);
+
+      expect(id).toBe(TEST_TX_HASH);
+      expect(mockSigner.publicKey).toHaveBeenCalled();
+    });
+
+    it('rejects a trigger price at or above the current market price', async () => {
+      mockOraclePrice(900_0000n); // equal to trigger
+
+      await expect(
+        stopLoss.createStopLoss(makeParams(), mockSigner),
+      ).rejects.toThrow('triggerPrice must be below the current market price');
+    });
+
+    it('rejects a trigger price above the current market price', async () => {
+      mockOraclePrice(800_0000n); // below trigger of 900_0000
+
+      await expect(
+        stopLoss.createStopLoss(makeParams(), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError for an invalid tokenIn address', async () => {
+      await expect(
+        stopLoss.createStopLoss(
+          makeParams({ tokenIn: 'not-an-address' }),
+          mockSigner,
+        ),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when tokenIn and tokenOut are identical', async () => {
+      await expect(
+        stopLoss.createStopLoss(
+          makeParams({ tokenOut: TOKEN_IN }),
+          mockSigner,
+        ),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when the amount is zero', async () => {
+      await expect(
+        stopLoss.createStopLoss(makeParams({ amount: 0n }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when the trigger price is zero', async () => {
+      await expect(
+        stopLoss.createStopLoss(makeParams({ triggerPrice: 0n }), mockSigner),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when the oracle asset is empty', async () => {
+      await expect(
+        stopLoss.createStopLoss(makeParams({ oracleAsset: '' }), mockSigner),
+      ).rejects.toThrow('oracleAsset must not be empty');
+    });
+
+    it('throws TransactionError when submitTransaction reports failure', async () => {
+      mockOraclePrice(1_000_0000n);
+      jest.spyOn(client, 'submitTransaction').mockResolvedValue({
+        success: false,
+        error: { code: 'TX_FAILED', message: 'Escrow transfer failed' },
+      });
+
+      await expect(
+        stopLoss.createStopLoss(makeParams(), mockSigner),
+      ).rejects.toThrow(TransactionError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getStopLoss()
+  // -------------------------------------------------------------------------
+
+  describe('getStopLoss()', () => {
+    it('reports triggered=false while price is above the trigger', async () => {
+      const spy = jest.spyOn(client, 'simulateTransaction');
+      // First call: get_order; second call: get_price
+      spy.mockResolvedValueOnce(makeSimResult(makeOrderNative()));
+      spy.mockResolvedValueOnce(makeSimResult('10000000')); // 10_000_000 > 9_000_000
+
+      const order = await stopLoss.getStopLoss('order-1');
+
+      expect(order.id).toBe('order-1');
+      expect(order.triggerPrice).toBe(9_000_000n);
+      expect(order.currentPrice).toBe(10_000_000n);
+      expect(order.triggered).toBe(false);
+      expect(order.status).toBe('active');
+    });
+
+    it('reports triggered=true once price falls to the trigger', async () => {
+      const spy = jest.spyOn(client, 'simulateTransaction');
+      spy.mockResolvedValueOnce(makeSimResult(makeOrderNative()));
+      spy.mockResolvedValueOnce(makeSimResult('9000000')); // equal to trigger
+
+      const order = await stopLoss.getStopLoss('order-1');
+
+      expect(order.currentPrice).toBe(9_000_000n);
+      expect(order.triggered).toBe(true);
+    });
+
+    it('reports triggered=true when price falls below the trigger', async () => {
+      const spy = jest.spyOn(client, 'simulateTransaction');
+      spy.mockResolvedValueOnce(makeSimResult(makeOrderNative()));
+      spy.mockResolvedValueOnce(makeSimResult('8500000'));
+
+      const order = await stopLoss.getStopLoss('order-1');
+
+      expect(order.triggered).toBe(true);
+    });
+
+    it('throws ValidationError for an empty orderId', async () => {
+      await expect(stopLoss.getStopLoss('')).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError when the order does not exist', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValue(makeEmptySimResult());
+
+      await expect(stopLoss.getStopLoss('missing')).rejects.toThrow(
+        'Stop-loss order not found',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements three assigned SDK issues plus the one prerequisite they depend on. All work is additive, follows existing module/type/error patterns, and ships with mocked unit tests.

| Issue | What was added |
| --- | --- |
| **#154** | `FlashLoanModule.compareFees(pair, amount)` — flash-loan vs swap fee comparison |
| **#247** | `tests/dca.test.ts` — comprehensive `DCAModule` unit tests (28 cases) |
| **#248** | `src/modules/stop-loss.ts` — automated stop-loss orders with RedStone trigger detection |
| **#244** *(prerequisite)* | `src/modules/dca.ts` — the `DCAModule` that #247 tests |

### Why #244 is included
Issue #247 asks for unit tests of `DCAModule`, but that module did not yet exist in the repo — it is defined by the separate, currently-unassigned issue **#244**. Tests cannot pass against a non-existent module, and "all tests pass with `npm test`" is an explicit #247 acceptance criterion. The module is therefore included here as a minimal, spec-faithful prerequisite. **If the maintainer prefers #244 to land separately, that commit (`feat: add DCAModule…`) can be cherry-picked out and this PR rebased onto it.**

## #154 — Flash loan fee comparison
- `compareFees(pair, amount)` fetches the flash-loan `fee_bps` and the dynamic swap fee **in parallel**, reduces both to absolute amounts via `(amount * feeBps) / 10000n`, and returns `{ flashLoanFee, swapFee, cheaperOption: 'flashLoan' | 'swap' | 'equal' }`.
- Throws `ValidationError` for a zero/negative amount or invalid pair address.
- New type `FlashLoanFeeComparison`; tests cover flash-cheaper, swap-cheaper, equal, parallel-fetch, and validation cases.

## #247 — DCAModule tests
- `tests/dca.test.ts`, 28 mocked-RPC cases (no live network), covering:
  - `createDCA()` — valid creation, invalid/identical tokens, zero amount, sub-hour & non-integer intervals, interval/total **boundary** values, on-chain failure.
  - `getDCASchedule()` / `getDCASchedules()` — decode, `remainingCount` derivation, empty-address case.
  - `getDCAPerformance()` — positive/negative savings, zero-baseline.
  - `cancelDCA()` — refund math, double-cancel prevention, completed-schedule rejection.

## #248 — Stop-loss module
- `createStopLoss(params, signer)` reads the live price from a **RedStone** oracle contract and rejects a `triggerPrice` that is not strictly below current market price.
- `getStopLoss(orderId)` re-reads the feed and computes `triggered = currentPrice <= triggerPrice`.
- New types in `src/types/stop-loss.ts`; exported from `src/modules/index.ts`. Tests cover below/at/above-market boundaries, validation, and not-found handling.

## Verification
- `npm test` — **838 passed** locally (full suite).
- New/changed source files type-check clean under `tsc --noEmit` and pass `eslint`.

## ⚠️ Pre-existing CI failure (not caused by this PR)
CI is currently red, but **the failure is pre-existing and unrelated to these changes**:

- `main` has failed CI since commit `e8c9446` ("add TaxReportingModule"); the last green commit was `e583f36`.
- The `prepare` lifecycle hook runs `npm run build` (`tsc`) during `npm ci`, which fails on a pre-existing type error in `src/modules/tax-reporting.ts:210` (`TS2352`). CI therefore dies at dependency install and never reaches this PR's tests/lint.
- This PR does **not** touch `tax-reporting.ts`. Its own files type-check and lint cleanly, and the full suite passes locally.

A one-line fix (`return response.events as unknown as RawEvent[];`) would turn CI green, but it lives outside the scope of these three issues, so it has been deliberately left out. Happy to add it (or open a separate PR) if preferred.

## Notes
- Branch is based on current upstream `main`; all changes are additive (new files + appended barrel exports) to minimise merge-conflict risk.
- New on-chain modules (`DCAModule`, `StopLossModule`) take their contract addresses via constructor, matching the existing `GovernanceModule` pattern.

Closes #154
Closes #247
Closes #248
