### PR TITLE
feat(webhooks): add registerWebhook, verifyWebhook, updateWebhook, li…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export {
   TreasuryModule,
   AlertModule,
   LeaderboardModule,
+  WebhookModule,
 } from "@/modules";
 export type { OptimalPath } from "@/modules/router";
 export type { TWAPObservation, TWAPResult, TraderRanking, GetTopTradersOptions } from "@/modules";

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -11,3 +11,4 @@ export type { TreasuryModuleOptions } from './treasury';
 export { AlertModule } from './alerts';
 export { LeaderboardModule } from './leaderboard';
 export type { TraderRanking, GetTopTradersOptions } from './leaderboard';
+export { WebhookModule } from './webhooks';

--- a/src/modules/webhooks.ts
+++ b/src/modules/webhooks.ts
@@ -1,0 +1,276 @@
+import { ValidationError } from '@/errors';
+import {
+  RegisterWebhookParams,
+  UpdateWebhookParams,
+  Webhook,
+  WebhookEventType,
+  WebhookStatus,
+  WebhookVerificationResult,
+} from '@/types/webhooks';
+
+/** Maximum consecutive delivery failures before a webhook is auto-disabled. */
+const AUTO_DISABLE_THRESHOLD = 5;
+
+/** All supported event types — used as default subscription list. */
+const ALL_EVENT_TYPES: WebhookEventType[] = [
+  'swap',
+  'liquidity_add',
+  'liquidity_remove',
+  'flash_loan',
+  'price_alert',
+  'fee_change',
+];
+
+/** Internal storage record augmenting the public Webhook shape. */
+interface StoredWebhook extends Webhook {
+  status: WebhookStatus;
+}
+
+/**
+ * Minimal fetch-compatible interface used by WebhookModule.
+ *
+ * Accepting this as a constructor parameter keeps the module fully testable
+ * without real HTTP calls.
+ */
+export interface FetchFn {
+  (url: string, init: RequestInit): Promise<{ status: number }>;
+}
+
+/**
+ * Manages webhook endpoint registration, verification, updates, and listing.
+ *
+ * @example
+ * ```ts
+ * import { WebhookModule } from '@coralswap/sdk';
+ *
+ * const webhooks = new WebhookModule();
+ *
+ * const { id } = await webhooks.registerWebhook({
+ *   url: 'https://example.com/hooks/coralswap',
+ *   events: ['swap', 'price_alert'],
+ * });
+ *
+ * const result = await webhooks.verifyWebhook(id);
+ * console.log('verified:', result.success);
+ * ```
+ */
+export class WebhookModule {
+  private readonly store: Map<string, StoredWebhook> = new Map();
+  private readonly fetchFn: FetchFn;
+
+  /**
+   * @param fetchFn - Optional custom fetch implementation (useful in tests).
+   *   Defaults to the global `fetch` when not provided.
+   */
+  constructor(fetchFn?: FetchFn) {
+    this.fetchFn = fetchFn ?? (globalThis.fetch as FetchFn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a new webhook endpoint.
+   *
+   * The webhook is created in `unverified` status. Call {@link verifyWebhook}
+   * to promote it to `active`.
+   *
+   * @param params - URL and optional event filter list.
+   * @returns The newly created webhook.
+   * @throws {ValidationError} If the URL is invalid or the event list contains
+   *   unrecognised event types.
+   */
+  async registerWebhook(params: RegisterWebhookParams): Promise<Webhook> {
+    this.validateUrl(params.url);
+
+    const events = params.events ?? [...ALL_EVENT_TYPES];
+    this.validateEventTypes(events);
+
+    const id = generateId();
+    const webhook: StoredWebhook = {
+      id,
+      url: params.url,
+      events,
+      verified: false,
+      lastDelivery: null,
+      failCount: 0,
+      status: 'unverified',
+    };
+
+    this.store.set(id, webhook);
+    return { ...webhook };
+  }
+
+  /**
+   * Send a test payload to the endpoint and mark the webhook as verified on
+   * HTTP 200, or unverified on any other outcome.
+   *
+   * @param webhookId - ID returned by {@link registerWebhook}.
+   * @returns Verification outcome.
+   * @throws {ValidationError} If the webhook ID does not exist.
+   */
+  async verifyWebhook(webhookId: string): Promise<WebhookVerificationResult> {
+    const stored = this.requireWebhook(webhookId);
+
+    const testPayload = {
+      type: 'verification',
+      webhookId,
+      timestamp: new Date().toISOString(),
+    };
+
+    let statusCode: number | null = null;
+
+    try {
+      const response = await this.fetchFn(stored.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(testPayload),
+      });
+
+      statusCode = response.status;
+
+      if (response.status === 200) {
+        stored.verified = true;
+        stored.status = 'active';
+        stored.failCount = 0;
+        stored.lastDelivery = new Date().toISOString();
+        return { success: true, statusCode };
+      }
+
+      // Non-200 — mark as unverified
+      stored.verified = false;
+      stored.status = 'unverified';
+      return {
+        success: false,
+        statusCode,
+        error: `Endpoint returned HTTP ${statusCode}`,
+      };
+    } catch (err) {
+      stored.verified = false;
+      stored.status = 'unverified';
+      return {
+        success: false,
+        statusCode: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Update the URL or event filter list of an existing webhook.
+   *
+   * Changing the URL resets `verified` to `false` and status to `unverified`
+   * because the new endpoint has not yet been confirmed.
+   *
+   * @param webhookId - ID of the webhook to update.
+   * @param updates   - Fields to change (URL and/or events).
+   * @returns The updated webhook snapshot.
+   * @throws {ValidationError} If the webhook is not found, the new URL is
+   *   invalid, or any event type is unrecognised.
+   */
+  async updateWebhook(
+    webhookId: string,
+    updates: UpdateWebhookParams,
+  ): Promise<Webhook> {
+    const stored = this.requireWebhook(webhookId);
+
+    if (updates.url !== undefined) {
+      this.validateUrl(updates.url);
+      stored.url = updates.url;
+      // Changing the URL invalidates the previous verification.
+      stored.verified = false;
+      stored.status = stored.status === 'disabled' ? 'disabled' : 'unverified';
+    }
+
+    if (updates.events !== undefined) {
+      this.validateEventTypes(updates.events);
+      stored.events = [...updates.events];
+    }
+
+    return { ...stored };
+  }
+
+  /**
+   * Return all registered webhooks (all statuses).
+   *
+   * @returns Array of webhook snapshots ordered by insertion time.
+   */
+  async listWebhooks(): Promise<Webhook[]> {
+    return Array.from(this.store.values()).map(w => ({ ...w }));
+  }
+
+  /**
+   * Record a delivery attempt outcome for a webhook.
+   *
+   * Increments `failCount` on failure and auto-disables the webhook once
+   * {@link AUTO_DISABLE_THRESHOLD} consecutive failures are reached. Resets
+   * `failCount` to 0 on success.
+   *
+   * @param webhookId - Target webhook ID.
+   * @param success   - Whether the delivery was acknowledged (HTTP 2xx).
+   * @throws {ValidationError} If the webhook does not exist.
+   */
+  recordDelivery(webhookId: string, success: boolean): void {
+    const stored = this.requireWebhook(webhookId);
+    stored.lastDelivery = new Date().toISOString();
+
+    if (success) {
+      stored.failCount = 0;
+    } else {
+      stored.failCount += 1;
+      if (stored.failCount > AUTO_DISABLE_THRESHOLD) {
+        stored.status = 'disabled';
+        stored.verified = false;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private requireWebhook(id: string): StoredWebhook {
+    const stored = this.store.get(id);
+    if (!stored) {
+      throw new ValidationError(`Webhook not found: ${id}`, { id });
+    }
+    return stored;
+  }
+
+  private validateUrl(url: string): void {
+    if (!url || typeof url !== 'string') {
+      throw new ValidationError('Webhook URL must be a non-empty string', { url });
+    }
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        throw new ValidationError(
+          'Webhook URL must use http or https protocol',
+          { url },
+        );
+      }
+    } catch (err) {
+      if (err instanceof ValidationError) throw err;
+      throw new ValidationError('Webhook URL is not a valid URL', { url });
+    }
+  }
+
+  private validateEventTypes(events: WebhookEventType[]): void {
+    if (!Array.isArray(events) || events.length === 0) {
+      throw new ValidationError('events must be a non-empty array', { events });
+    }
+    for (const event of events) {
+      if (!ALL_EVENT_TYPES.includes(event)) {
+        throw new ValidationError(`Unrecognised event type: ${event}`, {
+          event,
+          valid: ALL_EVENT_TYPES,
+        });
+      }
+    }
+  }
+}
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,3 +9,4 @@ export * from './tokens';
 export * from './gas';
 export * from './treasury';
 export * from './alerts';
+export * from './webhooks';

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,0 +1,63 @@
+/** Event types that a webhook can subscribe to. */
+export type WebhookEventType =
+  | 'swap'
+  | 'liquidity_add'
+  | 'liquidity_remove'
+  | 'flash_loan'
+  | 'price_alert'
+  | 'fee_change';
+
+/** Current lifecycle state of a registered webhook. */
+export type WebhookStatus = 'active' | 'unverified' | 'disabled';
+
+/**
+ * A registered webhook endpoint.
+ *
+ * `failCount` tracks consecutive delivery failures; the webhook is
+ * auto-disabled once it exceeds the configured threshold (default 5).
+ */
+export interface Webhook {
+  /** Unique identifier assigned at registration time. */
+  id: string;
+  /** Target URL that receives POST payloads. */
+  url: string;
+  /** Event types that trigger a delivery to this endpoint. */
+  events: WebhookEventType[];
+  /** Whether the endpoint has passed the verification handshake. */
+  verified: boolean;
+  /** ISO-8601 timestamp of the most recent delivery attempt, or null. */
+  lastDelivery: string | null;
+  /** Number of consecutive delivery failures since the last success. */
+  failCount: number;
+  /** Current lifecycle status of the webhook. */
+  status: WebhookStatus;
+}
+
+/** Parameters accepted by `registerWebhook`. */
+export interface RegisterWebhookParams {
+  /** HTTPS URL that will receive event payloads. */
+  url: string;
+  /**
+   * Event types to subscribe to.
+   * Defaults to all event types when omitted.
+   */
+  events?: WebhookEventType[];
+}
+
+/** Fields that may be changed via `updateWebhook`. */
+export interface UpdateWebhookParams {
+  /** New target URL. */
+  url?: string;
+  /** Replacement event filter list. */
+  events?: WebhookEventType[];
+}
+
+/** Outcome returned by `verifyWebhook`. */
+export interface WebhookVerificationResult {
+  /** Whether the test payload was acknowledged with HTTP 200. */
+  success: boolean;
+  /** HTTP status received from the endpoint, or null on network error. */
+  statusCode: number | null;
+  /** Error message when `success` is false. */
+  error?: string;
+}

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,0 +1,522 @@
+import { WebhookModule } from '../src/modules/webhooks';
+import { ValidationError } from '../src/errors';
+import type { FetchFn } from '../src/modules/webhooks';
+import type { Webhook, WebhookEventType } from '../src/types/webhooks';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_URL = 'https://example.com/hooks/coralswap';
+const VALID_URL_2 = 'https://other.example.com/hooks';
+
+/** Build a FetchFn that always returns the given HTTP status code. */
+function makeFetch(status: number): FetchFn {
+  return jest.fn().mockResolvedValue({ status });
+}
+
+/** Build a FetchFn that throws a network-level error. */
+function makeNetworkErrorFetch(message = 'Network error'): FetchFn {
+  return jest.fn().mockRejectedValue(new Error(message));
+}
+
+// ---------------------------------------------------------------------------
+// registerWebhook
+// ---------------------------------------------------------------------------
+
+describe('registerWebhook()', () => {
+  it('creates a webhook and returns an object with a string ID', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const wh = await m.registerWebhook({ url: VALID_URL });
+
+    expect(typeof wh.id).toBe('string');
+    expect(wh.id.length).toBeGreaterThan(0);
+  });
+
+  it('new webhook starts as unverified', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const wh = await m.registerWebhook({ url: VALID_URL });
+
+    expect(wh.verified).toBe(false);
+    expect(wh.status).toBe('unverified');
+  });
+
+  it('stores the supplied URL', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const wh = await m.registerWebhook({ url: VALID_URL });
+
+    expect(wh.url).toBe(VALID_URL);
+  });
+
+  it('defaults to all event types when events is omitted', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const wh = await m.registerWebhook({ url: VALID_URL });
+
+    expect(wh.events).toEqual(
+      expect.arrayContaining([
+        'swap',
+        'liquidity_add',
+        'liquidity_remove',
+        'flash_loan',
+        'price_alert',
+        'fee_change',
+      ]),
+    );
+    expect(wh.events.length).toBe(6);
+  });
+
+  it('stores a custom event filter list', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const events: WebhookEventType[] = ['swap', 'price_alert'];
+    const wh = await m.registerWebhook({ url: VALID_URL, events });
+
+    expect(wh.events).toEqual(['swap', 'price_alert']);
+  });
+
+  it('initialises failCount and lastDelivery to defaults', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const wh = await m.registerWebhook({ url: VALID_URL });
+
+    expect(wh.failCount).toBe(0);
+    expect(wh.lastDelivery).toBeNull();
+  });
+
+  it('rejects a non-URL string', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    await expect(
+      m.registerWebhook({ url: 'not-a-url' }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('rejects an empty URL', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    await expect(m.registerWebhook({ url: '' })).rejects.toThrow(ValidationError);
+  });
+
+  it('rejects an unrecognised event type', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    await expect(
+      m.registerWebhook({ url: VALID_URL, events: ['swap', 'unknown_event' as WebhookEventType] }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('rejects an empty event list', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    await expect(
+      m.registerWebhook({ url: VALID_URL, events: [] }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('assigns unique IDs to different webhooks', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const a = await m.registerWebhook({ url: VALID_URL });
+    const b = await m.registerWebhook({ url: VALID_URL_2 });
+
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyWebhook
+// ---------------------------------------------------------------------------
+
+describe('verifyWebhook()', () => {
+  it('marks the webhook verified when the endpoint returns 200', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const result = await m.verifyWebhook(id);
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('promotes status to active after a successful verification', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    await m.verifyWebhook(id);
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.status).toBe('active');
+    expect(wh.verified).toBe(true);
+  });
+
+  it('resets failCount to 0 after successful verification', async () => {
+    // Pre-accumulate failures via recordDelivery then verify successfully.
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+    m.recordDelivery(id, false);
+    m.recordDelivery(id, false);
+
+    await m.verifyWebhook(id);
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.failCount).toBe(0);
+  });
+
+  it('sets lastDelivery timestamp after successful verification', async () => {
+    const before = new Date().toISOString();
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    await m.verifyWebhook(id);
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.lastDelivery).not.toBeNull();
+    expect(wh.lastDelivery! >= before).toBe(true);
+  });
+
+  it('sends the test payload via POST with JSON content-type', async () => {
+    const fetchFn = makeFetch(200);
+    const m = new WebhookModule(fetchFn);
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    await m.verifyWebhook(id);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      VALID_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    );
+  });
+
+  it('includes type=verification in the test payload body', async () => {
+    const fetchFn = makeFetch(200);
+    const m = new WebhookModule(fetchFn);
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    await m.verifyWebhook(id);
+
+    const [, init] = (fetchFn as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.type).toBe('verification');
+    expect(body.webhookId).toBe(id);
+  });
+
+  it('marks the webhook unverified when the endpoint returns non-200', async () => {
+    const m = new WebhookModule(makeFetch(404));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const result = await m.verifyWebhook(id);
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(404);
+    expect(result.error).toContain('404');
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.verified).toBe(false);
+    expect(wh.status).toBe('unverified');
+  });
+
+  it('marks the webhook unverified on a network-level error', async () => {
+    const m = new WebhookModule(makeNetworkErrorFetch('ECONNREFUSED'));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const result = await m.verifyWebhook(id);
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBeNull();
+    expect(result.error).toContain('ECONNREFUSED');
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.verified).toBe(false);
+  });
+
+  it('throws ValidationError for an unknown webhook ID', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    await expect(m.verifyWebhook('nonexistent')).rejects.toThrow(ValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateWebhook
+// ---------------------------------------------------------------------------
+
+describe('updateWebhook()', () => {
+  it('updates the URL', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const updated = await m.updateWebhook(id, { url: VALID_URL_2 });
+
+    expect(updated.url).toBe(VALID_URL_2);
+  });
+
+  it('resets verified to false when the URL is changed', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    // First verify the webhook.
+    await m.verifyWebhook(id);
+    let [wh] = await m.listWebhooks();
+    expect(wh.verified).toBe(true);
+
+    // Now change the URL — should invalidate verification.
+    await m.updateWebhook(id, { url: VALID_URL_2 });
+    [wh] = await m.listWebhooks();
+    expect(wh.verified).toBe(false);
+    expect(wh.status).toBe('unverified');
+  });
+
+  it('updates the event filter list', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const updated = await m.updateWebhook(id, { events: ['swap'] });
+
+    expect(updated.events).toEqual(['swap']);
+  });
+
+  it('event filter update does not change verification status', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+    await m.verifyWebhook(id);
+
+    await m.updateWebhook(id, { events: ['swap', 'fee_change'] });
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.verified).toBe(true);
+    expect(wh.status).toBe('active');
+  });
+
+  it('allows updating both URL and events simultaneously', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const updated = await m.updateWebhook(id, {
+      url: VALID_URL_2,
+      events: ['flash_loan'],
+    });
+
+    expect(updated.url).toBe(VALID_URL_2);
+    expect(updated.events).toEqual(['flash_loan']);
+  });
+
+  it('rejects an invalid URL update', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    await expect(
+      m.updateWebhook(id, { url: 'bad-url' }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('rejects an unrecognised event type on update', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    await expect(
+      m.updateWebhook(id, { events: ['swap', 'bogus' as WebhookEventType] }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for an unknown webhook ID', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    await expect(
+      m.updateWebhook('nonexistent', { url: VALID_URL }),
+    ).rejects.toThrow(ValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listWebhooks
+// ---------------------------------------------------------------------------
+
+describe('listWebhooks()', () => {
+  it('returns an empty array when no webhooks are registered', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    const list = await m.listWebhooks();
+
+    expect(list).toEqual([]);
+  });
+
+  it('returns all registered webhooks', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    await m.registerWebhook({ url: VALID_URL });
+    await m.registerWebhook({ url: VALID_URL_2, events: ['swap'] });
+
+    const list = await m.listWebhooks();
+
+    expect(list).toHaveLength(2);
+  });
+
+  it('includes webhooks of every status in the list', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    // unverified
+    await m.registerWebhook({ url: VALID_URL });
+
+    // active
+    const { id: activeId } = await m.registerWebhook({ url: VALID_URL_2 });
+    await m.verifyWebhook(activeId);
+
+    // disabled — exceed fail threshold
+    const fetchDisabled = makeFetch(500);
+    const mDisabled = new WebhookModule(fetchDisabled);
+    const { id: disabledId } = await mDisabled.registerWebhook({ url: VALID_URL });
+    for (let i = 0; i <= 5; i++) mDisabled.recordDelivery(disabledId, false);
+    const [disabled] = await mDisabled.listWebhooks();
+    expect(disabled.status).toBe('disabled');
+
+    // Back on the main instance — both unverified and active appear
+    const list = await m.listWebhooks();
+    const statuses = list.map((w: Webhook) => w.status);
+    expect(statuses).toContain('unverified');
+    expect(statuses).toContain('active');
+  });
+
+  it('returns snapshots, not live references', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const [snapshot] = await m.listWebhooks();
+    // Mutating the snapshot should not affect stored state.
+    (snapshot as Webhook & { url: string }).url = 'https://mutated.example.com/x';
+
+    const [fresh] = await m.listWebhooks();
+    expect(fresh.url).toBe(VALID_URL);
+    void id;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Events filter (acceptance criterion: events filter alert types)
+// ---------------------------------------------------------------------------
+
+describe('events filter', () => {
+  it('a webhook with only swap events does not include price_alert in its list', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const wh = await m.registerWebhook({ url: VALID_URL, events: ['swap'] });
+
+    expect(wh.events).not.toContain('price_alert');
+    expect(wh.events).toContain('swap');
+  });
+
+  it('a webhook with multiple event types contains all specified types', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const events: WebhookEventType[] = ['swap', 'flash_loan', 'price_alert'];
+    const wh = await m.registerWebhook({ url: VALID_URL, events });
+
+    expect(wh.events).toEqual(events);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-disable on consecutive failures
+// ---------------------------------------------------------------------------
+
+describe('auto-disable on consecutive failures', () => {
+  it('disables the webhook after more than 5 consecutive failures', async () => {
+    const m = new WebhookModule(makeFetch(500));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    // 6 failures (> 5)
+    for (let i = 0; i < 6; i++) {
+      m.recordDelivery(id, false);
+    }
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.status).toBe('disabled');
+    expect(wh.verified).toBe(false);
+  });
+
+  it('does NOT disable the webhook at exactly 5 consecutive failures', async () => {
+    const m = new WebhookModule(makeFetch(500));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+    await m.verifyWebhook(id);
+
+    for (let i = 0; i < 5; i++) {
+      m.recordDelivery(id, false);
+    }
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.status).not.toBe('disabled');
+    expect(wh.failCount).toBe(5);
+  });
+
+  it('resets failCount to 0 after a successful delivery', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    m.recordDelivery(id, false);
+    m.recordDelivery(id, false);
+    m.recordDelivery(id, true);
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.failCount).toBe(0);
+  });
+
+  it('records lastDelivery timestamp on each delivery attempt', async () => {
+    const m = new WebhookModule(makeFetch(200));
+    const { id } = await m.registerWebhook({ url: VALID_URL });
+
+    const before = new Date().toISOString();
+    m.recordDelivery(id, true);
+    const after = new Date().toISOString();
+
+    const [wh] = await m.listWebhooks();
+    expect(wh.lastDelivery).not.toBeNull();
+    expect(wh.lastDelivery! >= before).toBe(true);
+    expect(wh.lastDelivery! <= after).toBe(true);
+  });
+
+  it('throws ValidationError when recording delivery for unknown webhook', () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    expect(() => m.recordDelivery('nonexistent', true)).toThrow(ValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full registration + verification flow
+// ---------------------------------------------------------------------------
+
+describe('end-to-end: register → verify → update', () => {
+  it('full happy path: register, verify, update events, re-list', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    // 1. Register
+    const wh = await m.registerWebhook({ url: VALID_URL, events: ['swap'] });
+    expect(wh.status).toBe('unverified');
+
+    // 2. Verify
+    const result = await m.verifyWebhook(wh.id);
+    expect(result.success).toBe(true);
+
+    // 3. Update event filter
+    const updated = await m.updateWebhook(wh.id, { events: ['swap', 'fee_change'] });
+    expect(updated.events).toEqual(['swap', 'fee_change']);
+    expect(updated.verified).toBe(true); // event-only update preserves verification
+
+    // 4. List
+    const list = await m.listWebhooks();
+    expect(list).toHaveLength(1);
+    expect(list[0].status).toBe('active');
+  });
+
+  it('changing URL after verification requires re-verification', async () => {
+    const m = new WebhookModule(makeFetch(200));
+
+    const wh = await m.registerWebhook({ url: VALID_URL });
+    await m.verifyWebhook(wh.id);
+
+    let [snapshot] = await m.listWebhooks();
+    expect(snapshot.status).toBe('active');
+
+    await m.updateWebhook(wh.id, { url: VALID_URL_2 });
+
+    [snapshot] = await m.listWebhooks();
+    expect(snapshot.verified).toBe(false);
+    expect(snapshot.status).toBe('unverified');
+  });
+});


### PR DESCRIPTION
…stWebhooks (#277)

Implements the WebhookModule with full endpoint registration and validation:

- registerWebhook(params): validates URL (http/https) and event types, stores webhook in unverified state with failCount=0 and lastDelivery=null
- verifyWebhook(id): sends a test POST payload {type:'verification', webhookId, timestamp} to the endpoint; HTTP 200 promotes status to active; any other response or network error marks it unverified
- updateWebhook(id, updates): updates URL (resets verification) and/or events (preserves verification); validates both fields before applying
- listWebhooks(): returns defensive snapshots of all webhooks regardless of status
- recordDelivery(id, success): tracks consecutive failures; auto-disables the webhook (status='disabled', verified=false) once failCount exceeds 5

Types added in src/types/webhooks.ts:
  Webhook, WebhookEventType, WebhookStatus, RegisterWebhookParams, UpdateWebhookParams, WebhookVerificationResult

All symbols exported via src/modules/index.ts, src/types/index.ts, src/index.ts. 41 unit tests covering happy paths, edge cases, and acceptance criteria.

## Description

Describe what this PR changes and why it is needed.

## Related Issue

Closes #XXX

Replace `XXX` with the issue number this PR resolves. If there is no linked issue, explain why.

## Changes Made

- List the key changes included in this PR.

## Testing

Describe the tests or manual checks performed for this change.

- [ ] Tests added or updated
- [ ] Existing tests pass

## Checklist

- [ ] Tests added where applicable
- [ ] Documentation updated where applicable
- [ ] Lint passes
- [ ] No breaking changes, or any breaking changes are documented
- [ ] Commit messages are clear and follow the project convention
closes #277 