### PR TITLE
feat: add price alerts module with RedStone oracle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,10 @@ export {
 export type { OptimalPath } from "@/modules/router";
 export type { TWAPObservation, TWAPResult } from "@/modules";
 
+// Price alerts
+export { createPriceAlert, getPriceAlerts } from "@/modules/alerts";
+export type { PriceAlertParams, PriceAlert } from "@/modules/alerts";
+
 // Utilities
 export {
   toSorobanAmount,

--- a/src/modules/alerts.ts
+++ b/src/modules/alerts.ts
@@ -1,0 +1,150 @@
+import { ValidationError } from "@/errors";
+
+const REDSTONE_PRICE_URL =
+  "https://api.redstone.finance/prices?symbol={symbol}&provider=redstone";
+
+export interface PriceAlertParams {
+  tokenAddress: string;
+  /** Token symbol used for RedStone price lookup (e.g. "XLM", "USDC") */
+  tokenSymbol: string;
+  targetPriceUSD: number;
+  direction: "above" | "below";
+  pairAddress?: string;
+  label?: string;
+}
+
+export interface PriceAlert {
+  id: string;
+  tokenAddress: string;
+  tokenSymbol: string;
+  targetPriceUSD: number;
+  direction: "above" | "below";
+  pairAddress?: string;
+  label?: string;
+  triggered: boolean;
+  /** True while price is on the trigger side; resets when it crosses back */
+  armed: boolean;
+  createdAt: number;
+  lastCheckedAt: number | null;
+  lastPriceUSD: number | null;
+}
+
+/** In-memory store keyed by wallet address → alerts */
+const store = new Map<string, PriceAlert[]>();
+
+function generateId(): string {
+  return `alert_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+async function fetchPriceUSD(symbol: string): Promise<number> {
+  const url = REDSTONE_PRICE_URL.replace("{symbol}", encodeURIComponent(symbol));
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`RedStone price fetch failed for ${symbol}: ${res.status}`);
+  }
+  const data = (await res.json()) as { value: number }[];
+  if (!data?.length || typeof data[0].value !== "number") {
+    throw new Error(`No price data returned for ${symbol}`);
+  }
+  return data[0].value;
+}
+
+/**
+ * Create a price alert for a token.
+ *
+ * Alert triggers when `currentPrice` crosses `targetPriceUSD` in the specified
+ * `direction`. It will not re-trigger until the price crosses back and returns.
+ *
+ * @param walletAddress - Owner address used to scope alerts
+ * @param params - Alert configuration
+ * @returns The created PriceAlert
+ * @throws {ValidationError} If targetPriceUSD is not positive
+ */
+export async function createPriceAlert(
+  walletAddress: string,
+  params: PriceAlertParams,
+): Promise<PriceAlert> {
+  if (params.targetPriceUSD <= 0) {
+    throw new ValidationError("targetPriceUSD must be positive", {
+      targetPriceUSD: params.targetPriceUSD,
+    });
+  }
+  if (!params.tokenAddress) {
+    throw new ValidationError("tokenAddress must not be empty");
+  }
+  if (!params.tokenSymbol) {
+    throw new ValidationError("tokenSymbol must not be empty");
+  }
+
+  // Fetch current price to set initial armed state
+  const currentPrice = await fetchPriceUSD(params.tokenSymbol);
+  const alreadyOnTriggerSide =
+    params.direction === "above"
+      ? currentPrice > params.targetPriceUSD
+      : currentPrice < params.targetPriceUSD;
+
+  const alert: PriceAlert = {
+    id: generateId(),
+    tokenAddress: params.tokenAddress,
+    tokenSymbol: params.tokenSymbol,
+    targetPriceUSD: params.targetPriceUSD,
+    direction: params.direction,
+    pairAddress: params.pairAddress,
+    label: params.label,
+    triggered: false,
+    armed: !alreadyOnTriggerSide,
+    createdAt: Date.now(),
+    lastCheckedAt: Date.now(),
+    lastPriceUSD: currentPrice,
+  };
+
+  const existing = store.get(walletAddress) ?? [];
+  existing.push(alert);
+  store.set(walletAddress, existing);
+
+  return alert;
+}
+
+/**
+ * Get all active (non-triggered) price alerts for a wallet address,
+ * refreshing their state against the current RedStone price.
+ *
+ * @param walletAddress - Owner address
+ * @returns Array of current PriceAlert objects
+ */
+export async function getPriceAlerts(
+  walletAddress: string,
+): Promise<PriceAlert[]> {
+  const alerts = store.get(walletAddress);
+  if (!alerts?.length) return [];
+
+  // Group by symbol to minimise fetch calls
+  const symbols = [...new Set(alerts.map((a) => a.tokenSymbol))];
+  const prices = new Map<string, number>();
+  await Promise.all(
+    symbols.map(async (sym) => {
+      prices.set(sym, await fetchPriceUSD(sym));
+    }),
+  );
+
+  for (const alert of alerts) {
+    const price = prices.get(alert.tokenSymbol)!;
+    alert.lastCheckedAt = Date.now();
+    alert.lastPriceUSD = price;
+
+    const onTriggerSide =
+      alert.direction === "above"
+        ? price > alert.targetPriceUSD
+        : price < alert.targetPriceUSD;
+
+    if (alert.armed && onTriggerSide) {
+      alert.triggered = true;
+      alert.armed = false; // disarm until price crosses back
+    } else if (!alert.armed && !onTriggerSide) {
+      // Price crossed back -- re-arm so it can trigger again
+      alert.armed = true;
+    }
+  }
+
+  return alerts;
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -7,3 +7,5 @@ export { TokenListModule } from './tokens';
 export { FactoryModule } from './factory';
 export { RouterModule } from './router';
 export { GovernanceModule } from './governance';
+export { createPriceAlert, getPriceAlerts } from './alerts';
+export type { PriceAlertParams, PriceAlert } from './alerts';

--- a/tests/alerts.test.ts
+++ b/tests/alerts.test.ts
@@ -1,0 +1,241 @@
+import { createPriceAlert, getPriceAlerts } from '../src/modules/alerts';
+import { ValidationError } from '../src/errors';
+
+const WALLET = 'GABC123WALLET';
+const TOKEN = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2ZCMJ';
+
+function mockFetch(price: number) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [{ value: price }],
+  } as any);
+}
+
+beforeEach(() => {
+  // Reset in-memory store between tests by re-importing is not needed;
+  // use unique wallet addresses per test to isolate state.
+  jest.restoreAllMocks();
+});
+
+describe('createPriceAlert', () => {
+  it('creates an alert and returns it with correct fields', async () => {
+    mockFetch(1.5);
+    const alert = await createPriceAlert(`${WALLET}_create`, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 2.0,
+      direction: 'above',
+      label: 'XLM moon',
+    });
+
+    expect(alert.tokenAddress).toBe(TOKEN);
+    expect(alert.tokenSymbol).toBe('XLM');
+    expect(alert.targetPriceUSD).toBe(2.0);
+    expect(alert.direction).toBe('above');
+    expect(alert.label).toBe('XLM moon');
+    expect(alert.triggered).toBe(false);
+    expect(alert.id).toMatch(/^alert_/);
+  });
+
+  it('throws ValidationError when targetPriceUSD is zero', async () => {
+    await expect(
+      createPriceAlert(`${WALLET}_zero`, {
+        tokenAddress: TOKEN,
+        tokenSymbol: 'XLM',
+        targetPriceUSD: 0,
+        direction: 'above',
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('throws ValidationError when targetPriceUSD is negative', async () => {
+    await expect(
+      createPriceAlert(`${WALLET}_neg`, {
+        tokenAddress: TOKEN,
+        tokenSymbol: 'XLM',
+        targetPriceUSD: -5,
+        direction: 'above',
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('accepts optional label and pairAddress', async () => {
+    mockFetch(1.0);
+    const alert = await createPriceAlert(`${WALLET}_opts`, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 0.5,
+      direction: 'below',
+      pairAddress: 'CPAIR123',
+      label: 'stop loss',
+    });
+    expect(alert.pairAddress).toBe('CPAIR123');
+    expect(alert.label).toBe('stop loss');
+  });
+
+  it('label is optional -- undefined when not provided', async () => {
+    mockFetch(1.0);
+    const alert = await createPriceAlert(`${WALLET}_nolabel`, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 5.0,
+      direction: 'above',
+    });
+    expect(alert.label).toBeUndefined();
+  });
+
+  describe('initial armed state', () => {
+    it('starts armed (not triggered) when price is below target for "above" alert', async () => {
+      mockFetch(1.0); // price < 2.0 target
+      const alert = await createPriceAlert(`${WALLET}_armed_above`, {
+        tokenAddress: TOKEN,
+        tokenSymbol: 'XLM',
+        targetPriceUSD: 2.0,
+        direction: 'above',
+      });
+      expect(alert.armed).toBe(true);
+      expect(alert.triggered).toBe(false);
+    });
+
+    it('starts disarmed when price is already above target for "above" alert', async () => {
+      mockFetch(3.0); // price > 2.0 target
+      const alert = await createPriceAlert(`${WALLET}_disarmed_above`, {
+        tokenAddress: TOKEN,
+        tokenSymbol: 'XLM',
+        targetPriceUSD: 2.0,
+        direction: 'above',
+      });
+      expect(alert.armed).toBe(false);
+    });
+
+    it('starts armed when price is above target for "below" alert', async () => {
+      mockFetch(3.0); // price > 2.0 target → not on trigger side
+      const alert = await createPriceAlert(`${WALLET}_armed_below`, {
+        tokenAddress: TOKEN,
+        tokenSymbol: 'XLM',
+        targetPriceUSD: 2.0,
+        direction: 'below',
+      });
+      expect(alert.armed).toBe(true);
+    });
+  });
+});
+
+describe('getPriceAlerts', () => {
+  it('returns empty array when no alerts exist', async () => {
+    const alerts = await getPriceAlerts(`${WALLET}_empty`);
+    expect(alerts).toEqual([]);
+  });
+
+  it('triggers alert when price crosses above target', async () => {
+    const wallet = `${WALLET}_trigger_above`;
+    mockFetch(1.0);
+    await createPriceAlert(wallet, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 2.0,
+      direction: 'above',
+    });
+
+    // Price crosses above threshold
+    mockFetch(3.0);
+    const alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].triggered).toBe(true);
+    expect(alerts[0].armed).toBe(false);
+  });
+
+  it('triggers alert when price crosses below target', async () => {
+    const wallet = `${WALLET}_trigger_below`;
+    mockFetch(5.0);
+    await createPriceAlert(wallet, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 2.0,
+      direction: 'below',
+    });
+
+    mockFetch(1.0);
+    const alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].triggered).toBe(true);
+  });
+
+  it('does not re-trigger until price crosses back and returns', async () => {
+    const wallet = `${WALLET}_no_retrigger`;
+    mockFetch(1.0);
+    await createPriceAlert(wallet, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 2.0,
+      direction: 'above',
+    });
+
+    // First cross — triggers
+    mockFetch(3.0);
+    let alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].triggered).toBe(true);
+    expect(alerts[0].armed).toBe(false);
+
+    // Still above — no re-trigger, remains triggered & disarmed
+    mockFetch(4.0);
+    alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].triggered).toBe(true);
+    expect(alerts[0].armed).toBe(false);
+
+    // Drops back below — re-arms
+    mockFetch(1.5);
+    alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].armed).toBe(true);
+
+    // Crosses above again — re-triggers
+    mockFetch(3.5);
+    alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].triggered).toBe(true);
+    expect(alerts[0].armed).toBe(false);
+  });
+
+  it('does not trigger when price stays on the safe side', async () => {
+    const wallet = `${WALLET}_no_trigger`;
+    mockFetch(1.0);
+    await createPriceAlert(wallet, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 2.0,
+      direction: 'above',
+    });
+
+    mockFetch(1.8); // still below target
+    const alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].triggered).toBe(false);
+    expect(alerts[0].armed).toBe(true);
+  });
+
+  it('updates lastCheckedAt and lastPriceUSD on each check', async () => {
+    const wallet = `${WALLET}_meta`;
+    mockFetch(1.0);
+    const created = await createPriceAlert(wallet, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 5.0,
+      direction: 'above',
+    });
+
+    mockFetch(1.2);
+    const alerts = await getPriceAlerts(wallet);
+    expect(alerts[0].lastPriceUSD).toBe(1.2);
+    expect(alerts[0].lastCheckedAt).toBeGreaterThanOrEqual(created.createdAt);
+  });
+
+  it('throws when RedStone fetch fails', async () => {
+    const wallet = `${WALLET}_fetch_fail`;
+    mockFetch(1.0);
+    await createPriceAlert(wallet, {
+      tokenAddress: TOKEN,
+      tokenSymbol: 'XLM',
+      targetPriceUSD: 2.0,
+      direction: 'above',
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 } as any);
+    await expect(getPriceAlerts(wallet)).rejects.toThrow('RedStone price fetch failed');
+  });
+});


### PR DESCRIPTION
- Add createPriceAlert/getPriceAlerts to src/modules/alerts.ts
- PriceAlertParams supports tokenAddress, tokenSymbol, targetPriceUSD, direction (above/below), optional pairAddress and label
- Alert arms on creation, triggers on threshold crossing, disarms to prevent re-triggering until price crosses back
- Export PriceAlertParams, PriceAlert, createPriceAlert, getPriceAlerts from modules/index.ts and src/index.ts
- 15 tests covering creation, validation, triggering, re-arm logic

Closes #273

## Summary

Brief description of what this PR does.

## Related Issue

Closes #

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality
- [ ] No `any` types introduced

## Checklist

- [ ] Code follows project coding standards
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript compiles)
- [ ] `npm test` passes
- [ ] Public functions have JSDoc comments
- [ ] Commit messages follow conventional format
- [ ] No unrelated changes included
- [ ] Uses typed errors from `src/errors.ts` (no raw `Error` throws)
