### PR TITLE
feat: add contract status health reporting

### DIFF
--- a/src/modules/health-check.ts
+++ b/src/modules/health-check.ts
@@ -14,8 +14,18 @@
  *  - `getBestEndpoint`     — rank endpoints by latency + error rate
  */
 
-import { SorobanRpc, Contract, xdr, StrKey } from '@stellar/stellar-sdk';
+import {
+  SorobanRpc,
+  Contract,
+  xdr,
+  StrKey,
+  TransactionBuilder,
+  Address,
+  nativeToScVal,
+} from '@stellar/stellar-sdk';
 
+import { NETWORK_CONFIGS, TESTNET_NETWORK } from '@/config';
+import { Network } from '@/types/common';
 import { sleep } from '@/utils/retry';
 
 /** Default RPC health-probe timeout in milliseconds. */
@@ -63,16 +73,24 @@ export interface LatencyStats {
  * Result of a contract deployment/status check.
  */
 export interface ContractStatus {
-  /** True when the contract exists on-chain and responded to a ledger read. */
-  deployed: boolean;
-  /** True when the contract's TTL has not yet expired. */
-  ttlValid: boolean;
-  /** Latest ledger at entry is live. 0 when unknown. */
-  liveUntilLedger: number;
-  /** Number of ledgers remaining until expiry; -1 when not determinable. */
-  remainingLedgers: number;
-  /** Error message when the check failed; `null` on success. */
-  error: string | null;
+  /** True when the contract instance entry is present in the ledger state. */
+  isDeployed: boolean;
+  /** True when the contract responds to a read-only simulation. */
+  isOperational: boolean;
+  /** Number of ledgers remaining before the contract instance TTL expires. */
+  ttlRemaining: number;
+  /** Last ledger sequence known to have touched the contract instance. */
+  lastActivity: number;
+  /** Legacy alias for `isDeployed`. */
+  deployed?: boolean;
+  /** Legacy alias for `ttlRemaining > 0`. */
+  ttlValid?: boolean;
+  /** Legacy alias for the internal live-until ledger sequence. */
+  liveUntilLedger?: number;
+  /** Legacy alias for TTL remaining in ledger counts. */
+  remainingLedgers?: number;
+  /** Error message when the check failed; `null` when healthy. */
+  error?: string | null;
 }
 
 /**
@@ -279,55 +297,78 @@ export async function getRPCLatency(
 /**
  * Check whether a Soroban contract is deployed and still within its TTL.
  *
- * Uses the Stellar RPC `getContractData` with a ledger-key read for the
- * contract instance.  This is cheaper than a full simulation and relies
- * on the ledger entry being present in the live state.
+ * When `contractId` is omitted, the SDK resolves the default Factory and
+ * Router contracts from the configured network defaults and returns an array
+ * of status objects for each of them. When a legacy `(url, contractId)`
+ * pair is supplied, the function preserves the previous behaviour while
+ * adding a simulation-backed operational check.
  *
- * The TTL check reports false if the entry's `liveUntilLedger` is past
- * the current ledger, meaning the contract will expire soon unless bumped.
- *
- * @param url        - The Soroban RPC endpoint URL.
- * @param contractId - The Stellar contract address (C...).
- * @returns ContractStatus with deployment status and TTL information.
- *
- * @example
- * const status = await getContractStatus(
- *   'https://soroban-testnet.stellar.org',
- *   'CA3J7GYCCX7NVPY...',
- * );
- * if (!status.deployed) console.error('Contract is not deployed');
+ * @param contractAddressOrUrl - Optional contract ID, or the legacy RPC URL.
+ * @param maybeContractId      - Optional legacy contract ID when using the old API.
+ * @returns A single `ContractStatus` or an array of statuses when checking defaults.
  */
 export async function getContractStatus(
+  contractAddressOrUrl?: string,
+  maybeContractId?: string,
+): Promise<ContractStatus | ContractStatus[]> {
+  if (typeof maybeContractId === 'string') {
+    return probeContractStatusAtUrl(contractAddressOrUrl ?? '', maybeContractId);
+  }
+
+  if (typeof contractAddressOrUrl === 'string') {
+    const status = await probeContractStatusAtUrl(
+      getDefaultRpcUrl(),
+      contractAddressOrUrl,
+    );
+    return status;
+  }
+
+  const defaultTargets = getDefaultHealthCheckTargets();
+  if (defaultTargets.length === 0) {
+    return [];
+  }
+
+  return Promise.all(
+    defaultTargets.map((target) =>
+      probeContractStatusAtUrl(target.rpcUrl, target.contractAddress, target.kind),
+    ),
+  );
+}
+
+function getDefaultHealthCheckTargets(): Array<{ rpcUrl: string; contractAddress: string; kind: 'factory' | 'router' | 'custom' }> {
+  const rpcUrl = getDefaultRpcUrl();
+  const factoryAddress = NETWORK_CONFIGS[Network.TESTNET].factoryAddress || TESTNET_NETWORK.factoryAddress;
+  const routerAddress = NETWORK_CONFIGS[Network.TESTNET].routerAddress || TESTNET_NETWORK.routerAddress;
+
+  const targets: Array<{ rpcUrl: string; contractAddress: string; kind: 'factory' | 'router' | 'custom' }> = [];
+  if (factoryAddress) targets.push({ rpcUrl, contractAddress: factoryAddress, kind: 'factory' });
+  if (routerAddress) targets.push({ rpcUrl, contractAddress: routerAddress, kind: 'router' });
+  return targets;
+}
+
+function getDefaultRpcUrl(): string {
+  return NETWORK_CONFIGS[Network.TESTNET].rpcUrl || TESTNET_NETWORK.rpcUrl;
+}
+
+async function probeContractStatusAtUrl(
   url: string,
   contractId: string,
+  kind: 'factory' | 'router' | 'custom' = 'custom',
 ): Promise<ContractStatus> {
   if (!url || typeof url !== 'string') {
-    return {
-      deployed: false,
-      ttlValid: false,
-      liveUntilLedger: 0,
-      remainingLedgers: -1,
-      error: 'Invalid RPC URL',
-    };
+    return newContractStatus(false, false, 0, 0, 'Invalid RPC URL');
   }
 
   let server: SorobanRpc.Server;
   try {
     server = makeServer(url);
   } catch (err) {
-    return {
-      deployed: false,
-      ttlValid: false,
-      liveUntilLedger: 0,
-      remainingLedgers: -1,
-      error: err instanceof Error ? err.message : 'Failed to construct RPC server',
-    };
+    return newContractStatus(false, false, 0, 0, err instanceof Error ? err.message : 'Failed to construct RPC server');
   }
 
   try {
     const contract = new Contract(contractId);
     const rawContractId = StrKey.decodeContract(contractId);
-    // Wrap the raw 32-byte contract hash in an ScVal Bytes for the instance key.
     const key = xdr.ScVal.scvBytes(Buffer.from(rawContractId));
 
     const response = await Promise.race([
@@ -337,31 +378,24 @@ export async function getContractStatus(
       ),
     ]);
 
-    const entry = response as any;
-    const result = response as any;
+    const entry = response as { liveUntilLedgerSeq?: number; latestLedger?: number; lastModifiedLedgerSeq?: number };
+    const liveUntilLedger = entry.liveUntilLedgerSeq ?? 0;
+    const latestLedger = entry.latestLedger ?? 0;
+    const lastActivity = entry.lastModifiedLedgerSeq ?? latestLedger;
 
-    if (!result || !('liveUntilLedgerSeq' in result) || (result.liveUntilLedgerSeq as number) <= 0) {
-      return {
-        deployed: false,
-        ttlValid: false,
-        liveUntilLedger: 0,
-        remainingLedgers: -1,
-        error: 'Contract ledger entry not found',
-      };
+    if (!entry || liveUntilLedger <= 0) {
+      return newContractStatus(false, false, 0, 0, 'Contract ledger entry not found');
     }
 
-    const liveUntilLedger = (result.liveUntilLedgerSeq as number) ?? 0;
-    const currentLedger = entry.latestLedger ?? 0;
-    const remainingLedgers =
-      currentLedger > 0 ? liveUntilLedger - currentLedger : -1;
-    const ttlValid = liveUntilLedger > currentLedger;
+    const ttlRemaining = latestLedger > 0 ? liveUntilLedger - latestLedger : 0;
+    const isOperational = await simulateReadOnlyContract(server, contractId, kind);
 
     return {
+      ...newContractStatus(true, isOperational, ttlRemaining, lastActivity, null),
       deployed: true,
-      ttlValid,
+      ttlValid: ttlRemaining > 0,
       liveUntilLedger,
-      remainingLedgers,
-      error: null,
+      remainingLedgers: ttlRemaining,
     };
   } catch (err) {
     const isMissing = err instanceof Error && (
@@ -370,21 +404,71 @@ export async function getContractStatus(
       msgIncludes(err.message, 'missing')
     );
     if (isMissing) {
-      return {
-        deployed: false,
-        ttlValid: false,
-        liveUntilLedger: 0,
-        remainingLedgers: -1,
-        error: 'Contract not deployed',
-      };
+      return newContractStatus(false, false, 0, 0, 'Contract not deployed');
     }
-    return {
-      deployed: false,
-      ttlValid: false,
-      liveUntilLedger: 0,
-      remainingLedgers: -1,
-      error: err instanceof Error ? err.message : 'Unknown error',
-    };
+    return newContractStatus(false, false, 0, 0, err instanceof Error ? err.message : 'Unknown error');
+  }
+}
+
+function newContractStatus(
+  isDeployed: boolean,
+  isOperational: boolean,
+  ttlRemaining: number,
+  lastActivity: number,
+  error: string | null,
+): ContractStatus {
+  return {
+    isDeployed,
+    isOperational,
+    ttlRemaining,
+    lastActivity,
+    deployed: isDeployed,
+    ttlValid: ttlRemaining > 0,
+    liveUntilLedger: lastActivity,
+    remainingLedgers: ttlRemaining,
+    error,
+  };
+}
+
+async function simulateReadOnlyContract(
+  server: SorobanRpc.Server,
+  contractAddress: string,
+  kind: 'factory' | 'router' | 'custom',
+): Promise<boolean> {
+  try {
+    const contract = new Contract(contractAddress);
+    const account = await server.getAccount(
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    );
+
+    const tx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: TESTNET_NETWORK.networkPassphrase,
+    });
+
+    if (kind === 'router') {
+      tx.addOperation(
+        contract.call(
+          'get_dynamic_fee',
+          nativeToScVal(Address.fromString('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'), { type: 'address' }),
+          nativeToScVal(Address.fromString('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'), { type: 'address' }),
+        ),
+      );
+    } else {
+      tx.addOperation(contract.call('get_protocol_version'));
+    }
+
+    const builtTx = tx.setTimeout(30).build();
+    const sim = await Promise.race([
+      server.simulateTransaction(builtTx),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('contract simulation timeout')), 8_000),
+      ),
+    ]);
+
+    return SorobanRpc.Api.isSimulationSuccess(sim);
+  } catch {
+    return false;
   }
 }
 
