### PR TITLE
[#300] Fix missing error context in governance module exceptions

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -25,6 +25,16 @@ export class CoralSwapSDKError extends Error {
     this.details = details;
     Object.setPrototypeOf(this, new.target.prototype);
   }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      details: this.details,
+      stack: this.stack,
+    };
+  }
 }
 
 /**

--- a/src/modules/governance.ts
+++ b/src/modules/governance.ts
@@ -10,7 +10,7 @@ import {
 import { Signer } from '@/types/common';
 import {
   ValidationError,
-  PairNotFoundError,
+  InvalidOperationError,
   TransactionError,
 } from '@/errors';
 import { validateAddress } from '@/utils/validation';
@@ -59,13 +59,22 @@ export class GovernanceModule {
     signer: Signer,
   ): Promise<string> {
     if (!title || title.trim().length === 0) {
-      throw new ValidationError('title must not be empty');
+      throw new ValidationError('title must not be empty', {
+        operation: 'createProposal',
+        title,
+      });
     }
     if (!description || description.trim().length === 0) {
-      throw new ValidationError('description must not be empty');
+      throw new ValidationError('description must not be empty', {
+        operation: 'createProposal',
+        description,
+      });
     }
     if (!Array.isArray(actions) || actions.length === 0) {
-      throw new ValidationError('actions must be a non-empty array');
+      throw new ValidationError('actions must be a non-empty array', {
+        operation: 'createProposal',
+        actions,
+      });
     }
     for (const action of actions) {
       validateAddress(action.contractAddress, 'action.contractAddress');
@@ -96,6 +105,7 @@ export class GovernanceModule {
       throw new TransactionError(
         `createProposal failed: ${result.error?.message ?? 'Unknown error'}`,
         result.txHash,
+        { operation: 'createProposal', title, description },
       );
     }
 
@@ -122,12 +132,15 @@ export class GovernanceModule {
     signer: Signer,
   ): Promise<string> {
     if (!proposalId || proposalId.trim().length === 0) {
-      throw new ValidationError('proposalId must not be empty');
+      throw new ValidationError('proposalId must not be empty', {
+        operation: 'castVote',
+        proposalId,
+      });
     }
     if (!['for', 'against', 'abstain'].includes(voteType)) {
       throw new ValidationError(
         `voteType must be 'for', 'against', or 'abstain', got: ${voteType}`,
-        { voteType },
+        { operation: 'castVote', proposalId, voteType },
       );
     }
 
@@ -147,6 +160,7 @@ export class GovernanceModule {
       throw new TransactionError(
         `castVote failed: ${result.error?.message ?? 'Unknown error'}`,
         result.txHash,
+        { operation: 'castVote', proposalId, voteType },
       );
     }
 
@@ -168,7 +182,10 @@ export class GovernanceModule {
     const signerPublicKey = await signer.publicKey();
 
     if (toAddress === signerPublicKey) {
-      throw new ValidationError('Cannot delegate to self', { toAddress });
+      throw new ValidationError('Cannot delegate to self', {
+        operation: 'delegate',
+        delegateAddress: toAddress,
+      });
     }
 
     const contract = new Contract(this.contractAddress);
@@ -184,6 +201,7 @@ export class GovernanceModule {
       throw new TransactionError(
         `delegate failed: ${result.error?.message ?? 'Unknown error'}`,
         result.txHash,
+        { operation: 'delegate', delegateAddress: toAddress },
       );
     }
 
@@ -212,6 +230,7 @@ export class GovernanceModule {
       throw new TransactionError(
         `undelegate failed: ${result.error?.message ?? 'Unknown error'}`,
         result.txHash,
+        { operation: 'undelegate' },
       );
     }
 
@@ -228,11 +247,14 @@ export class GovernanceModule {
    * @param proposalId - Unique proposal identifier
    * @returns Full proposal state including vote tallies
    * @throws {ValidationError} If `proposalId` is empty
-   * @throws {PairNotFoundError} If no proposal exists for the given ID
+   * @throws {InvalidOperationError} If no proposal exists for the given ID
    */
   async getProposal(proposalId: string): Promise<Proposal> {
     if (!proposalId || proposalId.trim().length === 0) {
-      throw new ValidationError('proposalId must not be empty');
+      throw new ValidationError('proposalId must not be empty', {
+        operation: 'getProposal',
+        proposalId,
+      });
     }
 
     const contract = new Contract(this.contractAddress);
@@ -244,7 +266,10 @@ export class GovernanceModule {
     const sim = await this.client.simulateTransaction([op], {});
 
     if (!sim.success || !sim.returnValue) {
-      throw new PairNotFoundError(proposalId, 'governance');
+      throw new InvalidOperationError('Proposal not found', {
+        operation: 'getProposal',
+        proposalId,
+      });
     }
 
     return this.decodeProposal(sim.returnValue);

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -1,7 +1,7 @@
 
 import { CoralSwapClient } from '../src/client';
 import { GovernanceModule } from '../src/modules/governance';
-import { ValidationError, PairNotFoundError, TransactionError } from '../src/errors';
+import { ValidationError, InvalidOperationError, TransactionError } from '../src/errors';
 import { Network } from '../src/types/common';
 import type { Proposal, DelegationState, ProposalAction } from '../src/types/governance';
 import type { SimulateTransactionResult } from '../src/types/common';
@@ -265,12 +265,12 @@ describe('GovernanceModule', () => {
       await expect(governance.getProposal('')).rejects.toThrow(ValidationError);
     });
 
-    it('throws PairNotFoundError when the simulation returns no value', async () => {
+    it('throws InvalidOperationError when the simulation returns no value', async () => {
       jest
         .spyOn(client, 'simulateTransaction')
         .mockResolvedValue(makeSimResult(null, false) as never);
 
-      await expect(governance.getProposal('nonexistent')).rejects.toThrow(PairNotFoundError);
+      await expect(governance.getProposal('nonexistent')).rejects.toThrow(InvalidOperationError);
     });
 
     it('decodes executedAt when present in the contract response', async () => {


### PR DESCRIPTION
## Description

# Closes #300

When governance operations fail, the error message now includes enough context for the user to understand what went wrong and how to fix it — proposal ID, vote type, or delegation address.

## Changes

### `src/errors.ts`
- Added `toJSON()` method to `CoralSwapSDKError` base class returning `{ name, code, message, details, stack }` for structured logging and serialization.

### `src/modules/governance.ts`
- Every `ValidationError` throw now includes:
  - `operation` — the method that failed (`createProposal`, `castVote`, `delegate`, `getProposal`)
  - Relevant input fields (`proposalId`, `voteType`, `title`, `description`, `delegateAddress`)
- Every `TransactionError` throw now includes the same `operation` + input context in its `details`.
- Replaced `PairNotFoundError(proposalId, "governance")` with `InvalidOperationError("Proposal not found", { operation: "getProposal", proposalId })` — the former was semantically incorrect (it is meant for liquidity pool lookups).

### `tests/governance.test.ts`
- Updated import: `PairNotFoundError` → `InvalidOperationError`
- Updated test description and assertion to match the new error type.

## Acceptance criteria

- [x] No generic `Error` throws remain in governance module
- [x] All errors include the operation that failed
- [x] All errors include the input that caused the failure
- [x] Errors are catchable by type (`instanceof ValidationError`, `instanceof InvalidOperationError`, `instanceof TransactionError`)
- [x] `toJSON()` is available on all SDK errors for structured logging