### PR TITLE
[SDK] Add rate-limiter.ts utility — client-side RPC rate limiting (#292)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -70,6 +70,8 @@ export {
 export type { BatchRequestOptions, BatchResult } from './batch-request';
 
 export { parseChangelog } from './changelog';
+export { RateLimiter } from './rate-limiter';
+export type { RateLimiterOptions } from './rate-limiter';
 export { estimateGas } from './gas';
 export type { SimulateFn } from './gas';
 

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -1,20 +1,27 @@
 /**
  * Token-bucket rate limiter for throttling outbound RPC requests.
  *
- * Implements the classic token-bucket algorithm:
- *  - The bucket holds at most `capacity` tokens.
- *  - Tokens refill at `refillRate` tokens per `refillIntervalMs` milliseconds.
- *  - Each call to `acquire()` waits until a token is available, then consumes it.
- *  - Requests are served in FIFO order so starvation is impossible.
+ * Implements the token-bucket algorithm with configurable sustained rate
+ * and burst capacity.  Uses `setTimeout` internally — no CPU spinning.
+ *
+ * @example
+ * ```ts
+ * const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 20 });
+ *
+ * // Each call to acquire() consumes one token, blocking until one is available.
+ * await limiter.acquire();
+ * await someRpcCall();
+ *
+ * // Check remaining capacity without consuming.
+ * console.log(limiter.getRemainingCapacity());
+ * ```
  */
 
 export interface RateLimiterOptions {
+  /** Maximum sustained requests per second (e.g. 10). */
+  maxRequestsPerSecond: number;
   /** Maximum number of tokens the bucket can hold (burst size). */
-  capacity: number;
-  /** Number of tokens added per refill interval. */
-  refillRate: number;
-  /** Milliseconds between refills. */
-  refillIntervalMs: number;
+  maxBurst: number;
 }
 
 interface PendingRequest {
@@ -23,30 +30,27 @@ interface PendingRequest {
 
 export class RateLimiter {
   private tokens: number;
-  private readonly capacity: number;
-  private readonly refillRate: number;
-  private readonly refillIntervalMs: number;
+  private readonly maxBurst: number;
+  private readonly maxRequestsPerSecond: number;
   private lastRefillTime: number;
   private readonly queue: PendingRequest[] = [];
-  private refillTimer: ReturnType<typeof setInterval> | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: RateLimiterOptions) {
-    if (options.capacity <= 0) throw new Error('capacity must be > 0');
-    if (options.refillRate <= 0) throw new Error('refillRate must be > 0');
-    if (options.refillIntervalMs <= 0) throw new Error('refillIntervalMs must be > 0');
+    if (options.maxRequestsPerSecond <= 0) throw new Error('maxRequestsPerSecond must be > 0');
+    if (options.maxBurst <= 0) throw new Error('maxBurst must be > 0');
 
-    this.capacity = options.capacity;
-    this.refillRate = options.refillRate;
-    this.refillIntervalMs = options.refillIntervalMs;
-    this.tokens = options.capacity;
+    this.maxRequestsPerSecond = options.maxRequestsPerSecond;
+    this.maxBurst = options.maxBurst;
+    this.tokens = options.maxBurst;
     this.lastRefillTime = Date.now();
   }
 
   /**
-   * Current number of tokens available (read-only snapshot).
-   * Triggers an internal refill calculation to return the latest count.
+   * Number of tokens currently available (read-only snapshot).
+   * Triggers an internal refill calculation so the value is current.
    */
-  get availableTokens(): number {
+  getRemainingCapacity(): number {
     this._refill();
     return this.tokens;
   }
@@ -62,7 +66,7 @@ export class RateLimiter {
    * Consume one token, waiting if none are available.
    *
    * Returns a Promise that resolves once the token has been granted.
-   * Requests are granted in FIFO order.
+   * Requests are granted in FIFO order so starvation is impossible.
    */
   acquire(): Promise<void> {
     this._refill();
@@ -74,7 +78,7 @@ export class RateLimiter {
 
     return new Promise<void>((resolve) => {
       this.queue.push({ resolve });
-      this._scheduleRefill();
+      this._scheduleNext();
     });
   }
 
@@ -93,15 +97,14 @@ export class RateLimiter {
   }
 
   /**
-   * Stop the internal refill timer and drain the pending queue.
+   * Stop the internal timer and drain the pending queue.
    * Pending requests are resolved immediately (tokens are "gifted").
    */
   destroy(): void {
-    if (this.refillTimer !== null) {
-      clearInterval(this.refillTimer);
-      this.refillTimer = null;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
     }
-    // Resolve all waiting requests so they don't leak
     for (const pending of this.queue.splice(0)) {
       pending.resolve();
     }
@@ -115,27 +118,26 @@ export class RateLimiter {
   private _refill(): void {
     const now = Date.now();
     const elapsed = now - this.lastRefillTime;
-    const intervals = Math.floor(elapsed / this.refillIntervalMs);
-
-    if (intervals > 0) {
-      this.tokens = Math.min(this.capacity, this.tokens + intervals * this.refillRate);
-      this.lastRefillTime += intervals * this.refillIntervalMs;
+    const tokensToAdd = Math.floor((elapsed * this.maxRequestsPerSecond) / 1000);
+    if (tokensToAdd > 0) {
+      this.tokens = Math.min(this.maxBurst, this.tokens + tokensToAdd);
+      this.lastRefillTime += Math.floor((tokensToAdd * 1000) / this.maxRequestsPerSecond);
     }
   }
 
-  /** Start a periodic timer to flush the queue as tokens become available. */
-  private _scheduleRefill(): void {
-    if (this.refillTimer !== null) return;
+  /** Schedule a one-shot timer to flush the queue when the next token arrives. */
+  private _scheduleNext(): void {
+    if (this.timer !== null) return;
 
-    this.refillTimer = setInterval(() => {
+    const delay = Math.max(1, Math.ceil(1000 / this.maxRequestsPerSecond));
+    this.timer = setTimeout(() => {
+      this.timer = null;
       this._refill();
       this._flush();
-
-      if (this.queue.length === 0) {
-        clearInterval(this.refillTimer!);
-        this.refillTimer = null;
+      if (this.queue.length > 0 && this.tokens < 1) {
+        this._scheduleNext();
       }
-    }, this.refillIntervalMs);
+    }, delay);
   }
 
   /** Grant tokens to waiting requests in FIFO order. */

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -13,11 +13,10 @@ import { RateLimiter } from '../src/utils/rate-limiter';
 
 /**
  * Advance fake timers AND flush microtask queue so that Promise continuations
- * scheduled inside RateLimiter._scheduleRefill() have a chance to run.
+ * scheduled inside RateLimiter timer callbacks have a chance to run.
  */
 async function tick(ms: number): Promise<void> {
   jest.advanceTimersByTime(ms);
-  // Drain the microtask queue (multiple await-yields for nested promises)
   for (let i = 0; i < 10; i++) {
     await Promise.resolve();
   }
@@ -41,28 +40,28 @@ describe('RateLimiter', () => {
   // -------------------------------------------------------------------------
 
   describe('constructor validation', () => {
-    it('throws when capacity is 0', () => {
-      expect(() => new RateLimiter({ capacity: 0, refillRate: 1, refillIntervalMs: 100 })).toThrow(
-        'capacity must be > 0',
-      );
+    it('throws when maxRequestsPerSecond is 0', () => {
+      expect(
+        () => new RateLimiter({ maxRequestsPerSecond: 0, maxBurst: 5 }),
+      ).toThrow('maxRequestsPerSecond must be > 0');
     });
 
-    it('throws when capacity is negative', () => {
-      expect(() => new RateLimiter({ capacity: -1, refillRate: 1, refillIntervalMs: 100 })).toThrow(
-        'capacity must be > 0',
-      );
+    it('throws when maxRequestsPerSecond is negative', () => {
+      expect(
+        () => new RateLimiter({ maxRequestsPerSecond: -1, maxBurst: 5 }),
+      ).toThrow('maxRequestsPerSecond must be > 0');
     });
 
-    it('throws when refillRate is 0', () => {
-      expect(() => new RateLimiter({ capacity: 5, refillRate: 0, refillIntervalMs: 100 })).toThrow(
-        'refillRate must be > 0',
-      );
+    it('throws when maxBurst is 0', () => {
+      expect(
+        () => new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 0 }),
+      ).toThrow('maxBurst must be > 0');
     });
 
-    it('throws when refillIntervalMs is 0', () => {
-      expect(() => new RateLimiter({ capacity: 5, refillRate: 1, refillIntervalMs: 0 })).toThrow(
-        'refillIntervalMs must be > 0',
-      );
+    it('throws when maxBurst is negative', () => {
+      expect(
+        () => new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: -1 }),
+      ).toThrow('maxBurst must be > 0');
     });
   });
 
@@ -71,14 +70,14 @@ describe('RateLimiter', () => {
   // -------------------------------------------------------------------------
 
   describe('initial state', () => {
-    it('starts with capacity tokens', () => {
-      const limiter = new RateLimiter({ capacity: 5, refillRate: 1, refillIntervalMs: 1000 });
-      expect(limiter.availableTokens).toBe(5);
+    it('starts with maxBurst tokens', () => {
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 5 });
+      expect(limiter.getRemainingCapacity()).toBe(5);
       limiter.destroy();
     });
 
     it('reports zero items in queue initially', () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 1000 });
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       expect(limiter.queueLength).toBe(0);
       limiter.destroy();
     });
@@ -90,25 +89,25 @@ describe('RateLimiter', () => {
 
   describe('tryAcquire()', () => {
     it('returns true and decrements token count when tokens are available', () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 1000 });
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       expect(limiter.tryAcquire()).toBe(true);
-      expect(limiter.availableTokens).toBe(2);
+      expect(limiter.getRemainingCapacity()).toBe(2);
       limiter.destroy();
     });
 
     it('returns false when bucket is empty', () => {
-      const limiter = new RateLimiter({ capacity: 1, refillRate: 1, refillIntervalMs: 1000 });
-      limiter.tryAcquire(); // drain the single token
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 1 });
+      limiter.tryAcquire();
       expect(limiter.tryAcquire()).toBe(false);
       limiter.destroy();
     });
 
     it('can drain all tokens to zero', () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 1000 });
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       expect(limiter.tryAcquire()).toBe(true);
       expect(limiter.tryAcquire()).toBe(true);
       expect(limiter.tryAcquire()).toBe(true);
-      expect(limiter.availableTokens).toBe(0);
+      expect(limiter.getRemainingCapacity()).toBe(0);
       expect(limiter.tryAcquire()).toBe(false);
       limiter.destroy();
     });
@@ -120,42 +119,38 @@ describe('RateLimiter', () => {
 
   describe('token refill accuracy', () => {
     it('replenishes tokens after one refill interval', async () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 100 });
-      // Drain the bucket
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       limiter.tryAcquire();
       limiter.tryAcquire();
       limiter.tryAcquire();
-      expect(limiter.availableTokens).toBe(0);
+      expect(limiter.getRemainingCapacity()).toBe(0);
 
       await tick(100);
 
-      expect(limiter.availableTokens).toBe(1);
+      expect(limiter.getRemainingCapacity()).toBe(1);
       limiter.destroy();
     });
 
-    it('does not exceed capacity when multiple intervals elapse', async () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 100 });
-      // Drain the bucket
+    it('does not exceed maxBurst when multiple intervals elapse', async () => {
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       limiter.tryAcquire();
       limiter.tryAcquire();
       limiter.tryAcquire();
 
-      // Advance well past capacity
       await tick(1000);
 
-      expect(limiter.availableTokens).toBe(3); // capped at capacity
+      expect(limiter.getRemainingCapacity()).toBe(3);
       limiter.destroy();
     });
 
-    it('adds multiple tokens per interval when refillRate > 1', async () => {
-      const limiter = new RateLimiter({ capacity: 10, refillRate: 3, refillIntervalMs: 100 });
-      // Drain completely
+    it('adds multiple tokens per interval when maxRequestsPerSecond > 1', async () => {
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 30, maxBurst: 10 });
       for (let i = 0; i < 10; i++) limiter.tryAcquire();
-      expect(limiter.availableTokens).toBe(0);
+      expect(limiter.getRemainingCapacity()).toBe(0);
 
       await tick(100);
 
-      expect(limiter.availableTokens).toBe(3);
+      expect(limiter.getRemainingCapacity()).toBe(3);
       limiter.destroy();
     });
   });
@@ -165,22 +160,22 @@ describe('RateLimiter', () => {
   // -------------------------------------------------------------------------
 
   describe('burst behaviour', () => {
-    it('allows up to capacity requests immediately without waiting', async () => {
-      const capacity = 5;
-      const limiter = new RateLimiter({ capacity, refillRate: 1, refillIntervalMs: 1000 });
+    it('allows up to maxBurst requests immediately without waiting', async () => {
+      const burst = 5;
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 1, maxBurst: burst });
       const results: boolean[] = [];
 
-      for (let i = 0; i < capacity; i++) {
+      for (let i = 0; i < burst; i++) {
         results.push(limiter.tryAcquire());
       }
 
       expect(results).toEqual([true, true, true, true, true]);
-      expect(limiter.availableTokens).toBe(0);
+      expect(limiter.getRemainingCapacity()).toBe(0);
       limiter.destroy();
     });
 
-    it('rejects the (capacity + 1)th tryAcquire in a burst', () => {
-      const limiter = new RateLimiter({ capacity: 2, refillRate: 1, refillIntervalMs: 1000 });
+    it('rejects the (maxBurst + 1)th tryAcquire in a burst', () => {
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 1, maxBurst: 2 });
       limiter.tryAcquire();
       limiter.tryAcquire();
       expect(limiter.tryAcquire()).toBe(false);
@@ -194,44 +189,41 @@ describe('RateLimiter', () => {
 
   describe('acquire() — FIFO ordering', () => {
     it('resolves immediately when tokens are available', async () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 100 });
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       const resolved = jest.fn();
 
       limiter.acquire().then(resolved);
-      await Promise.resolve(); // flush microtasks
+      await Promise.resolve();
 
       expect(resolved).toHaveBeenCalledTimes(1);
       limiter.destroy();
     });
 
     it('queues requests when bucket is empty', async () => {
-      const limiter = new RateLimiter({ capacity: 1, refillRate: 1, refillIntervalMs: 100 });
-      limiter.tryAcquire(); // drain
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 1 });
+      limiter.tryAcquire();
 
       const resolved = jest.fn();
       limiter.acquire().then(resolved);
       await Promise.resolve();
 
-      expect(resolved).not.toHaveBeenCalled(); // still waiting
+      expect(resolved).not.toHaveBeenCalled();
       expect(limiter.queueLength).toBe(1);
 
       limiter.destroy();
     });
 
     it('resolves queued requests in FIFO order after refill', async () => {
-      const limiter = new RateLimiter({ capacity: 1, refillRate: 1, refillIntervalMs: 100 });
-      limiter.tryAcquire(); // drain
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 1 });
+      limiter.tryAcquire();
 
       const order: number[] = [];
       limiter.acquire().then(() => order.push(1));
       limiter.acquire().then(() => order.push(2));
       limiter.acquire().then(() => order.push(3));
 
-      // First refill — grants token to request #1
       await tick(100);
-      // Second refill — grants token to request #2
       await tick(100);
-      // Third refill — grants token to request #3
       await tick(100);
 
       expect(order).toEqual([1, 2, 3]);
@@ -239,11 +231,41 @@ describe('RateLimiter', () => {
     });
 
     it('handles multiple concurrent acquire() calls within burst capacity', async () => {
-      const limiter = new RateLimiter({ capacity: 3, refillRate: 1, refillIntervalMs: 100 });
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 3 });
       const promises = [limiter.acquire(), limiter.acquire(), limiter.acquire()];
 
       const results = await Promise.all(promises);
       expect(results).toHaveLength(3);
+      limiter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance: enforces rate limit without exceeding by more than 1 request
+  // -------------------------------------------------------------------------
+
+  describe('rate limit enforcement', () => {
+    it('does not exceed maxRequestsPerSecond in steady state', async () => {
+      // 3 req/s with burst of 3. After burst is consumed, at most 1 token
+      // refills per ~333ms interval.
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 3, maxBurst: 3 });
+
+      // Drain the burst
+      limiter.tryAcquire();
+      limiter.tryAcquire();
+      limiter.tryAcquire();
+      expect(limiter.getRemainingCapacity()).toBe(0);
+
+      // After 1 second (3 tokens worth of refill time), we should have at most 3 tokens
+      await tick(1000);
+      expect(limiter.getRemainingCapacity()).toBe(3);
+
+      // Consume all 3 — they should all succeed
+      expect(limiter.tryAcquire()).toBe(true);
+      expect(limiter.tryAcquire()).toBe(true);
+      expect(limiter.tryAcquire()).toBe(true);
+      expect(limiter.tryAcquire()).toBe(false);
+
       limiter.destroy();
     });
   });
@@ -254,8 +276,8 @@ describe('RateLimiter', () => {
 
   describe('destroy()', () => {
     it('resolves pending requests when destroyed', async () => {
-      const limiter = new RateLimiter({ capacity: 1, refillRate: 1, refillIntervalMs: 1000 });
-      limiter.tryAcquire(); // drain
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 1 });
+      limiter.tryAcquire();
 
       const resolved = jest.fn();
       limiter.acquire().then(resolved);
@@ -269,8 +291,8 @@ describe('RateLimiter', () => {
       expect(resolved).toHaveBeenCalledTimes(1);
     });
 
-    it('stops the refill timer so no more tokens are emitted', async () => {
-      const limiter = new RateLimiter({ capacity: 2, refillRate: 1, refillIntervalMs: 100 });
+    it('stops the timer so no more tokens are generated', async () => {
+      const limiter = new RateLimiter({ maxRequestsPerSecond: 10, maxBurst: 2 });
       limiter.tryAcquire();
       limiter.tryAcquire();
 
@@ -278,9 +300,6 @@ describe('RateLimiter', () => {
 
       await tick(500);
 
-      // After destroy the timer is cleared; we expect availableTokens not to have grown
-      // beyond 0 (it was drained before destroy).  We cannot call tryAcquire after
-      // destroy but we can verify the queue is empty.
       expect(limiter.queueLength).toBe(0);
     });
   });


### PR DESCRIPTION
# Closes #292

## Summary

Implements a token-bucket rate limiter for throttling outbound Soroban RPC requests. Public RPC endpoints enforce rate limits (typically 10–50 req/s); this utility self-throttles the SDK to prevent 429 errors that cascade into failed transactions.

## Changes

### `src/utils/rate-limiter.ts` — Rewritten
- **Token-bucket algorithm** with configurable `maxRequestsPerSecond` and `maxBurst`
- **`acquire(): Promise<void>`** — blocks (via FIFO queue) until a token is available, then consumes one
- **`tryAcquire(): boolean`** — non-blocking path for optional pre-flight checks
- **`getRemainingCapacity(): number`** — returns current token count for monitoring
- **`queueLength` getter** — visibility into pending request depth
- **`destroy()`** — resolves all pending requests and clears the internal timer
- **`setTimeout`-based scheduling** — no polling, no CPU spinning; timer fires only when the queue is non-empty
- Token refill uses elapsed-time calculation with fractional carryover for precise rate enforcement

### `tests/rate-limiter.test.ts` — Updated (21 tests, all passing)
| Category | Tests | What it covers |
|---|---|---|
| Constructor | 4 | Rejects zero/negative `maxRequestsPerSecond` and `maxBurst` |
| Initial state | 2 | Starts with `maxBurst` tokens, empty queue |
| `tryAcquire()` | 3 | Token consumption, empty bucket, full drain |
| Refill accuracy | 3 | Single-interval refill, capacity cap, multi-rate refill |
| Burst behavior | 2 | Full burst consumption, burst-limit rejection |
| FIFO ordering | 4 | Immediate resolve, queuing, order preservation, concurrent burst |
| Rate enforcement | 1 | Steady-state limit not exceeded |
| `destroy()` | 2 | Pending resolution, timer cleanup |

### `src/utils/index.ts` — Extended
- Exports `RateLimiter` (class) and `RateLimiterOptions` (type)

## Acceptance criteria

- [x] Enforces rate limit without exceeding by more than 1 request
- [x] Burst capacity allows short spikes
- [x] `acquire()` resolves in order (FIFO)
- [x] No CPU spinning — uses `setTimeout` internally