@@ -507,8 +591,8 @@ export class HealthCheckModule {
    * Check whether a Soroban contract is deployed and within TTL.
    * @see {@link getContractStatus}
    */
-  getContractStatus(url: string, contractId: string): Promise<ContractStatus> {
-    return getContractStatus(url, contractId);
+  getContractStatus(contractAddressOrUrl?: string, maybeContractId?: string): Promise<ContractStatus | ContractStatus[]> {
+    return getContractStatus(contractAddressOrUrl, maybeContractId);
   }
 
   /**

--- a/tests/health-check.test.ts
+++ b/tests/health-check.test.ts
@@ -9,6 +9,8 @@
  * Tests are grouped by the four main probe functions.
  */
 
+import { SorobanRpc, TransactionBuilder } from '@stellar/stellar-sdk';
+
 import {
   checkRPCHealth,
   percentile,
@@ -16,6 +18,8 @@ import {
   getContractStatus,
   getBestEndpoint,
 } from '../src/modules/health-check';
+import { NETWORK_CONFIGS } from '../src/config';
+import { Network } from '../src/types/common';
 
 // ---------------------------------------------------------------------------
 // SorobanRpc.Server mock
@@ -29,6 +33,8 @@ type ServerMockConfig = {
   getHealthFn?: (url: string) => Promise<unknown>;
   getLatestLedgerFn?: (url: string) => Promise<unknown>;
   getContractDataFn?: (url: string) => Promise<unknown>;
+  getAccountFn?: (url: string) => Promise<unknown>;
+  simulateTransactionFn?: (url: string) => Promise<unknown>;
 };
 
 const serverMockConfig: ServerMockConfig = {};
@@ -57,6 +63,14 @@ jest.mock('@stellar/stellar-sdk', () => {
         async getContractData(): Promise<unknown> {
           if (serverMockConfig.getContractDataFn) return serverMockConfig.getContractDataFn(this.url);
           throw new Error('getContractData not configured');
+        }
+        async getAccount(): Promise<unknown> {
+          if (serverMockConfig.getAccountFn) return serverMockConfig.getAccountFn(this.url);
+          throw new Error('getAccount not configured');
+        }
+        async simulateTransaction(): Promise<unknown> {
+          if (serverMockConfig.simulateTransactionFn) return serverMockConfig.simulateTransactionFn(this.url);
+          throw new Error('simulateTransaction not configured');
         }
       },
     },
@@ -90,6 +104,16 @@ beforeEach(() => {
     if (fn) return fn();
     throw new Error('getContractData not configured');
   };
+  serverMockConfig.getAccountFn = async () => ({}) as Promise<unknown>;
+  serverMockConfig.simulateTransactionFn = async () => ({ resultXdr: 'simulated' });
+
+  jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValue(true);
+  jest.spyOn(TransactionBuilder.prototype, 'addOperation').mockReturnThis();
+  jest.spyOn(TransactionBuilder.prototype, 'setTimeout').mockReturnThis();
+  jest.spyOn(TransactionBuilder.prototype, 'build').mockReturnValue({} as never);
+
+  NETWORK_CONFIGS[Network.TESTNET].factoryAddress = '';
+  NETWORK_CONFIGS[Network.TESTNET].routerAddress = '';
 });
 
 afterEach(() => {
@@ -289,10 +313,42 @@ describe('getContractStatus()', () => {
     }));
     const status = await getContractStatus('https://rpc.example.com', CONTRACT_ID);
     expect(status.deployed).toBe(true);
+    expect(status.isDeployed).toBe(true);
+    expect(status.isOperational).toBe(true);
     expect(status.ttlValid).toBe(true);
     expect(status.liveUntilLedger).toBe(5000);
     expect(status.remainingLedgers).toBe(4000);
     expect(status.error).toBeNull();
+  });
+
+  it('returns default factory and router statuses from the SDK config', async () => {
+    const factoryAddress = 'CADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP5KR';
+    const routerAddress = 'CBYHYT6FQG2F7NWM4SRI2QH5AGDSN5BO4JYH7BHVQZSQ5CPQY43XCN22';
+    NETWORK_CONFIGS[Network.TESTNET].factoryAddress = factoryAddress;
+    NETWORK_CONFIGS[Network.TESTNET].routerAddress = routerAddress;
+
+    setContractHandler('https://soroban-testnet.stellar.org', async () => ({
+      liveUntilLedgerSeq: 5000,
+      latestLedger: 1000,
+    }));
+
+    const statuses = await getContractStatus();
+    expect(Array.isArray(statuses)).toBe(true);
+    expect(statuses).toHaveLength(2);
+    expect((statuses as Array<{ isDeployed: boolean; contractAddress?: string }>)[0].isDeployed).toBe(true);
+    expect((statuses as Array<{ isOperational: boolean }>)[0].isOperational).toBe(true);
+  });
+
+  it('marks a contract non-operational when read-only simulation fails', async () => {
+    setContractHandler('https://rpc.example.com', async () => ({
+      liveUntilLedgerSeq: 5000,
+      latestLedger: 1000,
+    }));
+    jest.spyOn(SorobanRpc.Api, 'isSimulationSuccess').mockReturnValue(false);
+
+    const status = await getContractStatus('https://rpc.example.com', CONTRACT_ID);
+    expect(status.isOperational).toBe(false);
+    expect(status.deployed).toBe(true);
   });
 
   it('reports ttlValid=false when the liveUntilLedger has already passed', async () => {


### PR DESCRIPTION
## Summary
Adds `getContractStatus(contractAddress?)` coverage to the health-check module and exposes the requested `ContractStatus` contract-state shape.

## What changed
- Added `ContractStatus` fields:
  - `isDeployed`
  - `isOperational`
  - `ttlRemaining`
  - `lastActivity`
- Preserved backward-compatible legacy aliases for older consumers.
- Added default SDK config resolution for factory/router contract probes when no address is passed.
- Introduced simulation-backed operational checks for read-only readiness.
- Added regression coverage for the default contract-status and simulation-failure behaviors.

## Verification
- `npx jest --runInBand tests/health-check.test.ts` → `30 passed, 0 failed`
- `npm run build` → success

closes #282  