### PR TITLE
[SDK] Add AlertsModule unit tests and no-retrigger behavior

### DIFF
--- a/src/modules/alerts.ts
+++ b/src/modules/alerts.ts
@@ -2,7 +2,6 @@ import { CoralSwapClient } from '@/client';
 import {
   Alert,
   AlertConfig,
-  AlertDirection,
   AlertStatus,
   PriceAlertConfig,
   ILAlertConfig,
@@ -24,12 +23,34 @@ const PRICE_SCALE = 1_000_000_000_000_000_000n;
 const PRICE_SCALE_SQRT = 1_000_000_000n;
 const BPS = 10_000n;
 
-interface StoredAlert {
+interface StoredGenericAlert {
+  kind: 'generic';
   id: string;
   config: AlertConfig;
-  referencePrice?: bigint;
+  target: string;
+  triggeredAt?: number;
   createdAt: number;
 }
+
+interface StoredPriceAlert {
+  kind: 'price';
+  id: string;
+  config: PriceAlertConfig;
+  target: string;
+  triggeredAt?: number;
+  createdAt: number;
+}
+
+interface StoredILAlert {
+  kind: 'il';
+  id: string;
+  config: ILAlertConfig;
+  target: string;
+  triggeredAt?: number;
+  createdAt: number;
+}
+
+type StoredAlert = StoredGenericAlert | StoredPriceAlert | StoredILAlert;
 
 export class AlertModule {
   private client: CoralSwapClient;
@@ -42,18 +63,53 @@ export class AlertModule {
   async createAlert(config: AlertConfig): Promise<string> {
     this.validateAlertConfig(config);
     const id = generateId();
-    this.alerts.set(id, { id, config, createdAt: Date.now() });
+    this.alerts.set(id, {
+      kind: 'generic',
+      id,
+      config,
+      target: config.target,
+      createdAt: Date.now(),
+    });
+    return id;
+  }
+
+  async createPriceAlert(config: PriceAlertConfig): Promise<string> {
+    this.validatePriceAlertConfig(config);
+    const id = generateId();
+    this.alerts.set(id, {
+      kind: 'price',
+      id,
+      config,
+      target: config.pairAddress,
+      createdAt: Date.now(),
+    });
+    return id;
+  }
+
+  async createILAlert(config: ILAlertConfig): Promise<string> {
+    this.validateILAlertConfig(config);
+    const id = generateId();
+    this.alerts.set(id, {
+      kind: 'il',
+      id,
+      config,
+      target: config.pairAddress,
+      createdAt: Date.now(),
+    });
     return id;
   }
 
   async checkAlerts(address: string): Promise<Alert[]> {
     const results: Alert[] = [];
     const targetAlerts = Array.from(this.alerts.values())
-      .filter(a => a.config.target === address);
+      .filter(a => a.target === address && a.triggeredAt === undefined);
 
     for (const stored of targetAlerts) {
       const alert = await this.checkStoredAlert(stored);
-      results.push(alert);
+      if (alert.triggered) {
+        stored.triggeredAt = Date.now();
+        results.push(alert);
+      }
     }
 
     return results;
@@ -70,12 +126,7 @@ export class AlertModule {
     config: PriceAlertConfig,
     id: string,
   ): Promise<PriceAlert> {
-    validateAddress(config.tokenIn, 'tokenIn');
-    validateAddress(config.tokenOut, 'tokenOut');
-    validateAddress(config.pairAddress, 'pairAddress');
-    validateDistinctTokens(config.tokenIn, config.tokenOut);
-    validatePositiveAmount(config.thresholdPrice, 'thresholdPrice');
-    this.validateDirection(config.direction);
+    this.validatePriceAlertConfig(config);
 
     const currentPrice = await this.getPoolPrice(
       config.pairAddress,
@@ -95,12 +146,7 @@ export class AlertModule {
     config: ILAlertConfig,
     id: string,
   ): Promise<ILAlert> {
-    validateAddress(config.tokenA, 'tokenA');
-    validateAddress(config.tokenB, 'tokenB');
-    validateAddress(config.pairAddress, 'pairAddress');
-    validateDistinctTokens(config.tokenA, config.tokenB);
-    validatePositiveAmount(config.referencePrice, 'referencePrice');
-    this.validateBps(config.maxImpermanentLossBps, 'maxImpermanentLossBps');
+    this.validateILAlertConfig(config);
 
     const pair = this.client.pair(config.pairAddress);
     const { reserve0, reserve1 } = await pair.getReserves();
@@ -175,6 +221,19 @@ export class AlertModule {
   }
 
   private async checkStoredAlert(stored: StoredAlert): Promise<Alert> {
+    switch (stored.kind) {
+      case 'price':
+        return this.checkPriceAlert(stored.config, stored.id);
+      case 'il':
+        return this.checkILAlert(stored.config, stored.id);
+      case 'generic':
+        return this.checkGenericStoredAlert(stored);
+    }
+  }
+
+  private async checkGenericStoredAlert(
+    stored: StoredGenericAlert,
+  ): Promise<Alert> {
     switch (stored.config.type) {
       case 'price':
         return this.checkPriceFromStored(stored);
@@ -187,7 +246,9 @@ export class AlertModule {
     }
   }
 
-  private async checkPriceFromStored(stored: StoredAlert): Promise<PriceAlert> {
+  private async checkPriceFromStored(
+    stored: StoredGenericAlert,
+  ): Promise<PriceAlert> {
     const { target, threshold, direction } = stored.config;
     const pair = this.client.pair(target);
     const tokens = await pair.getTokens();
@@ -203,7 +264,7 @@ export class AlertModule {
     return this.checkPriceAlert(priceConfig, stored.id);
   }
 
-  private async checkILFromStored(stored: StoredAlert): Promise<ILAlert> {
+  private async checkILFromStored(stored: StoredGenericAlert): Promise<ILAlert> {
     const { target, threshold } = stored.config;
     const pair = this.client.pair(target);
     const tokens = await pair.getTokens();
@@ -227,13 +288,17 @@ export class AlertModule {
     return this.checkILAlert(ilConfig, stored.id);
   }
 
-  private async checkHealthFromStored(stored: StoredAlert): Promise<HealthAlert> {
+  private async checkHealthFromStored(
+    stored: StoredGenericAlert,
+  ): Promise<HealthAlert> {
     const { target } = stored.config;
     const config: HealthAlertConfig = { pairAddress: target };
     return this.checkHealthAlert(config, stored.id);
   }
 
-  private async checkVolumeFromStored(stored: StoredAlert): Promise<VolumeAlert> {
+  private async checkVolumeFromStored(
+    stored: StoredGenericAlert,
+  ): Promise<VolumeAlert> {
     const { target } = stored.config;
     const config: VolumeAlertConfig = { pairAddress: target };
     return this.checkVolumeAlert(config, stored.id);
@@ -261,6 +326,24 @@ export class AlertModule {
     }
 
     this.validateDirection(config.direction);
+  }
+
+  private validatePriceAlertConfig(config: PriceAlertConfig): void {
+    validateAddress(config.tokenIn, 'tokenIn');
+    validateAddress(config.tokenOut, 'tokenOut');
+    validateAddress(config.pairAddress, 'pairAddress');
+    validateDistinctTokens(config.tokenIn, config.tokenOut);
+    validatePositiveAmount(config.thresholdPrice, 'thresholdPrice');
+    this.validateDirection(config.direction);
+  }
+
+  private validateILAlertConfig(config: ILAlertConfig): void {
+    validateAddress(config.tokenA, 'tokenA');
+    validateAddress(config.tokenB, 'tokenB');
+    validateAddress(config.pairAddress, 'pairAddress');
+    validateDistinctTokens(config.tokenA, config.tokenB);
+    validatePositiveAmount(config.referencePrice, 'referencePrice');
+    this.validateBps(config.maxImpermanentLossBps, 'maxImpermanentLossBps');
   }
 
   private async getPoolPrice(

--- a/tests/alerts.test.ts
+++ b/tests/alerts.test.ts
@@ -105,6 +105,75 @@ describe('AlertModule', () => {
     });
   });
 
+  describe('createPriceAlert()', () => {
+    it('returns a triggered above alert when the pool price rises to the threshold', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 250n }));
+
+      const id = await alerts.createPriceAlert(makePriceConfig({
+        thresholdPrice: 2_000_000_000_000_000_000n,
+        direction: 'above',
+      }));
+
+      const results = await alerts.checkAlerts(PAIR);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        id,
+        type: 'price',
+        status: 'triggered',
+        triggered: true,
+      });
+    });
+
+    it('returns a triggered below alert when the pool price falls to the threshold', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 150n }));
+
+      const id = await alerts.createPriceAlert(makePriceConfig({
+        thresholdPrice: 2_000_000_000_000_000_000n,
+        direction: 'below',
+      }));
+
+      const results = await alerts.checkAlerts(PAIR);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        id,
+        type: 'price',
+        currentPrice: 1_500_000_000_000_000_000n,
+        triggered: true,
+      });
+    });
+
+    it('does not retrigger a stored price alert after it has fired once', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 250n }));
+
+      await alerts.createPriceAlert(makePriceConfig({
+        thresholdPrice: 2_000_000_000_000_000_000n,
+        direction: 'above',
+      }));
+
+      const firstCheck = await alerts.checkAlerts(PAIR);
+      const secondCheck = await alerts.checkAlerts(PAIR);
+
+      expect(firstCheck).toHaveLength(1);
+      expect(firstCheck[0].triggered).toBe(true);
+      expect(secondCheck).toEqual([]);
+    });
+
+    it('returns an empty array while a stored price alert has not triggered', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 150n }));
+
+      await alerts.createPriceAlert(makePriceConfig({
+        thresholdPrice: 2_000_000_000_000_000_000n,
+        direction: 'above',
+      }));
+
+      const results = await alerts.checkAlerts(PAIR);
+
+      expect(results).toEqual([]);
+    });
+  });
+
   describe('checkILAlert()', () => {
     it('triggers when impermanent loss reaches the configured threshold', async () => {
       const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 400n }));
@@ -140,6 +209,36 @@ describe('AlertModule', () => {
       await expect(
         alerts.checkILAlert(makeILConfig({ maxImpermanentLossBps: 10001 }), 'il-3'),
       ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('createILAlert()', () => {
+    it('returns a triggered IL alert using the pool impermanent-loss computation', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 400n }));
+
+      const id = await alerts.createILAlert(makeILConfig({
+        maxImpermanentLossBps: 500,
+      }));
+
+      const results = await alerts.checkAlerts(PAIR);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        id,
+        type: 'il',
+        currentILBps: 2000,
+        triggered: true,
+      });
+    });
+
+    it('rejects an invalid IL threshold before storing the alert', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 400n }));
+
+      await expect(
+        alerts.createILAlert(makeILConfig({ maxImpermanentLossBps: 10001 })),
+      ).rejects.toThrow(ValidationError);
+
+      await expect(alerts.checkAlerts(PAIR)).resolves.toEqual([]);
     });
   });
 
