### PR TITLE
closes (#285)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export {
 export type { OptimalPath } from "@/modules/router";
 export type { TWAPObservation, TWAPResult, TraderRanking, GetTopTradersOptions } from "@/modules";
 export type { TreasuryModuleOptions, LeaderboardEntry, LeaderboardOptions } from "@/modules";
+export type { MonitoringModuleOptions } from "@/modules";
 
 // Utilities
 export {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -22,6 +22,7 @@ export type { TreasuryModuleOptions } from './treasury';
 export { AlertsModule, AlertModule } from './alerts';
 export { WebhookModule } from './webhooks';
 export { MonitoringModule } from './monitoring';
+export type { MonitoringModuleOptions } from './monitoring';
 export type {
   AlertMetric,
   AlertOperator,

--- a/src/modules/monitoring.ts
+++ b/src/modules/monitoring.ts
@@ -8,6 +8,7 @@
  * @module monitoring
  */
 
+import { SorobanRpc } from '@stellar/stellar-sdk';
 import { CoralSwapClient } from '@/client';
 import {
   MetricConfig,
@@ -17,9 +18,27 @@ import {
   MetricGranularity,
   MetricQueryOptions,
   MonitoringDashboard,
+  SystemMetrics,
+  SystemMetricsPeriod,
+  MetricChange,
+  PoolTvlChange,
 } from '@/types/monitoring';
 import { ValidationError } from '@/errors';
 import { validateAddress } from '@/utils/validation';
+
+/** ~1 day of Soroban ledgers (5s/ledger). */
+const LEDGERS_PER_DAY = 17_280;
+
+/**
+ * Optional construction knobs for {@link MonitoringModule}.
+ */
+export interface MonitoringModuleOptions {
+  /**
+   * Addresses of tokens treated as $1 USD stablecoins.
+   * Anchors USD valuations for TVL, volume, and revenue.
+   */
+  stableAddresses?: string[];
+}
 
 // ---------------------------------------------------------------------------
 // Built-in metric definitions
@@ -136,6 +155,7 @@ const DEFAULT_GRANULARITY: MetricGranularity = '1h';
  * // Protocol-level health
  * const summary = await monitor.getProtocolSummary();
  * const health = await monitor.checkSystemHealth();
+ * const kpis = await monitor.getSystemMetrics('7d');
  * const poolHealth = await monitor.getPoolHealth('CA3D...');
  *
  * // Custom metric collection
@@ -150,9 +170,11 @@ const DEFAULT_GRANULARITY: MetricGranularity = '1h';
 export class MonitoringModule {
   private readonly client: CoralSwapClient;
   private readonly metrics: Map<string, MetricInstance> = new Map();
+  private readonly stableSet: Set<string>;
 
-  constructor(client: CoralSwapClient) {
+  constructor(client: CoralSwapClient, options: MonitoringModuleOptions = {}) {
     this.client = client;
+    this.stableSet = new Set(options.stableAddresses ?? []);
   }
 
   // -----------------------------------------------------------------------
@@ -244,6 +266,115 @@ export class MonitoringModule {
       activePairCount: active.length,
       totalLPHolders: 0,
       timestamp: new Date().toISOString(),
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // System metrics (growth KPIs)
+  // -----------------------------------------------------------------------
+
+  /**
+   * High-level protocol KPIs for operators and governance.
+   *
+   * Compares the requested lookback window against the immediately preceding
+   * window of equal length for TVL, volume, and unique users. Fee revenue is
+   * reported for the current window only.
+   *
+   * @param period - Lookback window; defaults to `'24h'`.
+   * @returns Aggregated {@link SystemMetrics}.
+   * @throws {ValidationError} When `period` is not one of `'24h' | '7d' | '30d'`.
+   *
+   * @example
+   * ```ts
+   * const metrics = await monitor.getSystemMetrics('7d');
+   * console.log(metrics.tvlChange.percentage); // e.g. 12.5
+   * ```
+   */
+  async getSystemMetrics(period: SystemMetricsPeriod = '24h'): Promise<SystemMetrics> {
+    if (period !== '24h' && period !== '7d' && period !== '30d') {
+      throw new ValidationError(`Invalid system metrics period: ${period}`);
+    }
+
+    const empty: SystemMetrics = {
+      tvlChange: { absolute: 0, percentage: 0 },
+      volumeChange: { absolute: 0, percentage: 0 },
+      userGrowth: { absolute: 0, percentage: 0 },
+      revenueUSD: 0,
+      topGrowingPool: null,
+      topDecliningPool: null,
+    };
+
+    let allPairs: string[];
+    try {
+      allPairs = await this.client.factory.getAllPairs();
+    } catch {
+      return empty;
+    }
+
+    if (allPairs.length === 0) {
+      return empty;
+    }
+
+    const periodLedgers = this.periodToLedgers(period);
+    const currentLedger = await this.client.getCurrentLedger();
+    const currentStart = Math.max(0, currentLedger - periodLedgers);
+    const previousStart = Math.max(0, currentLedger - periodLedgers * 2);
+    const previousEnd = currentStart;
+
+    const priceMap = await this.buildPriceMap(allPairs);
+
+    const poolChanges: PoolTvlChange[] = [];
+    let currentTvlTotal = 0;
+    let previousTvlTotal = 0;
+
+    let currentVolume = 0;
+    let previousVolume = 0;
+    let currentRevenue = 0;
+    const currentUsers = new Set<string>();
+    const previousUsers = new Set<string>();
+
+    for (const pairAddress of allPairs) {
+      const { currentTvlUSD, previousTvlUSD } = await this.fetchPoolTvlWindow(
+        pairAddress,
+        priceMap,
+        previousStart,
+        previousEnd,
+      );
+
+      currentTvlTotal += currentTvlUSD;
+      previousTvlTotal += previousTvlUSD;
+
+      poolChanges.push({
+        pairAddress,
+        currentTvlUSD,
+        previousTvlUSD,
+        tvlChange: computeMetricChange(currentTvlUSD, previousTvlUSD),
+      });
+
+      const activity = await this.fetchPoolSwapActivity(
+        pairAddress,
+        priceMap,
+        previousStart,
+        currentLedger,
+        currentStart,
+      );
+
+      currentVolume += activity.currentVolumeUSD;
+      previousVolume += activity.previousVolumeUSD;
+      currentRevenue += activity.currentRevenueUSD;
+      for (const u of activity.currentUsers) currentUsers.add(u);
+      for (const u of activity.previousUsers) previousUsers.add(u);
+    }
+
+    const { topGrowingPool, topDecliningPool } = pickTopPools(poolChanges);
+
+    return {
+      tvlChange: computeMetricChange(currentTvlTotal, previousTvlTotal),
+      volumeChange: computeMetricChange(currentVolume, previousVolume),
+      userGrowth: computeMetricChange(currentUsers.size, previousUsers.size),
+      revenueUSD: currentRevenue,
+      topGrowingPool,
+      topDecliningPool,
     };
   }
 
@@ -365,6 +496,202 @@ export class MonitoringModule {
     }
   }
 
+  // -----------------------------------------------------------------------
+  // Private helpers — system metrics
+  // -----------------------------------------------------------------------
+
+  private periodToLedgers(period: SystemMetricsPeriod): number {
+    if (period === '7d') return LEDGERS_PER_DAY * 7;
+    if (period === '30d') return LEDGERS_PER_DAY * 30;
+    return LEDGERS_PER_DAY;
+  }
+
+  private async buildPriceMap(allPairs: string[]): Promise<Map<string, number>> {
+    const prices = new Map<string, number>();
+    for (const addr of this.stableSet) {
+      prices.set(addr, 1.0);
+    }
+    if (this.stableSet.size === 0) return prices;
+
+    for (const pairAddress of allPairs) {
+      try {
+        const pair = this.client.pair(pairAddress);
+        const [{ token0, token1 }, { reserve0, reserve1 }] = await Promise.all([
+          pair.getTokens(),
+          pair.getReserves(),
+        ]);
+        if (reserve0 === 0n || reserve1 === 0n) continue;
+        if (this.stableSet.has(token0) && !prices.has(token1)) {
+          prices.set(token1, Number(reserve0) / Number(reserve1));
+        } else if (this.stableSet.has(token1) && !prices.has(token0)) {
+          prices.set(token0, Number(reserve1) / Number(reserve0));
+        }
+      } catch {
+        continue;
+      }
+    }
+    return prices;
+  }
+
+  private reservesToTvlUSD(
+    reserve0: bigint,
+    reserve1: bigint,
+    token0: string,
+    token1: string,
+    priceMap: Map<string, number>,
+  ): number {
+    const price0 = priceMap.get(token0) ?? 0;
+    const price1 = priceMap.get(token1) ?? 0;
+    return (Number(reserve0) / 1e7) * price0 + (Number(reserve1) / 1e7) * price1;
+  }
+
+  private async fetchPoolTvlWindow(
+    pairAddress: string,
+    priceMap: Map<string, number>,
+    previousStart: number,
+    previousEnd: number,
+  ): Promise<{ currentTvlUSD: number; previousTvlUSD: number }> {
+    try {
+      const pair = this.client.pair(pairAddress);
+      const [{ reserve0, reserve1 }, { token0, token1 }] = await Promise.all([
+        pair.getReserves(),
+        pair.getTokens(),
+      ]);
+      const currentTvlUSD = this.reservesToTvlUSD(reserve0, reserve1, token0, token1, priceMap);
+
+      const previousReserves = await this.fetchPreviousReserves(
+        pairAddress,
+        previousStart,
+        previousEnd,
+      );
+      const previousTvlUSD = previousReserves
+        ? this.reservesToTvlUSD(
+            previousReserves.reserve0,
+            previousReserves.reserve1,
+            token0,
+            token1,
+            priceMap,
+          )
+        : 0;
+
+      return { currentTvlUSD, previousTvlUSD };
+    } catch {
+      return { currentTvlUSD: 0, previousTvlUSD: 0 };
+    }
+  }
+
+  private async fetchPreviousReserves(
+    pairAddress: string,
+    fromLedger: number,
+    toLedger: number,
+  ): Promise<{ reserve0: bigint; reserve1: bigint } | null> {
+    try {
+      const request: SorobanRpc.Server.GetEventsRequest = {
+        startLedger: fromLedger,
+        filters: [
+          {
+            type: 'contract',
+            contractIds: [pairAddress],
+            topics: [['sync']],
+          },
+        ],
+        limit: 10000,
+      };
+      const response = await this.client.server.getEvents(request);
+      if (!Array.isArray(response?.events) || response.events.length === 0) {
+        return null;
+      }
+
+      let best: { ledger: number; reserve0: bigint; reserve1: bigint } | null = null;
+      for (const event of response.events) {
+        if (event.ledger > toLedger) continue;
+        const parsed = parseSyncEvent(event);
+        if (!parsed) continue;
+        if (!best || event.ledger >= best.ledger) {
+          best = { ledger: event.ledger, ...parsed };
+        }
+      }
+      return best ? { reserve0: best.reserve0, reserve1: best.reserve1 } : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async fetchPoolSwapActivity(
+    pairAddress: string,
+    priceMap: Map<string, number>,
+    fromLedger: number,
+    toLedger: number,
+    currentStart: number,
+  ): Promise<{
+    currentVolumeUSD: number;
+    previousVolumeUSD: number;
+    currentRevenueUSD: number;
+    currentUsers: Set<string>;
+    previousUsers: Set<string>;
+  }> {
+    const empty = {
+      currentVolumeUSD: 0,
+      previousVolumeUSD: 0,
+      currentRevenueUSD: 0,
+      currentUsers: new Set<string>(),
+      previousUsers: new Set<string>(),
+    };
+
+    try {
+      const request: SorobanRpc.Server.GetEventsRequest = {
+        startLedger: fromLedger,
+        filters: [
+          {
+            type: 'contract',
+            contractIds: [pairAddress],
+            topics: [['swap']],
+          },
+        ],
+        limit: 10000,
+      };
+      const response = await this.client.server.getEvents(request);
+      if (!Array.isArray(response?.events) || response.events.length === 0) {
+        return empty;
+      }
+
+      let currentVolumeUSD = 0;
+      let previousVolumeUSD = 0;
+      let currentRevenueUSD = 0;
+      const currentUsers = new Set<string>();
+      const previousUsers = new Set<string>();
+
+      for (const event of response.events) {
+        if (event.ledger > toLedger) continue;
+        const parsed = parseSwapEvent(event);
+        if (!parsed) continue;
+
+        const priceUSD = priceMap.get(parsed.tokenIn) ?? 0;
+        const volumeUSD = (Number(parsed.amountIn) / 1e7) * priceUSD;
+        const feeUSD = (Number(parsed.feeAmount) / 1e7) * priceUSD;
+
+        if (event.ledger >= currentStart) {
+          currentVolumeUSD += volumeUSD;
+          currentRevenueUSD += feeUSD;
+          currentUsers.add(parsed.sender);
+        } else {
+          previousVolumeUSD += volumeUSD;
+          previousUsers.add(parsed.sender);
+        }
+      }
+
+      return {
+        currentVolumeUSD,
+        previousVolumeUSD,
+        currentRevenueUSD,
+        currentUsers,
+        previousUsers,
+      };
+    } catch {
+      return empty;
+    }
+  }
+
   private async fetchMetricValue(config: MetricConfig): Promise<number> {
     switch (config.category) {
       case 'liquidity': return this.fetchLiquidityValue(config.targetAddress);
@@ -395,4 +722,199 @@ export class MonitoringModule {
     try { return (await this.client.factory.getAllPairs()).length; }
     catch { return 0; }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute absolute + percentage change with correct zero-to-nonzero handling.
+ *
+ * - previous = 0, current = 0 → percentage 0
+ * - previous = 0, current ≠ 0 → percentage 100
+ * - otherwise → ((current − previous) / previous) × 100
+ */
+export function computeMetricChange(current: number, previous: number): MetricChange {
+  const absolute = current - previous;
+  if (previous === 0) {
+    return { absolute, percentage: current === 0 ? 0 : 100 };
+  }
+  return { absolute, percentage: (absolute / previous) * 100 };
+}
+
+/**
+ * Pick distinct top-growing and top-declining pools by absolute TVL change.
+ */
+export function pickTopPools(pools: PoolTvlChange[]): {
+  topGrowingPool: PoolTvlChange | null;
+  topDecliningPool: PoolTvlChange | null;
+} {
+  if (pools.length === 0) {
+    return { topGrowingPool: null, topDecliningPool: null };
+  }
+
+  if (pools.length === 1) {
+    const only = pools[0];
+    if (only.tvlChange.absolute >= 0) {
+      return { topGrowingPool: only, topDecliningPool: null };
+    }
+    return { topGrowingPool: null, topDecliningPool: only };
+  }
+
+  const sorted = [...pools].sort((a, b) => b.tvlChange.absolute - a.tvlChange.absolute);
+  const topGrowingPool = sorted[0];
+  const topDecliningPool = sorted[sorted.length - 1];
+
+  // Guarantee distinct pools even if all changes are equal (already true for length ≥ 2)
+  if (topGrowingPool.pairAddress === topDecliningPool.pairAddress) {
+    return { topGrowingPool, topDecliningPool: null };
+  }
+
+  return { topGrowingPool, topDecliningPool };
+}
+
+function parseSyncEvent(rawEvent: unknown): { reserve0: bigint; reserve1: bigint } | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== 'object') return null;
+    const eventObj = rawEvent as Record<string, unknown>;
+    const topics = (eventObj.topic as unknown[]) ?? [];
+    const topic0 = topics[0];
+    const topicName =
+      typeof topic0 === 'string'
+        ? topic0
+        : topic0 && typeof topic0 === 'object'
+          ? (() => {
+              const t = topic0 as Record<string, () => { toString(): string }>;
+              try {
+                return t.sym?.().toString() ?? t.str?.().toString() ?? '';
+              } catch {
+                return '';
+              }
+            })()
+          : '';
+    if (topicName !== 'sync') return null;
+
+    const map = decodeEventMap(eventObj.value);
+    if (!map) return null;
+    const reserve0 = readI128(map, 'reserve0');
+    const reserve1 = readI128(map, 'reserve1');
+    if (reserve0 === undefined || reserve1 === undefined) return null;
+    return { reserve0, reserve1 };
+  } catch {
+    return null;
+  }
+}
+
+function parseSwapEvent(rawEvent: unknown): {
+  amountIn: bigint;
+  feeAmount: bigint;
+  tokenIn: string;
+  sender: string;
+} | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== 'object') return null;
+    const eventObj = rawEvent as Record<string, unknown>;
+    const topics = (eventObj.topic as unknown[]) ?? [];
+    const topic0 = topics[0];
+    const topicName =
+      typeof topic0 === 'string'
+        ? topic0
+        : topic0 && typeof topic0 === 'object'
+          ? (() => {
+              const t = topic0 as Record<string, () => { toString(): string }>;
+              try {
+                return t.sym?.().toString() ?? t.str?.().toString() ?? '';
+              } catch {
+                return '';
+              }
+            })()
+          : '';
+    if (topicName !== 'swap') return null;
+
+    const map = decodeEventMap(eventObj.value);
+    if (!map) return null;
+
+    const amountIn = readI128(map, 'amount_in');
+    const feeBps = readU32(map, 'fee_bps');
+    const tokenIn = readAddress(map, 'token_in');
+    const sender = readAddress(map, 'sender');
+    if (amountIn === undefined || feeBps === undefined || !tokenIn || !sender) return null;
+
+    const feeAmount = (amountIn * BigInt(feeBps)) / 10000n;
+    return { amountIn, feeAmount, tokenIn, sender };
+  } catch {
+    return null;
+  }
+}
+
+function decodeEventMap(value: unknown): Map<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null;
+  const valueObj = value as Record<string, unknown>;
+  const entries: unknown[] =
+    typeof valueObj.map === 'function'
+      ? (valueObj.map as () => unknown[])()
+      : (valueObj._value as unknown[]);
+  if (!Array.isArray(entries)) return null;
+
+  const map = new Map<string, unknown>();
+  for (const entry of entries as Array<{ key: unknown; val: unknown }>) {
+    if (!entry || typeof entry !== 'object') continue;
+    const k = entry.key as Record<string, () => { toString(): string }>;
+    let key: string | undefined;
+    try {
+      key = k.sym?.().toString() ?? k.str?.().toString();
+    } catch {
+      /* skip */
+    }
+    if (key) map.set(key, entry.val);
+  }
+  return map;
+}
+
+function readAddress(map: Map<string, unknown>, key: string): string | undefined {
+  const val = map.get(key);
+  if (!val || typeof val !== 'object') return undefined;
+  try {
+    const v = val as Record<string, unknown>;
+    if (typeof v.address === 'function') {
+      return (v.address as () => { toString(): string })().toString();
+    }
+    if (v._value && typeof (v._value as { toString(): string }).toString === 'function') {
+      return (v._value as { toString(): string }).toString();
+    }
+  } catch {
+    /* skip */
+  }
+  return undefined;
+}
+
+function readI128(map: Map<string, unknown>, key: string): bigint | undefined {
+  const val = map.get(key);
+  if (!val || typeof val !== 'object') return undefined;
+  try {
+    const v = val as Record<string, unknown>;
+    if (typeof v.i128 === 'function') {
+      const parts = (v.i128 as () => {
+        hi(): { toString(): string };
+        lo(): { toString(): string };
+      })();
+      return (BigInt(parts.hi().toString()) << 64n) + BigInt(parts.lo().toString());
+    }
+  } catch {
+    /* skip */
+  }
+  return undefined;
+}
+
+function readU32(map: Map<string, unknown>, key: string): number | undefined {
+  const val = map.get(key);
+  if (!val || typeof val !== 'object') return undefined;
+  try {
+    const v = val as Record<string, unknown>;
+    if (typeof v.u32 === 'function') return (v.u32 as () => number)();
+  } catch {
+    /* skip */
+  }
+  return undefined;
 }

--- a/src/modules/monitoring.ts
+++ b/src/modules/monitoring.ts
@@ -8,7 +8,7 @@
  * @module monitoring
  */
 
-import { SorobanRpc } from '@stellar/stellar-sdk';
+import { SorobanRpc, xdr } from '@stellar/stellar-sdk';
 import { CoralSwapClient } from '@/client';
 import {
   MetricConfig,
@@ -28,6 +28,13 @@ import { validateAddress } from '@/utils/validation';
 
 /** ~1 day of Soroban ledgers (5s/ledger). */
 const LEDGERS_PER_DAY = 17_280;
+
+/**
+ * Base64-encoded XDR `ScVal` symbols for Soroban `getEvents` topic filters.
+ * Raw strings like `'sync'` / `'swap'` are rejected by real RPC servers.
+ */
+const TOPIC_SYNC = xdr.ScVal.scvSymbol('sync').toXDR('base64');
+const TOPIC_SWAP = xdr.ScVal.scvSymbol('swap').toXDR('base64');
 
 /**
  * Optional construction knobs for {@link MonitoringModule}.
@@ -280,6 +287,14 @@ export class MonitoringModule {
    * window of equal length for TVL, volume, and unique users. Fee revenue is
    * reported for the current window only.
    *
+   * **RPC event retention:** the previous window starts at
+   * `currentLedger - 2 * periodLedgers` (~2 days for `'24h'`, ~14 days for
+   * `'7d'`, ~60 days for `'30d'`). Public Soroban RPC providers often retain
+   * only a few days of events; if `startLedger` falls outside that window the
+   * request fails (or returns empty) and previous-period metrics degrade to
+   * zero (false 100% zero-to-nonzero growth). Prefer an archival/long-retention
+   * RPC when using `'7d'` or `'30d'`.
+   *
    * @param period - Lookback window; defaults to `'24h'`.
    * @returns Aggregated {@link SystemMetrics}.
    * @throws {ValidationError} When `period` is not one of `'24h' | '7d' | '30d'`.
@@ -318,6 +333,9 @@ export class MonitoringModule {
     const periodLedgers = this.periodToLedgers(period);
     const currentLedger = await this.client.getCurrentLedger();
     const currentStart = Math.max(0, currentLedger - periodLedgers);
+    // Previous window is the equal-length interval immediately before the
+    // current window. Requires RPC event retention covering ~2× the period
+    // (see getSystemMetrics JSDoc).
     const previousStart = Math.max(0, currentLedger - periodLedgers * 2);
     const previousEnd = currentStart;
 
@@ -592,7 +610,7 @@ export class MonitoringModule {
           {
             type: 'contract',
             contractIds: [pairAddress],
-            topics: [['sync']],
+            topics: [[TOPIC_SYNC]],
           },
         ],
         limit: 10000,
@@ -645,7 +663,7 @@ export class MonitoringModule {
           {
             type: 'contract',
             contractIds: [pairAddress],
-            topics: [['swap']],
+            topics: [[TOPIC_SWAP]],
           },
         ],
         limit: 10000,

--- a/src/types/monitoring.ts
+++ b/src/types/monitoring.ts
@@ -50,3 +50,52 @@ export interface MetricQueryOptions {
   granularity?: MetricGranularity;
   limit?: number;
 }
+
+/** Lookback window for {@link SystemMetrics}. */
+export type SystemMetricsPeriod = '24h' | '7d' | '30d';
+
+/**
+ * Absolute and percentage change between two samples.
+ *
+ * When the previous value is `0` and the current value is nonzero,
+ * `percentage` is `100` (zero-to-nonzero transition). When both are `0`,
+ * `percentage` is `0`.
+ */
+export interface MetricChange {
+  /** Absolute delta: current − previous */
+  absolute: number;
+  /** Percentage delta relative to previous (see zero-to-nonzero rules above) */
+  percentage: number;
+}
+
+/**
+ * Per-pool TVL movement used for top-growing / top-declining rankings.
+ */
+export interface PoolTvlChange {
+  /** Pair contract address */
+  pairAddress: string;
+  /** TVL change over the requested period */
+  tvlChange: MetricChange;
+  /** Current pool TVL in USD */
+  currentTvlUSD: number;
+  /** Estimated TVL in USD at the start of the period */
+  previousTvlUSD: number;
+}
+
+/**
+ * High-level protocol KPIs for operators and governance.
+ */
+export interface SystemMetrics {
+  /** Protocol-wide TVL change over the period */
+  tvlChange: MetricChange;
+  /** Aggregate swap volume change over the period */
+  volumeChange: MetricChange;
+  /** Unique swapper count change over the period */
+  userGrowth: MetricChange;
+  /** Fee revenue collected during the current period, in USD */
+  revenueUSD: number;
+  /** Pool with the largest TVL increase; `null` when unavailable */
+  topGrowingPool: PoolTvlChange | null;
+  /** Pool with the largest TVL decrease; `null` when unavailable */
+  topDecliningPool: PoolTvlChange | null;
+}

--- a/tests/monitoring.test.ts
+++ b/tests/monitoring.test.ts
@@ -6,6 +6,7 @@ import {
 import type { PoolTvlChange } from '../src/types/monitoring';
 import { CoralSwapClient } from '../src/client';
 import { ValidationError } from '../src/errors';
+import { xdr } from '@stellar/stellar-sdk';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -20,6 +21,15 @@ const USER_1 = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 const USER_2 = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
 
 const LEDGERS_PER_DAY = 17_280;
+
+/** Real Soroban RPC topic filters must be base64-encoded XDR ScVal symbols. */
+const TOPIC_SYNC = xdr.ScVal.scvSymbol('sync').toXDR('base64');
+const TOPIC_SWAP = xdr.ScVal.scvSymbol('swap').toXDR('base64');
+
+const ENCODED_TOPIC_TO_NAME: Record<string, string> = {
+  [TOPIC_SYNC]: 'sync',
+  [TOPIC_SWAP]: 'swap',
+};
 
 interface PairSpec {
   reserve0?: bigint;
@@ -127,10 +137,21 @@ function createMockClient(opts: {
       getEvents: jest.fn().mockImplementation(
         (req: { filters?: Array<{ contractIds?: string[]; topics?: string[][] }> }) => {
           const id = req?.filters?.[0]?.contractIds?.[0] ?? '';
-          const topic = req?.filters?.[0]?.topics?.[0]?.[0];
+          const topicFilter = req?.filters?.[0]?.topics?.[0]?.[0];
+
+          // Mirror real Soroban RPC: only base64-encoded XDR ScVal topics match.
+          // Raw strings like 'sync' / 'swap' must yield zero events.
+          const topicName =
+            typeof topicFilter === 'string'
+              ? ENCODED_TOPIC_TO_NAME[topicFilter]
+              : undefined;
+          if (!topicName) {
+            return Promise.resolve({ events: [] });
+          }
+
           const events = (eventsPerPair[id] ?? []).filter((e) => {
             const ev = e as { topic?: string[] };
-            return !topic || ev.topic?.[0] === topic;
+            return ev.topic?.[0] === topicName;
           });
           return Promise.resolve({ events });
         },
@@ -340,6 +361,54 @@ describe('MonitoringModule.getSystemMetrics()', () => {
     });
     await expect(monitor.getSystemMetrics('7d')).resolves.toBeDefined();
     await expect(monitor.getSystemMetrics('30d')).resolves.toBeDefined();
+  });
+
+  it('queries getEvents with base64-encoded XDR symbol topics (not raw strings)', async () => {
+    const currentLedger = 100_000;
+    const currentStart = currentLedger - LEDGERS_PER_DAY;
+    const client = createMockClient({
+      pairs: [PAIR_1],
+      pairSpecs: {
+        [PAIR_1]: {
+          reserve0: 200_000_000n,
+          reserve1: 200_000_000n,
+          token0: STABLE_ADDR,
+          token1: TOKEN_A,
+        },
+      },
+      eventsPerPair: {
+        [PAIR_1]: [
+          makeSyncEvent(currentStart - 50, 100_000_000n, 100_000_000n, PAIR_1),
+          makeSwapEvent({
+            ledger: currentStart + 5,
+            amountIn: 10_000_000n,
+            feeBps: 30,
+            tokenIn: STABLE_ADDR,
+            sender: USER_1,
+            contractId: PAIR_1,
+          }),
+        ],
+      },
+      currentLedger,
+    });
+
+    const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+    const metrics = await monitor.getSystemMetrics('24h');
+
+    const getEvents = client.server.getEvents as jest.Mock;
+    expect(getEvents).toHaveBeenCalled();
+
+    const topicFilters = getEvents.mock.calls.map(
+      (call) => call[0]?.filters?.[0]?.topics?.[0]?.[0],
+    );
+    expect(topicFilters).toContain(TOPIC_SYNC);
+    expect(topicFilters).toContain(TOPIC_SWAP);
+    expect(topicFilters).not.toContain('sync');
+    expect(topicFilters).not.toContain('swap');
+
+    // Encoded filters must actually resolve historical events (mock rejects raw strings).
+    expect(metrics.tvlChange.absolute).toBeGreaterThan(0);
+    expect(metrics.volumeChange.absolute).toBeGreaterThan(0);
   });
 
   it('throws ValidationError for an invalid period', async () => {

--- a/tests/monitoring.test.ts
+++ b/tests/monitoring.test.ts
@@ -1,0 +1,353 @@
+import {
+  MonitoringModule,
+  computeMetricChange,
+  pickTopPools,
+} from '../src/modules/monitoring';
+import type { PoolTvlChange } from '../src/types/monitoring';
+import { CoralSwapClient } from '../src/client';
+import { ValidationError } from '../src/errors';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STABLE_ADDR = 'CUSDC0000000000000000000000000000000000000000000000000000';
+const TOKEN_A = 'CTOKENA00000000000000000000000000000000000000000000000000';
+const TOKEN_B = 'CTOKENB00000000000000000000000000000000000000000000000000';
+const PAIR_1 = 'CPAIR0000000000000000000000000000000000000000000000000001';
+const PAIR_2 = 'CPAIR0000000000000000000000000000000000000000000000000002';
+const USER_1 = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const USER_2 = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+const LEDGERS_PER_DAY = 17_280;
+
+interface PairSpec {
+  reserve0?: bigint;
+  reserve1?: bigint;
+  token0?: string;
+  token1?: string;
+}
+
+function makeI128(n: bigint) {
+  return {
+    i128: () => ({
+      hi: () => ({ toString: () => (n >> 64n).toString() }),
+      lo: () => ({ toString: () => (n & ((1n << 64n) - 1n)).toString() }),
+    }),
+  };
+}
+
+function makeU32(n: number) {
+  return { u32: () => n };
+}
+
+function makeAddr(s: string) {
+  return { address: () => ({ toString: () => s }) };
+}
+
+function makeSym(s: string) {
+  return { sym: () => ({ toString: () => s }) };
+}
+
+function makeSyncEvent(
+  ledger: number,
+  reserve0: bigint,
+  reserve1: bigint,
+  contractId: string,
+) {
+  return {
+    topic: ['sync'],
+    value: {
+      map: () => [
+        { key: makeSym('reserve0'), val: makeI128(reserve0) },
+        { key: makeSym('reserve1'), val: makeI128(reserve1) },
+      ],
+    },
+    ledger,
+    contractId,
+  };
+}
+
+function makeSwapEvent(opts: {
+  ledger: number;
+  amountIn: bigint;
+  feeBps: number;
+  tokenIn: string;
+  sender: string;
+  contractId: string;
+}) {
+  return {
+    topic: ['swap'],
+    value: {
+      map: () => [
+        { key: makeSym('amount_in'), val: makeI128(opts.amountIn) },
+        { key: makeSym('fee_bps'), val: makeU32(opts.feeBps) },
+        { key: makeSym('token_in'), val: makeAddr(opts.tokenIn) },
+        { key: makeSym('sender'), val: makeAddr(opts.sender) },
+        { key: makeSym('amount_out'), val: makeI128(opts.amountIn) },
+        { key: makeSym('token_out'), val: makeAddr(TOKEN_B) },
+      ],
+    },
+    ledger: opts.ledger,
+    contractId: opts.contractId,
+  };
+}
+
+function createMockClient(opts: {
+  pairs?: string[];
+  pairSpecs?: Record<string, PairSpec>;
+  currentLedger?: number;
+  eventsPerPair?: Record<string, unknown[]>;
+} = {}): CoralSwapClient {
+  const {
+    pairs = [],
+    pairSpecs = {},
+    currentLedger = 100_000,
+    eventsPerPair = {},
+  } = opts;
+
+  return {
+    factory: {
+      getAllPairs: jest.fn().mockResolvedValue(pairs),
+    },
+    pair: jest.fn().mockImplementation((addr: string) => {
+      const spec = pairSpecs[addr] ?? {};
+      return {
+        getReserves: jest.fn().mockResolvedValue({
+          reserve0: spec.reserve0 ?? 10_000_000n,
+          reserve1: spec.reserve1 ?? 10_000_000n,
+        }),
+        getTokens: jest.fn().mockResolvedValue({
+          token0: spec.token0 ?? STABLE_ADDR,
+          token1: spec.token1 ?? TOKEN_A,
+        }),
+      };
+    }),
+    server: {
+      getEvents: jest.fn().mockImplementation(
+        (req: { filters?: Array<{ contractIds?: string[]; topics?: string[][] }> }) => {
+          const id = req?.filters?.[0]?.contractIds?.[0] ?? '';
+          const topic = req?.filters?.[0]?.topics?.[0]?.[0];
+          const events = (eventsPerPair[id] ?? []).filter((e) => {
+            const ev = e as { topic?: string[] };
+            return !topic || ev.topic?.[0] === topic;
+          });
+          return Promise.resolve({ events });
+        },
+      ),
+    },
+    getCurrentLedger: jest.fn().mockResolvedValue(currentLedger),
+  } as unknown as CoralSwapClient;
+}
+
+function poolChange(
+  pairAddress: string,
+  absolute: number,
+  previous = 100,
+): PoolTvlChange {
+  const current = previous + absolute;
+  return {
+    pairAddress,
+    currentTvlUSD: current,
+    previousTvlUSD: previous,
+    tvlChange: computeMetricChange(current, previous),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeMetricChange / pickTopPools
+// ---------------------------------------------------------------------------
+
+describe('computeMetricChange', () => {
+  it('returns 0% when both values are zero', () => {
+    expect(computeMetricChange(0, 0)).toEqual({ absolute: 0, percentage: 0 });
+  });
+
+  it('handles zero-to-nonzero transitions as 100%', () => {
+    expect(computeMetricChange(50, 0)).toEqual({ absolute: 50, percentage: 100 });
+    expect(computeMetricChange(-10, 0)).toEqual({ absolute: -10, percentage: 100 });
+  });
+
+  it('computes normal percentage changes', () => {
+    expect(computeMetricChange(150, 100)).toEqual({ absolute: 50, percentage: 50 });
+    expect(computeMetricChange(75, 100)).toEqual({ absolute: -25, percentage: -25 });
+  });
+});
+
+describe('pickTopPools', () => {
+  it('returns nulls when there are no pools', () => {
+    expect(pickTopPools([])).toEqual({
+      topGrowingPool: null,
+      topDecliningPool: null,
+    });
+  });
+
+  it('returns distinct growing and declining pools', () => {
+    const growing = poolChange(PAIR_1, 200);
+    const declining = poolChange(PAIR_2, -50);
+    const result = pickTopPools([growing, declining]);
+
+    expect(result.topGrowingPool?.pairAddress).toBe(PAIR_1);
+    expect(result.topDecliningPool?.pairAddress).toBe(PAIR_2);
+    expect(result.topGrowingPool?.pairAddress).not.toBe(
+      result.topDecliningPool?.pairAddress,
+    );
+  });
+
+  it('sets declining to null for a single growing pool', () => {
+    const result = pickTopPools([poolChange(PAIR_1, 10)]);
+    expect(result.topGrowingPool?.pairAddress).toBe(PAIR_1);
+    expect(result.topDecliningPool).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSystemMetrics
+// ---------------------------------------------------------------------------
+
+describe('MonitoringModule.getSystemMetrics()', () => {
+  it('handles a new protocol with no pairs / no historical data', async () => {
+    const client = createMockClient({ pairs: [] });
+    const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+    const metrics = await monitor.getSystemMetrics('24h');
+
+    expect(metrics.tvlChange).toEqual({ absolute: 0, percentage: 0 });
+    expect(metrics.volumeChange).toEqual({ absolute: 0, percentage: 0 });
+    expect(metrics.userGrowth).toEqual({ absolute: 0, percentage: 0 });
+    expect(metrics.revenueUSD).toBe(0);
+    expect(metrics.topGrowingPool).toBeNull();
+    expect(metrics.topDecliningPool).toBeNull();
+  });
+
+  it('handles pools with current TVL but no historical sync events (zero-to-nonzero)', async () => {
+    const client = createMockClient({
+      pairs: [PAIR_1],
+      pairSpecs: {
+        [PAIR_1]: {
+          token0: STABLE_ADDR,
+          token1: TOKEN_A,
+          reserve0: 100_000_000n, // $10
+          reserve1: 100_000_000n, // priced 1:1 → $10
+        },
+      },
+      eventsPerPair: { [PAIR_1]: [] },
+      currentLedger: 100_000,
+    });
+    const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+    const metrics = await monitor.getSystemMetrics('24h');
+
+    // Current TVL = $20, previous = 0 → 100% growth
+    expect(metrics.tvlChange.absolute).toBeCloseTo(20, 5);
+    expect(metrics.tvlChange.percentage).toBe(100);
+    expect(metrics.topGrowingPool?.pairAddress).toBe(PAIR_1);
+    expect(metrics.topDecliningPool).toBeNull();
+  });
+
+  it('computes TVL, volume, user, and revenue changes across the period', async () => {
+    const currentLedger = 100_000;
+    const periodLedgers = LEDGERS_PER_DAY;
+    const currentStart = currentLedger - periodLedgers;
+
+    const client = createMockClient({
+      pairs: [PAIR_1, PAIR_2],
+      pairSpecs: {
+        [PAIR_1]: {
+          token0: STABLE_ADDR,
+          token1: TOKEN_A,
+          reserve0: 200_000_000n, // $20
+          reserve1: 200_000_000n, // $20 → TVL $40
+        },
+        [PAIR_2]: {
+          token0: STABLE_ADDR,
+          token1: TOKEN_B,
+          reserve0: 50_000_000n, // $5
+          reserve1: 50_000_000n, // $5 → TVL $10
+        },
+      },
+      eventsPerPair: {
+        [PAIR_1]: [
+          // Previous TVL snapshot: $20
+          makeSyncEvent(currentStart - 100, 100_000_000n, 100_000_000n, PAIR_1),
+          // Previous-period swap: $10 volume, 30 bps fee → $0.03
+          makeSwapEvent({
+            ledger: currentStart - 50,
+            amountIn: 100_000_000n,
+            feeBps: 30,
+            tokenIn: STABLE_ADDR,
+            sender: USER_1,
+            contractId: PAIR_1,
+          }),
+          // Current-period swaps
+          makeSwapEvent({
+            ledger: currentStart + 10,
+            amountIn: 200_000_000n, // $20
+            feeBps: 30,
+            tokenIn: STABLE_ADDR,
+            sender: USER_1,
+            contractId: PAIR_1,
+          }),
+          makeSwapEvent({
+            ledger: currentStart + 20,
+            amountIn: 100_000_000n, // $10
+            feeBps: 30,
+            tokenIn: STABLE_ADDR,
+            sender: USER_2,
+            contractId: PAIR_1,
+          }),
+        ],
+        [PAIR_2]: [
+          // Previous TVL snapshot: $30 → declining to $10
+          makeSyncEvent(currentStart - 100, 150_000_000n, 150_000_000n, PAIR_2),
+        ],
+      },
+      currentLedger,
+    });
+
+    const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+    const metrics = await monitor.getSystemMetrics('24h');
+
+    // PAIR_1: 40 - 20 = +20; PAIR_2: 10 - 30 = -20; total change = 0
+    expect(metrics.tvlChange.absolute).toBeCloseTo(0, 5);
+    expect(metrics.tvlChange.percentage).toBeCloseTo(0, 5);
+
+    // Volume: current $30, previous $10 → +$20 / +200%
+    expect(metrics.volumeChange.absolute).toBeCloseTo(20, 5);
+    expect(metrics.volumeChange.percentage).toBeCloseTo(200, 5);
+
+    // Users: current {USER_1, USER_2}=2, previous {USER_1}=1 → +1 / +100%
+    expect(metrics.userGrowth).toEqual({ absolute: 1, percentage: 100 });
+
+    // Revenue from current-period fees only: ($20+$10)*0.003 = $0.09
+    expect(metrics.revenueUSD).toBeCloseTo(0.09, 5);
+
+    // Distinct top pools by TVL change
+    expect(metrics.topGrowingPool?.pairAddress).toBe(PAIR_1);
+    expect(metrics.topDecliningPool?.pairAddress).toBe(PAIR_2);
+    expect(metrics.topGrowingPool?.pairAddress).not.toBe(
+      metrics.topDecliningPool?.pairAddress,
+    );
+  });
+
+  it('defaults period to 24h and accepts 7d / 30d', async () => {
+    const client = createMockClient({ pairs: [], currentLedger: 500_000 });
+    const monitor = new MonitoringModule(client);
+
+    await expect(monitor.getSystemMetrics()).resolves.toMatchObject({
+      revenueUSD: 0,
+      topGrowingPool: null,
+    });
+    await expect(monitor.getSystemMetrics('7d')).resolves.toBeDefined();
+    await expect(monitor.getSystemMetrics('30d')).resolves.toBeDefined();
+  });
+
+  it('throws ValidationError for an invalid period', async () => {
+    const client = createMockClient({ pairs: [] });
+    const monitor = new MonitoringModule(client);
+
+    await expect(
+      monitor.getSystemMetrics('1h' as '24h'),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+});


### PR DESCRIPTION
## Description
Adds getSystemMetrics() to the monitoring module so protocol operators and governance participants can track high-level health KPIs — TVL, volume, user growth, and fee revenue — over 24h / 7d / 30d windows, including which pools are growing or declining fastest by TVL

## Related Issue

Closes #285

Replace `XXX` with the issue number this PR resolves. If there is no linked issue, explain why.

## Changes Made

Added SystemMetrics, MetricChange, PoolTvlChange, and SystemMetricsPeriod types
Implemented MonitoringModule.getSystemMetrics(period?) with absolute + percentage changes
Ranked topGrowingPool / topDecliningPool by TVL change (always distinct when ≥2 pools)
Handled zero-to-nonzero percentage transitions and empty/new protocol state
Optional stableAddresses on MonitoringModule for USD valuation
Added unit tests in tests/monitoring.test.ts


## Testing

Added tests/monitoring.test.ts covering zero-to-nonzero %, distinct top pools, empty protocol, and period validation

Ran: npm test -- --testPathPattern=monitoring (11 tests passed)


 Tests added or updated


 Existing tests pass

- [ ] Tests added or updated
- [ ] Existing tests pass

## Checklist

- [ ] Tests added where applicable
- [ ] Documentation updated where applicable
- [ ] Lint passes
- [ ] No breaking changes, or any breaking changes are documented
- [ ] Commit messages are clear and follow the project convention
