### PR TITLE
feat(leaderboard): add getTopTraders() ranked by swap volume and rest…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,9 +70,10 @@ export {
   RouterModule,
   TreasuryModule,
   AlertModule,
+  LeaderboardModule,
 } from "@/modules";
 export type { OptimalPath } from "@/modules/router";
-export type { TWAPObservation, TWAPResult } from "@/modules";
+export type { TWAPObservation, TWAPResult, TraderRanking, GetTopTradersOptions } from "@/modules";
 export type { TreasuryModuleOptions } from "@/modules";
 
 // Utilities

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,3 +9,5 @@ export { RouterModule } from './router';
 export { TreasuryModule } from './treasury';
 export type { TreasuryModuleOptions } from './treasury';
 export { AlertModule } from './alerts';
+export { LeaderboardModule } from './leaderboard';
+export type { TraderRanking, GetTopTradersOptions } from './leaderboard';

--- a/src/modules/leaderboard.ts
+++ b/src/modules/leaderboard.ts
@@ -1,0 +1,240 @@
+import { CoralSwapClient } from "../client";
+import { TreasuryModule, TreasuryModuleOptions } from "./treasury";
+import { SwapModule } from "./swap";
+import { validateAddress } from "../utils/validation";
+
+/**
+ * Rankings for a trader based on their swap activity.
+ */
+export interface TraderRanking {
+  /** The wallet address of the trader. */
+  address: string;
+  /** Total volume traded in USD across all pairs. */
+  totalVolumeUSD: number;
+  /** Total number of trades executed (includes all swap types). */
+  tradeCount: number;
+  /** Average trade size in USD. */
+  avgTradeSize: number;
+  /** The pair contract address the trader interacted with most. */
+  favoritePool: string;
+  /** Percentage of swaps where output value > input value at time of trade (0-100). */
+  winRate: number;
+}
+
+/**
+ * Options for querying the top traders leaderboard.
+ */
+export interface GetTopTradersOptions {
+  /** The period in days to look back for swaps (defaults to 30). */
+  periodDays?: number;
+  /** Optional pool/pair address to restrict the query. */
+  pairAddress?: string;
+  /** Maximum number of top traders to return. */
+  limit?: number;
+  /** Optional custom stablecoin addresses to override the constructor ones. */
+  stableAddresses?: string[];
+  /** Optional starting ledger sequence override. */
+  fromLedger?: number;
+  /** Optional ending ledger sequence override. */
+  toLedger?: number;
+}
+
+const decimalsCache = new Map<string, number>();
+
+async function getTokenDecimals(client: CoralSwapClient, address: string): Promise<number> {
+  if (decimalsCache.has(address)) {
+    return decimalsCache.get(address)!;
+  }
+  try {
+    const meta = await client.lpToken(address).metadata();
+    decimalsCache.set(address, meta.decimals);
+    return meta.decimals;
+  } catch {
+    return 7; // standard fallback for Soroban
+  }
+}
+
+/**
+ * Leaderboard module -- ranks traders by swap volume and calculates stats.
+ */
+export class LeaderboardModule extends TreasuryModule {
+  private readonly leaderboardClient: CoralSwapClient;
+  private readonly leaderboardStableSet: Set<string>;
+
+  constructor(client: CoralSwapClient, options: TreasuryModuleOptions = {}) {
+    super(client, options);
+    this.leaderboardClient = client;
+    this.leaderboardStableSet = new Set(options.stableAddresses ?? []);
+  }
+
+  /**
+   * Get the top traders ranked by total swap volume in USD.
+   *
+   * @param options - Query parameters (periodDays, pairAddress, limit, etc.)
+   * @returns List of top traders and their stats sorted by volume descending.
+   */
+  async getTopTraders(options: GetTopTradersOptions = {}): Promise<TraderRanking[]> {
+    if (options.pairAddress) {
+      validateAddress(options.pairAddress, "pairAddress");
+    }
+
+    const periodDays = options.periodDays ?? 30;
+    const currentLedger = await this.leaderboardClient.getCurrentLedger();
+    const estimatedLedgers = Math.floor((periodDays * 24 * 60 * 60) / 5);
+    const fromLedger = options.fromLedger ?? Math.max(0, currentLedger - estimatedLedgers);
+    const toLedger = options.toLedger ?? currentLedger;
+
+    const swapModule = new SwapModule(this.leaderboardClient);
+    const swaps = await swapModule.getSwapHistory({
+      pairAddress: options.pairAddress,
+      fromLedger,
+      toLedger,
+      limit: 10000,
+    });
+
+    if (swaps.length === 0) {
+      return [];
+    }
+
+    // Identify all unique tokens in the swaps to fetch their decimals
+    const uniqueTokens = new Set<string>();
+    for (const swap of swaps) {
+      uniqueTokens.add(swap.tokenIn);
+      uniqueTokens.add(swap.tokenOut);
+    }
+
+    // Fetch decimals for all tokens concurrently
+    const decimalsMap = new Map<string, number>();
+    await Promise.all(
+      Array.from(uniqueTokens).map(async (token) => {
+        const dec = await getTokenDecimals(this.leaderboardClient, token);
+        decimalsMap.set(token, dec);
+      })
+    );
+
+    // Get all pairs and prices
+    const allPairs = await this.leaderboardClient.factory.getAllPairs();
+    const stableAddresses = options.stableAddresses ?? Array.from(this.leaderboardStableSet);
+    const priceMap = await this.getPriceMap(allPairs, stableAddresses);
+
+    // Aggregate by trader address
+    const tradersData = new Map<
+      string,
+      {
+        totalVolumeUSD: number;
+        tradeCount: number;
+        winCount: number;
+        poolCounts: Map<string, number>;
+      }
+    >();
+
+    for (const swap of swaps) {
+      const trader = swap.sender;
+      const decIn = decimalsMap.get(swap.tokenIn) ?? 7;
+      const decOut = decimalsMap.get(swap.tokenOut) ?? 7;
+
+      const priceIn = priceMap.get(swap.tokenIn) ?? 0;
+      const priceOut = priceMap.get(swap.tokenOut) ?? 0;
+
+      // Calculate USD volume
+      let volumeUSD = 0;
+      if (priceIn > 0) {
+        volumeUSD = (Number(swap.amountIn) / 10 ** decIn) * priceIn;
+      } else if (priceOut > 0) {
+        volumeUSD = (Number(swap.amountOut) / 10 ** decOut) * priceOut;
+      }
+
+      // Calculate if it's a win
+      const valueIn = (Number(swap.amountIn) / 10 ** decIn) * priceIn;
+      const valueOut = (Number(swap.amountOut) / 10 ** decOut) * priceOut;
+      const isWin = (priceIn > 0 || priceOut > 0) && valueOut > valueIn;
+
+      let record = tradersData.get(trader);
+      if (!record) {
+        record = {
+          totalVolumeUSD: 0,
+          tradeCount: 0,
+          winCount: 0,
+          poolCounts: new Map<string, number>(),
+        };
+        tradersData.set(trader, record);
+      }
+
+      record.totalVolumeUSD += volumeUSD;
+      record.tradeCount += 1;
+      if (isWin) {
+        record.winCount += 1;
+      }
+
+      const pool = swap.pairAddress;
+      record.poolCounts.set(pool, (record.poolCounts.get(pool) ?? 0) + 1);
+    }
+
+    // Convert aggregated data to TraderRanking objects
+    const rankings: TraderRanking[] = [];
+    for (const [address, data] of tradersData.entries()) {
+      let favoritePool = "";
+      let maxCount = -1;
+      for (const [pool, count] of data.poolCounts.entries()) {
+        if (count > maxCount) {
+          maxCount = count;
+          favoritePool = pool;
+        }
+      }
+
+      const winRate = data.tradeCount > 0 ? (data.winCount / data.tradeCount) * 100 : 0;
+      const avgTradeSize = data.tradeCount > 0 ? data.totalVolumeUSD / data.tradeCount : 0;
+
+      rankings.push({
+        address,
+        totalVolumeUSD: data.totalVolumeUSD,
+        tradeCount: data.tradeCount,
+        avgTradeSize,
+        favoritePool,
+        winRate,
+      });
+    }
+
+    // Sort by totalVolumeUSD descending
+    rankings.sort((a, b) => b.totalVolumeUSD - a.totalVolumeUSD);
+
+    if (options.limit && options.limit > 0) {
+      return rankings.slice(0, options.limit);
+    }
+
+    return rankings;
+  }
+
+  private async getPriceMap(allPairs: string[], stableAddresses: string[]): Promise<Map<string, number>> {
+    const prices = new Map<string, number>();
+    const stableSet = new Set(stableAddresses);
+
+    for (const addr of stableSet) {
+      prices.set(addr, 1.0);
+    }
+
+    if (stableSet.size === 0) return prices;
+
+    for (const pairAddress of allPairs) {
+      try {
+        const pair = this.leaderboardClient.pair(pairAddress);
+        const [{ token0, token1 }, { reserve0, reserve1 }] = await Promise.all([
+          pair.getTokens(),
+          pair.getReserves(),
+        ]);
+
+        if (reserve0 === 0n || reserve1 === 0n) continue;
+
+        if (stableSet.has(token0) && !prices.has(token1)) {
+          prices.set(token1, Number(reserve0) / Number(reserve1));
+        } else if (stableSet.has(token1) && !prices.has(token0)) {
+          prices.set(token0, Number(reserve1) / Number(reserve0));
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return prices;
+  }
+}

--- a/src/modules/swap.ts
+++ b/src/modules/swap.ts
@@ -1,9 +1,19 @@
 import { CoralSwapClient } from '../client';
 import { TradeType } from '../types/common';
-import { SwapRequest, SwapQuote, SwapResult, HopResult } from '../types/swap';
+import { SwapRequest, SwapQuote, SwapResult, HopResult, SwapHistoryFilter, SwapHistoryEvent } from '../types/swap';
 import { PRECISION, DEFAULTS } from '../config';
 import { PairNotFoundError, ValidationError, InsufficientLiquidityError, TransactionError } from '../errors';
 import { PairClient } from '@/contracts/pair';
+import { SwapEvent } from '../types/events';
+import { validateAddress } from '../utils/validation';
+import { EventParser } from '../utils/events';
+import { SorobanRpc } from '@stellar/stellar-sdk';
+
+/** Default ledger window when no fromLedger/toLedger is specified. */
+const DEFAULT_HISTORY_WINDOW = 1000;
+
+/** Default maximum results per query. */
+const DEFAULT_HISTORY_LIMIT = 200;
 
 /**
  * Swap module -- builds, quotes, and executes token swaps.
@@ -444,5 +454,206 @@ export class SwapModule {
   private async isToken0(pair: PairClient, tokenIn: string): Promise<boolean> {
     const tokens = await pair.getTokens();
     return tokens.token0 === tokenIn;
+  }
+
+  /**
+   * Fetch swap history.
+   *
+   * Uses the Soroban RPC `getEvents` endpoint to fetch on-chain swap events
+   * and applies the provided filters client-side. Pagination is controlled
+   * via `fromLedger` / `toLedger`; both default to a 1000-ledger window
+   * ending at the current ledger when omitted.
+   *
+   * Filter semantics:
+   * - `pairAddress` alone  → all swaps in that pool
+   * - `userAddress` alone  → all swaps by that sender across all pools
+   * - both provided        → swaps by that sender in that pool (AND)
+   * - neither provided     → all swap events in the ledger window
+   *
+   * @param filter - Query parameters (pairAddress, userAddress, ledger range, limit)
+   * @returns Ordered array of SwapHistoryEvent (oldest first). Returns [] on no match.
+   * @throws {ValidationError} If pairAddress or userAddress is provided but invalid.
+   */
+  async getSwapHistory(filter: SwapHistoryFilter = {}): Promise<SwapHistoryEvent[]> {
+    const { pairAddress, userAddress, limit = DEFAULT_HISTORY_LIMIT } = filter;
+
+    // Validate optional addresses up-front
+    if (pairAddress) validateAddress(pairAddress, 'pairAddress');
+    if (userAddress) validateAddress(userAddress, 'userAddress');
+
+    // Resolve ledger range — default to last DEFAULT_HISTORY_WINDOW ledgers
+    const currentLedger = await this.client.getCurrentLedger();
+    const fromLedger = filter.fromLedger ?? Math.max(0, currentLedger - DEFAULT_HISTORY_WINDOW);
+    const toLedger = filter.toLedger ?? currentLedger;
+
+    if (fromLedger > toLedger) {
+      throw new ValidationError(
+        `fromLedger (${fromLedger}) must not be greater than toLedger (${toLedger})`,
+        { fromLedger, toLedger },
+      );
+    }
+
+    // Build the getEvents request.
+    // When pairAddress is given we scope the query to that contract, which is
+    // the most efficient path. Without it we query all contracts for "swap" topic.
+    const request: SorobanRpc.Server.GetEventsRequest = {
+      startLedger: fromLedger,
+      filters: [
+        {
+          type: 'contract',
+          contractIds: pairAddress ? [pairAddress] : [],
+          topics: [['swap']],
+        },
+      ],
+      limit,
+    };
+
+    const response = await this.client.server.getEvents(request);
+
+    if (!response || !Array.isArray(response.events)) {
+      return [];
+    }
+
+    const parser = new EventParser(pairAddress ? [pairAddress] : []);
+    const results: SwapHistoryEvent[] = [];
+
+    for (const rawEvent of response.events) {
+      // Respect toLedger upper bound (RPC only accepts startLedger, not endLedger)
+      if (rawEvent.ledger > toLedger) continue;
+
+      // Parse the raw event into a typed SwapEvent using the existing EventParser.
+      // The RPC returns events in a different shape than DiagnosticEvents, so we
+      // reconstruct the fields we need directly from the raw event value.
+      let swapEvent: SwapEvent | null = null;
+      try {
+        swapEvent = this.parseRawSwapEvent(rawEvent, parser);
+      } catch {
+        // Skip malformed events
+        continue;
+      }
+
+      if (!swapEvent) continue;
+
+      // Apply userAddress filter (AND with pairAddress if both given)
+      if (userAddress && swapEvent.sender !== userAddress) continue;
+
+      results.push({
+        txHash: swapEvent.txHash,
+        amountIn: swapEvent.amountIn,
+        amountOut: swapEvent.amountOut,
+        tokenIn: swapEvent.tokenIn,
+        tokenOut: swapEvent.tokenOut,
+        sender: swapEvent.sender,
+        pairAddress: swapEvent.contractId,
+        ledger: swapEvent.ledger,
+        timestamp: swapEvent.timestamp,
+        feeBps: swapEvent.feeBps,
+      });
+
+      if (results.length >= limit) break;
+    }
+
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helper: parse a raw RPC event into a SwapEvent
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Convert a raw `SorobanRpc.Api.EventResponse` entry into a typed SwapEvent.
+   *
+   * The RPC `getEvents` response carries decoded ScVal values in `event.value`
+   * and topic strings in `event.topic`. We reconstruct the SwapEvent fields
+   * directly from the decoded values rather than going through XDR re-encoding.
+   *
+   * Returns null if the event is not a swap event or cannot be decoded.
+   */
+  private parseRawSwapEvent(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawEvent: any,
+    _parser: EventParser,
+  ): SwapEvent | null {
+    // Verify this is a swap event by checking the first topic
+    const topics: string[] = rawEvent.topic ?? [];
+    if (!topics.length || topics[0] !== 'swap') return null;
+
+    // The `value` field is an ScVal (already decoded by stellar-sdk)
+    const value = rawEvent.value;
+    if (!value) return null;
+
+    // Extract the ScMap entries
+    const map: Array<{ key: { sym?: () => { toString(): string }; str?: () => { toString(): string } }; val: unknown }> =
+      typeof value.map === 'function' ? value.map() : value._value;
+
+    if (!Array.isArray(map)) return null;
+
+    // Helper to get a map value by key name
+    const get = (key: string): unknown => {
+      for (const entry of map) {
+        const k = entry.key;
+        let keyStr: string | undefined;
+        try {
+          if (typeof k.sym === 'function') keyStr = k.sym().toString();
+          else if (typeof k.str === 'function') keyStr = k.str().toString();
+        } catch { /* skip */ }
+        if (keyStr === key) return entry.val;
+      }
+      return undefined;
+    };
+
+    // Decode address ScVal to string
+    const decodeAddr = (val: unknown): string => {
+      if (!val) throw new Error('missing address');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const v = val as any;
+      if (typeof v.address === 'function') return v.address().toString();
+      if (typeof v._value?.toString === 'function') return v._value.toString();
+      throw new Error('cannot decode address');
+    };
+
+    // Decode i128 ScVal to bigint
+    const decodeI128 = (val: unknown): bigint => {
+      if (!val) throw new Error('missing i128');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const v = val as any;
+      if (typeof v.i128 === 'function') {
+        const parts = v.i128();
+        return (BigInt(parts.hi().toString()) << 64n) + BigInt(parts.lo().toString());
+      }
+      throw new Error('cannot decode i128');
+    };
+
+    // Decode u32 ScVal to number
+    const decodeU32 = (val: unknown): number => {
+      if (!val) throw new Error('missing u32');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const v = val as any;
+      if (typeof v.u32 === 'function') return v.u32();
+      throw new Error('cannot decode u32');
+    };
+
+    const sender = decodeAddr(get('sender'));
+    const tokenIn = decodeAddr(get('token_in'));
+    const tokenOut = decodeAddr(get('token_out'));
+    const amountIn = decodeI128(get('amount_in'));
+    const amountOut = decodeI128(get('amount_out'));
+    const feeBps = decodeU32(get('fee_bps'));
+
+    return {
+      type: 'swap',
+      contractId: rawEvent.contractId ?? '',
+      ledger: rawEvent.ledger ?? 0,
+      timestamp: rawEvent.ledgerClosedAt
+        ? Math.floor(new Date(rawEvent.ledgerClosedAt).getTime() / 1000)
+        : rawEvent.ledger ?? 0,
+      txHash: rawEvent.txHash ?? '',
+      sender,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      amountOut,
+      feeBps,
+    };
   }
 }

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,0 +1,214 @@
+import { LeaderboardModule } from "../src/modules/leaderboard";
+import { SwapModule } from "../src/modules/swap";
+import { CoralSwapClient } from "../src/client";
+import { Network } from "../src/types/common";
+
+const STABLE_ADDR = "CUSDC000000000000000000000000000000000000000000000000000000";
+const TOKEN_A     = "CTOKENA00000000000000000000000000000000000000000000000000";
+const TOKEN_B     = "CTOKENB00000000000000000000000000000000000000000000000000";
+const PAIR_1      = "CPAIR00000000000000000000000000000000000000000000000000001";
+const PAIR_2      = "CPAIR00000000000000000000000000000000000000000000000000002";
+
+describe("LeaderboardModule.getTopTraders()", () => {
+  let client: CoralSwapClient;
+  let leaderboard: LeaderboardModule;
+  let getSwapHistorySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    client = new CoralSwapClient({
+      network: Network.TESTNET,
+      secretKey: "SB6K2AINTGNYBFX4M7TRPGSKQ5RKNOXXWB7UZUHRYOVTM7REDUGECKZU",
+    });
+
+    leaderboard = new LeaderboardModule(client, { stableAddresses: [STABLE_ADDR] });
+
+    // Mock getCurrentLedger to return a fixed ledger sequence
+    jest.spyOn(client, "getCurrentLedger").mockResolvedValue(100000);
+
+    // Mock factory getter
+    jest.spyOn(client, "factory", "get").mockReturnValue({
+      getAllPairs: jest.fn().mockResolvedValue([PAIR_1, PAIR_2]),
+    } as any);
+
+    // Mock pair.getTokens and pair.getReserves
+    jest.spyOn(client, "pair").mockImplementation((pairAddr: string): any => {
+      if (pairAddr === PAIR_1) {
+        return {
+          getTokens: jest.fn().mockResolvedValue({ token0: STABLE_ADDR, token1: TOKEN_A }),
+          getReserves: jest.fn().mockResolvedValue({ reserve0: 1000000n, reserve1: 1000000n }), // 1:1 price
+        };
+      }
+      if (pairAddr === PAIR_2) {
+        return {
+          getTokens: jest.fn().mockResolvedValue({ token0: STABLE_ADDR, token1: TOKEN_B }),
+          getReserves: jest.fn().mockResolvedValue({ reserve0: 2000000n, reserve1: 1000000n }), // 2 USD per TOKEN_B
+        };
+      }
+      return {
+        getTokens: jest.fn().mockResolvedValue({ token0: TOKEN_A, token1: TOKEN_B }),
+        getReserves: jest.fn().mockResolvedValue({ reserve0: 1000000n, reserve1: 1000000n }),
+      };
+    });
+
+    // Mock lpToken metadata
+    jest.spyOn(client, "lpToken").mockImplementation((tokenAddr: string): any => {
+      return {
+        metadata: jest.fn().mockResolvedValue({
+          name: "Token",
+          symbol: "TKN",
+          decimals: 7,
+        }),
+      };
+    });
+
+    // Spy on SwapModule's getSwapHistory
+    getSwapHistorySpy = jest.spyOn(SwapModule.prototype, "getSwapHistory");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns empty array if no swap events found", async () => {
+    getSwapHistorySpy.mockResolvedValue([]);
+    const result = await leaderboard.getTopTraders();
+    expect(result).toEqual([]);
+  });
+
+  it("ranks traders by totalVolumeUSD descending", async () => {
+    getSwapHistorySpy.mockResolvedValue([
+      // Trader 1 (USER_1) - 100 tokens of STABLE_ADDR (100 USD)
+      {
+        txHash: "tx1",
+        amountIn: 1000000000n, // 100 tokens (7 decimals)
+        amountOut: 900000000n,
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_A,
+        sender: "USER_1",
+        pairAddress: PAIR_1,
+        ledger: 99000,
+        timestamp: 1234567,
+        feeBps: 30,
+      },
+      // Trader 2 (USER_2) - 300 tokens of STABLE_ADDR (300 USD)
+      {
+        txHash: "tx2",
+        amountIn: 3000000000n, // 300 tokens (7 decimals)
+        amountOut: 2800000000n,
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_A,
+        sender: "USER_2",
+        pairAddress: PAIR_1,
+        ledger: 99100,
+        timestamp: 1234580,
+        feeBps: 30,
+      },
+    ]);
+
+    const result = await leaderboard.getTopTraders();
+    expect(result).toHaveLength(2);
+    expect(result[0].address).toBe("USER_2");
+    expect(result[0].totalVolumeUSD).toBeCloseTo(300);
+    expect(result[1].address).toBe("USER_1");
+    expect(result[1].totalVolumeUSD).toBeCloseTo(100);
+  });
+
+  it("accurately calculates tradeCount, avgTradeSize and favoritePool", async () => {
+    getSwapHistorySpy.mockResolvedValue([
+      {
+        txHash: "tx1",
+        amountIn: 1000000000n, // 100 USD
+        amountOut: 900000000n,
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_A,
+        sender: "USER_1",
+        pairAddress: PAIR_1,
+        ledger: 99000,
+        timestamp: 1234567,
+        feeBps: 30,
+      },
+      {
+        txHash: "tx2",
+        amountIn: 2000000000n, // 200 USD
+        amountOut: 1800000000n,
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_A,
+        sender: "USER_1",
+        pairAddress: PAIR_1,
+        ledger: 99100,
+        timestamp: 1234580,
+        feeBps: 30,
+      },
+      {
+        txHash: "tx3",
+        amountIn: 5000000000n, // 500 USD
+        amountOut: 4500000000n,
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_B,
+        sender: "USER_1",
+        pairAddress: PAIR_2,
+        ledger: 99200,
+        timestamp: 1234600,
+        feeBps: 30,
+      },
+    ]);
+
+    const result = await leaderboard.getTopTraders();
+    expect(result).toHaveLength(1);
+    const u1 = result[0];
+    expect(u1.address).toBe("USER_1");
+    expect(u1.tradeCount).toBe(3);
+    expect(u1.totalVolumeUSD).toBeCloseTo(800);
+    expect(u1.avgTradeSize).toBeCloseTo(800 / 3);
+    expect(u1.favoritePool).toBe(PAIR_1); // PAIR_1 used twice, PAIR_2 once
+  });
+
+  it("calculates winRate correctly where output value > input value", async () => {
+    getSwapHistorySpy.mockResolvedValue([
+      // Win: input 100 stable, output value 105 (say, output token price is 1.0, output amount is 105)
+      // Since TOKEN_A price is 1.0 (reserves 1:1), 105 tokens of TOKEN_A is 105 USD.
+      {
+        txHash: "tx1",
+        amountIn: 1000000000n, // 100 USD input
+        amountOut: 1050000000n, // 105 USD output
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_A,
+        sender: "USER_1",
+        pairAddress: PAIR_1,
+        ledger: 99000,
+        timestamp: 1234567,
+        feeBps: 30,
+      },
+      // Loss: input 100 stable, output value 95
+      {
+        txHash: "tx2",
+        amountIn: 1000000000n, // 100 USD input
+        amountOut: 950000000n, // 95 USD output
+        tokenIn: STABLE_ADDR,
+        tokenOut: TOKEN_A,
+        sender: "USER_1",
+        pairAddress: PAIR_1,
+        ledger: 99100,
+        timestamp: 1234580,
+        feeBps: 30,
+      },
+    ]);
+
+    const result = await leaderboard.getTopTraders();
+    expect(result).toHaveLength(1);
+    expect(result[0].winRate).toBe(50); // 1 win out of 2 trades
+  });
+
+  it("respects the limit option", async () => {
+    getSwapHistorySpy.mockResolvedValue([
+      { txHash: "tx1", amountIn: 1000000000n, amountOut: 900000000n, tokenIn: STABLE_ADDR, tokenOut: TOKEN_A, sender: "USER_1", pairAddress: PAIR_1, ledger: 99000, timestamp: 1234567, feeBps: 30 },
+      { txHash: "tx2", amountIn: 2000000000n, amountOut: 1800000000n, tokenIn: STABLE_ADDR, tokenOut: TOKEN_A, sender: "USER_2", pairAddress: PAIR_1, ledger: 99100, timestamp: 1234580, feeBps: 30 },
+      { txHash: "tx3", amountIn: 3000000000n, amountOut: 2700000000n, tokenIn: STABLE_ADDR, tokenOut: TOKEN_A, sender: "USER_3", pairAddress: PAIR_1, ledger: 99200, timestamp: 1234590, feeBps: 30 },
+    ]);
+
+    const result = await leaderboard.getTopTraders({ limit: 2 });
+    expect(result).toHaveLength(2);
+    expect(result[0].address).toBe("USER_3"); // 300 USD
+    expect(result[1].address).toBe("USER_2"); // 200 USD
+  });
+});


### PR DESCRIPTION
closes #270

## Description
This PR implements the `getTopTraders(options?)` function in the new `LeaderboardModule` in `leaderboard.ts`.
It ranks traders by swap volume in USD and returns their stats (total volume, trade count, average trade size, favorite pool, and win rate).
It also restores the `getSwapHistory()` method on `SwapModule` which had been lost in a prior merge conflict, which is used to query the underlying trades.

### Acceptance Criteria
- Ranks by `totalVolumeUSD` descending.
- `tradeCount` includes all swap types.
- `winRate` is in 0-100 range.
- Default period is 30 days.
