### PR TITLE
docs: Add architectural decision records for module design

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ Add the following secrets to your repository (Settings → Secrets → Actions):
 | `TEST_TOKEN_A` | Testnet token A contract address |
 | `TEST_TOKEN_B` | Testnet token B contract address |
 
+## Architecture Decision Records
+
+- [ADR-001 Module Boundary Decisions](docs/adr/ADR-001-module-boundaries.md)
+- [ADR-002 Error Handling Strategy](docs/adr/ADR-002-error-handling.md)
+- [ADR-003 Caching Approach](docs/adr/ADR-003-caching-approach.md)
+
 ## License
 
 MIT

--- a/docs/adr/ADR-001-module-boundaries.md
+++ b/docs/adr/ADR-001-module-boundaries.md
@@ -1,0 +1,45 @@
+# Module Boundary Decisions
+
+- **Date**: 2026-06-29
+- **Status**: Accepted
+
+## Context
+
+The CoralSwap SDK is split into separate domain modules under `src/modules/` rather than exposing all functionality through a single monolithic class. Each module encapsulates the client logic for a specific CoralSwap protocol feature, and types are co-located in `src/types/`.
+
+The three modules covered by this decision are:
+
+- **Governance** (`src/modules/governance.ts`, `src/types/governance.ts`) — proposal creation, voting (`for`/`against`/`abstain`), LP-token delegation, and proposal history queries.
+- **Staking** (`src/modules/staking.ts`, `src/types/staking.ts`) — LP token staking for governance weight, reward accrual and claiming, cooldown-based unstaking, and APY queries.
+- **Treasury** (`src/modules/treasury.ts`, `src/types/treasury.ts`) — protocol treasury balance and allocation views, fee revenue tracking across all pools, and USD valuation via on-chain spot prices.
+
+Each module depends on `CoralSwapClient` for RPC access but is otherwise self-contained: it maintains its own contract address, validates its own inputs, and defines its own error handling.
+
+## Decision
+
+Each protocol concern is isolated in its own module class with a focused API surface rather than lumping all methods into a single client or scattering them across ad-hoc functions.
+
+1. **GovernanceModule** — accepts a `CoralSwapClient` and a governance contract address. Exposes `createProposal`, `castVote`, `delegate`, `undelegate`, `getProposal`, `getActiveProposals`, `getProposalHistory`, and `getDelegationState`.
+2. **StakingModule** — accepts a `CoralSwapClient`. Exposes `stake`, `unstake`, `claimRewards`, `getStakedBalance`, `getStakingAPY`, `getStakingRewards`, and `getCooldownStatus`.
+3. **TreasuryModule** — accepts a `CoralSwapClient` and optional `TreasuryModuleOptions` (stablecoin addresses for USD pricing). Exposes `getTreasuryAddress`, `getTreasuryBalance`, `getTreasuryAllocation`, and `getFeeRevenue`.
+
+This separation solves the following problems:
+
+- **Cohesion**: Related operations (e.g., all voting-related methods) live together instead of being spread across namespaces.
+- **Independent versioning & testing**: Each module can be unit-tested in isolation by mocking `CoralSwapClient`.
+- **Tree-shakeability**: Consumers import only the modules they need rather than pulling in the entire SDK surface.
+- **Clear ownership**: Each module has well-defined inputs and outputs, making it straightforward to audit, extend, or replace.
+
+## Consequences
+
+### Positive
+
+- Modules are easier to maintain because each file stays focused on one domain.
+- Testing is simpler — each module simulates its own contract calls and validates its own arguments without coupling to unrelated features.
+- Extending the SDK (e.g., adding a new module) follows a predictable pattern: create `src/modules/new-feature.ts`, define types in `src/types/new-feature.ts`, and export from `src/modules/index.ts`.
+
+### Negative
+
+- Cross-module concerns (e.g., staking affects governance voting power) are not automatically coordinated — callers must orchestrate inter-module workflows themselves.
+- The `CoralSwapClient` dependency is injected manually into each module constructor, which adds boilerplate compared to a single all-in-one client.
+- Module discovery is implicit — consumers must know which module class to import rather than calling methods on a unified API object.