@@ -314,7 +413,7 @@ describe('AlertModule', () => {
       expect(results).toHaveLength(0);
     });
 
-    it('returns active alerts that have not yet triggered', async () => {
+    it('returns empty array when matching alerts have not triggered', async () => {
       const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 250n }));
 
       await alerts.createAlert({
@@ -326,9 +425,26 @@ describe('AlertModule', () => {
 
       const results = await alerts.checkAlerts(PAIR);
 
+      expect(results).toEqual([]);
+    });
+
+    it('returns only triggered alerts for the requested address', async () => {
+      const alerts = new AlertModule(makeClient({ reserve0: 100n, reserve1: 250n }));
+
+      await alerts.createPriceAlert(makePriceConfig({
+        thresholdPrice: 2_000_000_000_000_000_000n,
+        direction: 'above',
+      }));
+      await alerts.createPriceAlert(makePriceConfig({
+        thresholdPrice: 3_000_000_000_000_000_000n,
+        direction: 'above',
+      }));
+
+      const results = await alerts.checkAlerts(PAIR);
+
       expect(results).toHaveLength(1);
-      expect(results[0].triggered).toBe(false);
-      expect(results[0].status).toBe('active');
+      expect(results[0].triggered).toBe(true);
+      expect(results[0].type).toBe('price');
     });
   });
 


### PR DESCRIPTION
Closes #275 

  - Adds expanded unit coverage for AlertModule with 32 test cases.
  - Covers all generic createAlert() types: price, IL, health, and
    volume.

  - Adds stored createPriceAlert() and createILAlert() paths.
  - Verifies price alert triggering above and below thresholds.
  - Verifies IL threshold validation and impermanent-loss
    computation integration.

  - Updates checkAlerts() to return only triggered alerts.
  - Tracks triggered alerts so they do not retrigger on later
    checks.

  - Covers deleteAlert() removal and non-existent ID handling.

  ## Verification

  - npm test -- --runInBand --watchman=false tests/alerts.test.ts
  - npx eslint src/modules/alerts.ts

  ## Notes

  Full npm test still has unrelated failures in swap, flash-loan,
  staking, webhooks, and integration test setup areas.}
  