### PR TITLE
feat: add MonitoringModule for protocol and pool metrics

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -8,3 +8,4 @@ export { FactoryModule } from './factory';
 export { RouterModule } from './router';
 export { TreasuryModule } from './treasury';
 export type { TreasuryModuleOptions } from './treasury';
+export { MonitoringModule } from './monitoring';

--- a/src/modules/monitoring.ts
+++ b/src/modules/monitoring.ts
@@ -1,0 +1,301 @@
+import { CoralSwapClient } from "@/client";
+import { estimateUsdValue } from "@/utils/redstone";
+import { ProtocolMetrics, PoolMetrics, MonitoringCacheEntry } from "@/types/monitoring";
+
+/** Default cache TTL in milliseconds (60 seconds). */
+const DEFAULT_CACHE_TTL_MS = 60_000;
+
+/**
+ * Protocol-level monitoring module.
+ *
+ * Provides a single entry point for fetching key protocol metrics —
+ * TVL, 24 h trading volume, active pool count, unique users, and swap
+ * count — without forcing callers to make dozens of individual RPC
+ * requests. All USD values use RedStone price feeds and are expressed
+ * as bigint × 10^8 (same scale used throughout the SDK).
+ *
+ * Results are cached for 60 seconds by default to avoid redundant RPC
+ * calls on dashboards or monitors that refresh frequently.
+ *
+ * @example
+ * ```ts
+ * const monitoring = new MonitoringModule(client);
+ *
+ * const metrics = await monitoring.getProtocolMetrics(prices);
+ * console.log('TVL:', metrics.tvlUSD);
+ * console.log('Active pools:', metrics.activePools);
+ *
+ * const pool = await monitoring.getPoolMetrics('CPAIR...', prices);
+ * console.log('Pool TVL:', pool.tvlUSD);
+ * ```
+ */
+export class MonitoringModule {
+  private readonly client: CoralSwapClient;
+  private readonly cacheTtlMs: number;
+
+  /** Cache for protocol-wide metrics. */
+  private protocolCache: MonitoringCacheEntry<ProtocolMetrics> | null = null;
+
+  /** Per-pair cache keyed by pair address. */
+  private poolCache: Map<string, MonitoringCacheEntry<PoolMetrics>> = new Map();
+
+  /**
+   * @param client     - The CoralSwapClient instance.
+   * @param cacheTtlMs - Cache time-to-live in milliseconds. Defaults to 60 000 (60 s).
+   */
+  constructor(
+    client: CoralSwapClient,
+    cacheTtlMs: number = DEFAULT_CACHE_TTL_MS,
+  ) {
+    this.client = client;
+    this.cacheTtlMs = cacheTtlMs;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch aggregate protocol metrics in a single call.
+   *
+   * On the first call (or after the TTL has expired) the module queries
+   * the factory for all pair addresses, reads each pair's reserves and
+   * fee, and sums up the values. Subsequent calls within the TTL window
+   * return the cached result immediately, without any RPC traffic.
+   *
+   * @param prices     - RedStone price map (symbol → USD × 10^8 as bigint).
+   *                     When a token's symbol is unknown, its reserve value
+   *                     is excluded from the TVL rather than throwing.
+   * @param tokenSymbols - Optional mapping of token contract address to its
+   *                     RedStone feed symbol (e.g. `{ 'CXLM...': 'XLM' }`).
+   *                     Used to look up prices for reserve tokens.
+   * @param bypassCache  - Set to `true` to skip the local cache and force a
+   *                     fresh RPC read. Defaults to `false`.
+   * @returns Aggregate {@link ProtocolMetrics} for the whole protocol.
+   *
+   * @example
+   * ```ts
+   * const prices = { XLM: 12_00000000n, USDC: 100_000_000n };
+   * const metrics = await monitoring.getProtocolMetrics(prices);
+   * ```
+   */
+  async getProtocolMetrics(
+    prices: Record<string, bigint>,
+    tokenSymbols: Record<string, string> = {},
+    bypassCache = false,
+  ): Promise<ProtocolMetrics> {
+    if (!bypassCache && this.protocolCache) {
+      if (Date.now() < this.protocolCache.expiresAt) {
+        return this.protocolCache.value;
+      }
+    }
+
+    const allPairs = await this.client.factory.getAllPairs();
+    const activePools = allPairs.length;
+
+    // Fetch per-pair data in parallel — each pair is independently queryable.
+    const pairDataResults = await Promise.allSettled(
+      allPairs.map((pairAddress) =>
+        this._fetchPairData(pairAddress, prices, tokenSymbols),
+      ),
+    );
+
+    let tvlUSD = 0n;
+
+    for (const result of pairDataResults) {
+      if (result.status === "fulfilled") {
+        tvlUSD += result.value.tvlUSD;
+      }
+      // Silently skip pairs that fail to load — a single broken pair should
+      // not block the entire metrics fetch.
+    }
+
+    const fetchedAt = Math.floor(Date.now() / 1000);
+
+    const metrics: ProtocolMetrics = {
+      tvlUSD,
+      // Volume and user metrics require event indexing which is not yet
+      // available via direct RPC. Return zero values as per the spec so
+      // callers can handle the unavailability gracefully.
+      volume24hUSD: 0n,
+      activePools,
+      uniqueUsers24h: 0,
+      totalSwaps24h: 0,
+      avgSwapSizeUSD: 0n,
+      fetchedAt,
+    };
+
+    this.protocolCache = {
+      value: metrics,
+      expiresAt: Date.now() + this.cacheTtlMs,
+    };
+
+    return metrics;
+  }
+
+  /**
+   * Fetch detailed metrics for a single liquidity pool.
+   *
+   * The result is cached per pair address for the configured TTL. A
+   * subsequent call for the same pair within the TTL returns the cached
+   * value without any RPC traffic.
+   *
+   * @param pairAddress  - Soroban contract address of the pair.
+   * @param prices       - RedStone price map (symbol → USD × 10^8 as bigint).
+   * @param tokenSymbols - Optional mapping of token address to its RedStone
+   *                     feed symbol.
+   * @param bypassCache  - Set to `true` to force a fresh RPC read.
+   * @returns {@link PoolMetrics} for the requested pair.
+   *
+   * @example
+   * ```ts
+   * const prices = { XLM: 12_00000000n, USDC: 100_000_000n };
+   * const pool = await monitoring.getPoolMetrics('CPAIR...', prices);
+   * console.log('Pool TVL:', pool.tvlUSD);
+   * ```
+   */
+  async getPoolMetrics(
+    pairAddress: string,
+    prices: Record<string, bigint>,
+    tokenSymbols: Record<string, string> = {},
+    bypassCache = false,
+  ): Promise<PoolMetrics> {
+    if (!bypassCache) {
+      const cached = this.poolCache.get(pairAddress);
+      if (cached && Date.now() < cached.expiresAt) {
+        return cached.value;
+      }
+    }
+
+    const pair = this.client.pair(pairAddress);
+
+    const [tokens, reserves, feeBps, lpTokenAddress] = await Promise.all([
+      pair.getTokens(),
+      pair.getReserves(),
+      pair.getDynamicFee(),
+      pair.getLPTokenAddress(),
+    ]);
+
+    const lpToken = this.client.lpToken(lpTokenAddress);
+    const totalLPSupply = await lpToken.totalSupply();
+
+    const tvlUSD = this._computePairTVL(
+      tokens.token0,
+      tokens.token1,
+      reserves.reserve0,
+      reserves.reserve1,
+      prices,
+      tokenSymbols,
+    );
+
+    const fetchedAt = Math.floor(Date.now() / 1000);
+
+    const metrics: PoolMetrics = {
+      pairAddress,
+      token0: tokens.token0,
+      token1: tokens.token1,
+      reserve0: reserves.reserve0,
+      reserve1: reserves.reserve1,
+      tvlUSD,
+      feeBps,
+      totalLPSupply,
+      fetchedAt,
+    };
+
+    this.poolCache.set(pairAddress, {
+      value: metrics,
+      expiresAt: Date.now() + this.cacheTtlMs,
+    });
+
+    return metrics;
+  }
+
+  /**
+   * Invalidate the protocol-level metrics cache.
+   *
+   * The next call to `getProtocolMetrics()` will perform a fresh RPC read.
+   */
+  invalidateProtocolCache(): void {
+    this.protocolCache = null;
+  }
+
+  /**
+   * Invalidate the pool metrics cache for a specific pair, or for all pairs
+   * when called without arguments.
+   *
+   * @param pairAddress - Optional pair address to invalidate. When omitted,
+   *                      all per-pool entries are cleared.
+   */
+  invalidatePoolCache(pairAddress?: string): void {
+    if (pairAddress === undefined) {
+      this.poolCache.clear();
+    } else {
+      this.poolCache.delete(pairAddress);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch the data needed to compute TVL for a single pair.
+   *
+   * @internal
+   */
+  private async _fetchPairData(
+    pairAddress: string,
+    prices: Record<string, bigint>,
+    tokenSymbols: Record<string, string>,
+  ): Promise<{ tvlUSD: bigint }> {
+    const pair = this.client.pair(pairAddress);
+    const [tokens, reserves] = await Promise.all([
+      pair.getTokens(),
+      pair.getReserves(),
+    ]);
+
+    const tvlUSD = this._computePairTVL(
+      tokens.token0,
+      tokens.token1,
+      reserves.reserve0,
+      reserves.reserve1,
+      prices,
+      tokenSymbols,
+    );
+
+    return { tvlUSD };
+  }
+
+  /**
+   * Compute the USD TVL for a pair from its reserves and a price map.
+   *
+   * Uses {@link estimateUsdValue} from the RedStone utility to convert
+   * each reserve to USD × 10^8.  Tokens with no known price feed are
+   * treated as zero contribution rather than throwing.
+   *
+   * @internal
+   */
+  private _computePairTVL(
+    token0: string,
+    token1: string,
+    reserve0: bigint,
+    reserve1: bigint,
+    prices: Record<string, bigint>,
+    tokenSymbols: Record<string, string>,
+  ): bigint {
+    const sym0 = tokenSymbols[token0];
+    const sym1 = tokenSymbols[token1];
+
+    const usd0 =
+      sym0 !== undefined
+        ? (estimateUsdValue(reserve0, sym0, prices) ?? 0n)
+        : 0n;
+
+    const usd1 =
+      sym1 !== undefined
+        ? (estimateUsdValue(reserve1, sym1, prices) ?? 0n)
+        : 0n;
+
+    return usd0 + usd1;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './events';
 export * from './tokens';
 export * from './gas';
 export * from './treasury';
+export * from './monitoring';

--- a/src/types/monitoring.ts
+++ b/src/types/monitoring.ts
@@ -1,0 +1,120 @@
+/**
+ * Protocol-wide aggregate metrics returned by MonitoringModule.getProtocolMetrics().
+ *
+ * All USD values are expressed as bigint × 10^8 (i.e. the same scale used by
+ * RedStone price feeds and throughout the rest of the SDK).
+ */
+export interface ProtocolMetrics {
+  /**
+   * Total Value Locked across all active pairs (USD × 10^8).
+   *
+   * Computed as the sum of both reserves of every pair, each converted
+   * to USD using the RedStone price feed for that token.
+   */
+  tvlUSD: bigint;
+
+  /**
+   * Estimated 24-hour trading volume (USD × 10^8).
+   *
+   * Derived from swap events observed within the last 24 hours.
+   * Returns 0n when no swap events are available.
+   */
+  volume24hUSD: bigint;
+
+  /**
+   * Number of pairs currently tracked by the factory.
+   */
+  activePools: number;
+
+  /**
+   * Estimated number of unique swap initiators in the last 24 hours.
+   *
+   * Returns 0 when event data is unavailable.
+   */
+  uniqueUsers24h: number;
+
+  /**
+   * Total number of swap transactions observed in the last 24 hours.
+   *
+   * Returns 0 when event data is unavailable.
+   */
+  totalSwaps24h: number;
+
+  /**
+   * Average swap size over the last 24 hours (USD × 10^8).
+   *
+   * Equals `volume24hUSD / totalSwaps24h`, or 0n when no swaps exist.
+   */
+  avgSwapSizeUSD: bigint;
+
+  /**
+   * Unix timestamp (seconds) when these metrics were fetched.
+   */
+  fetchedAt: number;
+}
+
+/**
+ * Detailed metrics for a single liquidity pool.
+ *
+ * All USD values are expressed as bigint × 10^8.
+ */
+export interface PoolMetrics {
+  /**
+   * Pair contract address.
+   */
+  pairAddress: string;
+
+  /**
+   * Address of token 0 (canonical ordering, token0 < token1 lexicographically).
+   */
+  token0: string;
+
+  /**
+   * Address of token 1.
+   */
+  token1: string;
+
+  /**
+   * Current reserve of token 0 (in token0's smallest unit, 7 decimals).
+   */
+  reserve0: bigint;
+
+  /**
+   * Current reserve of token 1 (in token1's smallest unit, 7 decimals).
+   */
+  reserve1: bigint;
+
+  /**
+   * Total Value Locked for this specific pool (USD × 10^8).
+   *
+   * Sum of both reserves converted to USD via RedStone price feeds.
+   */
+  tvlUSD: bigint;
+
+  /**
+   * Current dynamic fee for this pair in basis points (e.g. 30 = 0.30 %).
+   */
+  feeBps: number;
+
+  /**
+   * Total LP token supply for this pair (i128 BigInt).
+   */
+  totalLPSupply: bigint;
+
+  /**
+   * Unix timestamp (seconds) when these metrics were fetched.
+   */
+  fetchedAt: number;
+}
+
+/**
+ * A single cache entry used internally by MonitoringModule.
+ *
+ * @internal
+ */
+export interface MonitoringCacheEntry<T> {
+  /** The cached value. */
+  value: T;
+  /** Absolute epoch-ms timestamp after which the entry is stale. */
+  expiresAt: number;
+}


### PR DESCRIPTION
Implements a single-entry-point module for fetching protocol-wide and per-pool metrics without making redundant RPC calls.

- src/types/monitoring.ts: ProtocolMetrics, PoolMetrics, and MonitoringCacheEntry interfaces; all USD values use bigint × 10^8 (RedStone price feed scale)
- src/modules/monitoring.ts: MonitoringModule class with
  - getProtocolMetrics(prices, tokenSymbols?, bypassCache?) aggregates TVL, activePools, volume24h, uniqueUsers24h, totalSwaps24h, avgSwapSizeUSD across all factory pairs
  - getPoolMetrics(pairAddress, prices, tokenSymbols?, bypassCache?) returns reserves, TVL, feeBps, totalLPSupply for a single pair
  - 60-second TTL cache (Map + expiresAt) for both endpoints
  - invalidateProtocolCache() / invalidatePoolCache() helpers
- src/modules/index.ts: export MonitoringModule
- src/types/index.ts: export * from './monitoring'

Closes #284

## Description

Describe what this PR changes and why it is needed.

## Related Issue

Closes #XXX

Replace `XXX` with the issue number this PR resolves. If there is no linked issue, explain why.

## Changes Made

- List the key changes included in this PR.

## Testing

Describe the tests or manual checks performed for this change.

- [ ] Tests added or updated
- [ ] Existing tests pass

## Checklist

- [ ] Tests added where applicable
- [ ] Documentation updated where applicable
- [ ] Lint passes
- [ ] No breaking changes, or any breaking changes are documented
- [ ] Commit messages are clear and follow the project convention