--- a/docs/adr/ADR-002-error-handling.md
+++ b/docs/adr/ADR-002-error-handling.md
@@ -1,0 +1,67 @@
+# Error Handling Strategy
+
+- **Date**: 2026-06-29
+- **Status**: Accepted
+
+## Context
+
+The CoralSwap SDK interacts with Soroban RPC endpoints, submits transactions, and parses contract return values — each of which can fail in distinct ways. Without a consistent error strategy, callers would face a mix of raw `Error` instances, opaque RPC strings, and untyped contract error codes, making it impossible to handle failures programmatically.
+
+Specific problems addressed:
+
+- Soroban contracts return numerical error codes (`Error(Contract, #101)`) that are meaningless without context.
+- RPC failures (timeouts, rate limits, connection resets) are structurally different from contract logic errors.
+- Module-specific failures (e.g., staking cooldown not elapsed) need distinct types so callers can react appropriately.
+
+## Decision
+
+All SDK errors inherit from a base `CoralSwapSDKError` class that carries a machine-readable `code` string, a human-readable `message`, and optional structured `details` (`src/errors.ts:13-28`).
+
+**Typed error hierarchy** — 19 error types each with a unique `code`:
+
+| Error class              | Code                      | Usage                                                     |
+|--------------------------|---------------------------|-----------------------------------------------------------|
+| `CoralSwapSDKError`      | `UNKNOWN_ERROR`           | Catch-all fallback                                        |
+| `NetworkError`           | `NETWORK_ERROR`           | Connection resets, DNS failures                           |
+| `RpcError`               | `RPC_ERROR`               | Rate limits, 429 responses                                |
+| `SimulationError`        | `SIMULATION_ERROR`        | Soroban simulation failures                               |
+| `TransactionError`       | `TRANSACTION_ERROR`       | Failed tx submission (carries `txHash`)                   |
+| `DeadlineError`          | `DEADLINE_EXCEEDED`       | Transaction deadline expired                              |
+| `SlippageError`          | `SLIPPAGE_EXCEEDED`       | Price movement beyond tolerance                           |
+| `InsufficientLiquidityError` | `INSUFFICIENT_LIQUIDITY` | Pool lacks liquidity                                  |
+| `PairNotFoundError`      | `PAIR_NOT_FOUND`          | Token pair not registered                                 |
+| `ValidationError`        | `VALIDATION_ERROR`        | Invalid inputs (empty strings, bad addresses, zero amounts) |
+| `FlashLoanError`         | `FLASH_LOAN_ERROR`        | Flash loan general failure                                |
+| `FlashLoanFailedError`   | — (extends `FlashLoanError`) | On-chain flash loan callback failure                  |
+| `CircuitBreakerError`    | `CIRCUIT_BREAKER`         | Pool is paused                                            |
+| `PriceDeviationError`    | `PRICE_DEVIATION_TOO_HIGH`| Oracle price deviation exceeds threshold                 |
+| `StaleOracleError`       | `STALE_ORACLE_PAYLOAD`    | RedStone payload too old                                  |
+| `SignerError`            | `NO_SIGNER`               | No signing key configured                                 |
+| `OrderNotFoundError`     | `ORDER_NOT_FOUND`         | Order missing or cancelled                                |
+| `InvalidOperationError`  | `INVALID_OPERATION`       | Illegal action on an order                                |
+| `StakingError`           | `STAKING_ERROR`           | Staking-specific failures (no rewards, over-unstake)      |
+| `CooldownError`          | `COOLDOWN_ERROR`          | Staking cooldown not yet elapsed                          |
+
+**Error classification flow** (`mapError`, `src/errors.ts:419-563`):
+
+1. If the error is already a `CoralSwapSDKError`, pass through.
+2. Extract a Soroban contract error code via `ErrorParser.extractErrorCode` (`src/errors/parser.ts:76-87`), then map it via `mapContractError` to the appropriate SDK error type.
+3. Fall back to regex-based detection on the error message string (e.g., `"deadline"` → `DeadlineError`, `"slippage"` → `SlippageError`).
+4. If no pattern matches, wrap in `CoralSwapSDKError` with code `UNKNOWN_ERROR`.
+
+Each module validates its own inputs and throws `ValidationError` with context. Transaction failures are uniformly wrapped in `TransactionError` with the transaction hash attached for debugging.
+
+## Consequences
+
+### Positive
+
+- **Predictable error shapes** — every error has `.code`, `.message`, and `.details`, enabling structured logging and programmatic handling.
+- **Easier debugging** — `TransactionError` carries `txHash`, `ValidationError` carries the offending field, and contract error codes are translated to human-readable messages via `ErrorParser`.
+- **Safe error mapping** — `mapError` converts any thrown value into a typed error, so try/catch boundaries always receive a known type.
+- **Module-specific errors** — `StakingError` / `CooldownError` let staking callers distinguish "no rewards" from "cooldown active" without parsing strings.
+
+### Negative
+
+- **Code duplication** — each module repeats the same input-validation → `TransactionError` pattern. A future refactor could extract a base module class.
+- **String-based fallback** — the regex detection in `mapError` is fragile; a new RPC response format that changes wording could produce incorrect error mappings until the patterns are updated.
+- **Error count grows linearly with features** — every new module that introduces a unique failure mode adds a new error class, increasing the surface area callers must handle.

