### PR TITLE
fix: sanitize logger/error handling to prevent secret leakage

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -432,7 +432,12 @@ export class CoralSwapClient {
         "simulateTransaction",
       );
       if (!SorobanRpc.Api.isSimulationSuccess(sim)) {
-        this.logger?.error("simulateTransaction: simulation failed", {
+        const simSummary = {
+          error: SorobanRpc.Api.isSimulationError(sim) ? sim.error : 'restore required',
+          latestLedger: sim.latestLedger,
+        };
+        this.logger?.error("simulateTransaction: simulation failed", simSummary);
+        this.logger?.debug("simulateTransaction: full simulation response", {
           simulation: sim,
         });
         return {
@@ -440,7 +445,7 @@ export class CoralSwapClient {
           error: {
             code: "SIMULATION_FAILED",
             message: "Transaction simulation failed",
-            details: { simulation: sim },
+            details: simSummary,
           },
         };
       }
@@ -471,13 +476,21 @@ export class CoralSwapClient {
       );
 
       if (response.status === "ERROR") {
-        this.logger?.error("sendTransaction: submission failed", { response });
+        const responseSummary = {
+          status: response.status,
+          hash: response.hash,
+          latestLedger: response.latestLedger,
+        };
+        this.logger?.error("sendTransaction: submission failed", responseSummary);
+        this.logger?.debug("sendTransaction: full submission response", {
+          response,
+        });
         return {
           success: false,
           error: {
             code: "SUBMIT_FAILED",
             message: "Transaction submission failed",
-            details: { response },
+            details: responseSummary,
           },
         };
       }
@@ -488,13 +501,19 @@ export class CoralSwapClient {
       const result = await this.pollTransaction(response.hash);
       return result;
     } catch (err) {
-      this.logger?.error("submitTransaction: unexpected error", err);
+      this.logger?.error("submitTransaction: unexpected error", {
+        name: err instanceof Error ? err.name : 'Unknown',
+        message: err instanceof Error ? err.message : String(err),
+      });
       return {
         success: false,
         error: {
           code: "UNEXPECTED_ERROR",
           message: err instanceof Error ? err.message : "Unknown error",
-          details: { error: err },
+          details: {
+            name: err instanceof Error ? err.name : 'Unknown',
+            message: err instanceof Error ? err.message : String(err),
+          },
         },
       };
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -32,7 +32,6 @@ export class CoralSwapSDKError extends Error {
       code: this.code,
       message: this.message,
       details: this.details,
-      stack: this.stack,
     };
   }
 }
@@ -719,6 +718,9 @@ export function mapError(err: unknown): CoralSwapSDKError {
   }
 
   return new CoralSwapSDKError("UNKNOWN_ERROR", message, {
-    originalError: err,
+    originalError: {
+      name: err instanceof Error ? err.name : typeof err,
+      message: err instanceof Error ? err.message : String(err),
+    },
   });
 }

--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -223,11 +223,14 @@ export class FlashLoanModule {
         // A FlashLoanFailed event means the callback reverted; surface it as an error.
         const failedEvent = this.decodeFailedEvent(rawEvents);
         if (failedEvent) {
-          const err = new FlashLoanError(
+          throw new FlashLoanError(
             `Flash loan callback failed: ${failedEvent.reason}`,
+            {
+              reason: failedEvent.reason,
+              token: failedEvent.token,
+              borrowedAmount: failedEvent.borrowedAmount,
+            },
           );
-          (err as any).event = failedEvent;
-          throw err;
         }
 
         // Try decoding old-style executed event

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -36,7 +36,7 @@ export async function estimateGas(
   const sim = await simulate(operations);
   if (!sim.success) {
     throw new SimulationError(sim.error ?? 'Simulation failed', {
-      simulation: sim.raw,
+      reason: sim.error ?? 'Simulation failed',
     });
   }
   const fee = parseInt(sim.minResourceFee, 10) || 0;

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -87,6 +87,12 @@ export class TransactionPoller {
                 if (status.status === 'FAILED') {
                     this.logger?.error('TransactionPoller: transaction failed on-chain', {
                         txHash,
+                        ledger: status.ledger,
+                        createdAt: status.createdAt,
+                        applicationOrder: status.applicationOrder,
+                    });
+                    this.logger?.debug('TransactionPoller: full failed status', {
+                        txHash,
                         status,
                     });
                     return {
@@ -94,7 +100,12 @@ export class TransactionPoller {
                         error: {
                             code: 'TX_FAILED',
                             message: 'Transaction failed on-chain',
-                            details: { status },
+                            details: {
+                                txHash,
+                                ledger: status.ledger,
+                                createdAt: status.createdAt,
+                                applicationOrder: status.applicationOrder,
+                            },
                         },
                         txHash,
                     };

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -462,10 +462,13 @@ describe("Error Hierarchy", () => {
         expect(err.message).toBe("some string error");
       });
 
-      it("preserves original error in details", () => {
+      it("preserves original error name and message in details", () => {
         const original = new Error("custom error");
         const err = mapError(original);
-        expect(err.details?.originalError).toBe(original);
+        expect(err.details?.originalError).toEqual({
+          name: "Error",
+          message: "custom error",
+        });
       });
 
       it("handles non-Error objects", () => {

--- a/tests/flash-loan.test.ts
+++ b/tests/flash-loan.test.ts
@@ -246,11 +246,10 @@ describe('FlashLoanModule.execute()', () => {
       }
 
       expect(caught).not.toBeNull();
-      expect(caught!.event).toBeDefined();
-      expect(caught!.event!.type).toBe('FlashLoanFailed');
-      expect(caught!.event!.borrowedAmount).toBe(1_000_000n);
-      expect(caught!.event!.token).toBe('TOKEN_A');
-      expect(caught!.event!.reason).toBe('callback_revert');
+      expect(caught!.message).toContain('callback_revert');
+      expect(caught!.reason).toBe('callback_revert');
+      expect(caught!.token).toBe('TOKEN_A');
+      expect(caught!.borrowedAmount).toBe(1_000_000n);
     });
 
     it('throws FlashLoanError (without event) when submitTransaction fails', async () => {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -105,7 +105,10 @@ describe('Logger Middleware', () => {
       expect(result.success).toBe(false);
       expect(logger.error).toHaveBeenCalledWith(
         'submitTransaction: unexpected error',
-        expect.any(Error),
+        expect.objectContaining({
+          name: 'Error',
+          message: 'RPC connection lost',
+        }),
       );
     });
 


### PR DESCRIPTION
## Summary

This PR addresses four related issues around logging hygiene and secret leakage in error handling, following a consistent pattern: trim full objects in error-level logs, demote raw data to debug level, and sanitize caught errors before forwarding to loggers.

## Changes

### #507 - Fix TransactionPoller logging full raw transaction status on failure
- **src/utils/polling.ts**: Replaced the full `status` object (which carries `envelopeXdr`/resultXdr`/resultMetaXdr` XDR blobs) in the error-level log with a trimmed summary: `txHash`, `ledger`, `createdAt`, `applicationOrder`. Full status is now logged at `debug` level.
- Same trimming applied to the error's `details` field to prevent XDR leakage through serialized errors.

### #508 - Trim full simulation/response object logging in client.ts
- **src/client.ts** (`simulateTransaction` failure): Trimmed `{ simulation: sim }` to `{ error, latestLedger }` at error level; full response demoted to `debug`.
- **src/client.ts** (`sendTransaction` failure): Trimmed `{ response }` to `{ status, hash, latestLedger }` at error level; full response demoted to `debug`.
- Error details objects similarly trimmed.

### #509 - Sanitize raw caught error before logging in submitTransaction
- **src/client.ts** (`submitTransaction` catch block): Instead of forwarding the untyped `err` directly to the logger, extract only `name` and `message`. Same sanitization applied to the error's `details`.

### #510 - Audit remaining SDK files for secret-leakage patterns
All listed files were reviewed. Fixes applied where patterns were found:

| File | Issue | Fix |
|------|-------|-----|
| `src/errors.ts` (toJSON) | `stack` in JSON serialization could leak internal paths | Removed `stack` from `toJSON()` |
| `src/errors.ts` (mapError) | Full `err` object stored in `details.originalError` | Extract only `name` + `message` |
| `src/utils/gas.ts` | Full `sim.raw` RPC response in `SimulationError` details | Replaced with `reason` string |
| `src/modules/flash-loan.ts` | Full `FlashLoanFailedEvent` dynamically attached to error via `(err as any).event` | Pass `reason`, `token`, `borrowedAmount` as typed constructor details |

All other files listed in #510 were reviewed and found clean (no logger calls with full objects, no secret leakage in error details).

## Testing
- All 1295 existing tests pass (60 test suites)
- Updated tests in `tests/errors.test.ts`, `tests/flash-loan.test.ts`, and `tests/logger.test.ts` to reflect the new sanitized shapes

Closes #507
Closes #508
Closes #509
Closes #510