--- a/docs/adr/ADR-003-caching-approach.md
+++ b/docs/adr/ADR-003-caching-approach.md
@@ -1,0 +1,57 @@
+# Caching Approach
+
+- **Date**: 2026-06-29
+- **Status**: Accepted
+
+## Context
+
+The CoralSwap SDK makes frequent on-chain calls to Soroban contracts for pair lookups, pathfinding, TWAP observations, and LP token addresses. Without caching, every operation would require one or more RPC round-trips, increasing latency and hitting rate limits on public Soroban RPC endpoints.
+
+The data that benefits most from caching falls into three categories:
+
+- **Semi-static references** — pair contract addresses (change rarely, only when a new pair is created).
+- **Expensive computation results** — optimal swap paths (require building a token graph from all pairs and simulating multiple routes).
+- **Stable addresses** — LP token contract addresses (assigned once at pair creation and never change).
+
+## Decision
+
+Three caching strategies are used across the SDK, each appropriate to the data's volatility:
+
+**1. TTL-based cache** (`FactoryModule`, `RouterModule`)
+
+Entries are stored in an in-memory `Map<string, CacheEntry>` where each entry carries an `expiresAt` wall-clock timestamp. A lookup returns the cached value if `Date.now() < expiresAt`, otherwise it fetches fresh data and replaces the entry.
+
+- `FactoryModule` — caches `(tokenA, tokenB) → pairAddress` mappings with a default TTL of 60 seconds (`DEFAULT_CACHE_TTL_MS = 60_000`, `src/modules/factory.ts:7`). TTL is configurable via the constructor. Also exposes `preLoadPairs()` for seeding known pairs and `bypassCache` per-lookup.
+- `RouterModule` — caches `(tokenIn, tokenOut, tradeType, amount) → OptimalPath` with a default TTL of 30 seconds (`DEFAULT_CACHE_TTL_MS = 30_000`, `src/modules/router.ts:17`). Shorter TTL because path optimality depends on current reserves.
+
+**2. Write-once cache** (`LiquidityModule`, `PositionsModule`)
+
+LP token addresses are fetched once and stored indefinitely (`Map<string, string>`). These addresses are immutable after pair creation so no expiry is needed (`src/modules/liquidity.ts:28`, `src/modules/positions.ts:17`).
+
+**3. In-memory observation buffer** (`OracleModule`)
+
+TWAP observations are accumulated per pair in a `Map<string, TWAPObservation[]>` without a TTL. Callers explicitly `clearCache(pairAddress?)` when they want to reset (`src/modules/oracle.ts:37,193-198`).
+
+**Cache invalidation triggers:**
+
+| Trigger | Effect |
+|---|---|
+| `CoralSwapClient.setNetwork()` | Clears the `FactoryModule` cache and the public key cache (`src/client.ts:322-324`) |
+| `FactoryModule.invalidateCache(pairAddress?)` | Removes one pair or the entire pair-address cache |
+| `FactoryModule.clearCache()` | Alias for full invalidation |
+| `RouterModule.clearPathCache()` | Clears all cached optimal paths |
+| `OracleModule.clearCache(pairAddress?)` | Clears observations per pair or all pairs |
+
+## Consequences
+
+### Positive
+
+- **Reduced RPC calls** — repeated pair-address lookups during the same 60-second window hit the in-memory cache instead of the network. For apps that query many tokens (e.g., a portfolio view), this cuts latency dramatically.
+- **Better UX** — pathfinding results are cached for 30 seconds, so repeated swap quote requests with the same parameters return instantly.
+- **Low-overhead cache miss** — the cost of a cache miss is a single `Date.now()` comparison plus one contract call, so there is no complex bookkeeping.
+
+### Negative
+
+- **Stale data risk** — a new pair created on-chain is invisible to the factory cache for up to 60 seconds. Mitigated by `bypassCache: true` for callers that need immediate consistency, and `invalidateCache()` for explicit busting.
+- **No cross-tab or persistence** — all caches are in-memory `Map` instances, so they are lost on page refresh (in browser) or process restart (in Node). Acceptable for an SDK that is typically long-lived within a single session.
+- **Unbounded oracle cache** — `OracleModule.observationCache` grows monotonically unless callers call `clearCache()`. A future improvement could cap entries per pair.


### PR DESCRIPTION
# Closes #316

Added docs/adr/ directory containing three ADRs
following the MADR format.

ADR-001-module-boundaries.md
- Documents why governance, staking and treasury
  are separate modules

ADR-002-error-handling.md
- Documents typed error strategy and
  cross-module error mapping

ADR-003-caching-approach.md
- Documents TTL-based caching and
  cache invalidation approach

Each ADR includes date, Status: Accepted,
Context, Decision and Consequences sections.

README.md updated with links to all three ADRs
under Architecture Decision Records section.