### PR TITLE
Fix CodeQL gate script always failing on directory-shaped sarif output

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,10 +61,21 @@ jobs:
       - name: Block PR on high or critical findings
         if: github.event_name == 'pull_request'
         run: |
-          count=$(jq '[.runs[].results[] | select(.level == "error")] | length' codeql-results.sarif)
+          # The analyze action's `output` path is a directory of per-language
+          # .sarif files (e.g. codeql-results.sarif/javascript.sarif), not a
+          # single file — jq can't parse a directory directly, so locate the
+          # actual file(s) inside it first. Falls back to treating the path
+          # itself as a file if it's ever not a directory.
+          if [ -d codeql-results.sarif ]; then
+            sarif_files=$(find codeql-results.sarif -type f -name '*.sarif')
+          else
+            sarif_files=codeql-results.sarif
+          fi
+
+          count=$(jq -s '[.[] | .runs[].results[] | select(.level == "error")] | length' $sarif_files)
           if [ "${count}" -gt 0 ]; then
             echo "::error::CodeQL found ${count} high or critical severity finding(s). Merge is blocked."
-            jq -r '.runs[].results[] | select(.level == "error") | "- \(.ruleId): \(.message.text)"' codeql-results.sarif
+            jq -r '.runs[].results[] | select(.level == "error") | "- \(.ruleId): \(.message.text)"' $sarif_files
             exit 1
           fi
           echo "No high or critical CodeQL findings detected."


### PR DESCRIPTION
## Problem

Every PR's \`Analyze\` CodeQL check fails, unrelated to whether real findings exist. The gate step runs:

\`\`\`bash
jq '[.runs[].results[] | select(.level == "error")] | length' codeql-results.sarif
\`\`\`

But \`codeql-action/analyze\`'s \`output: codeql-results.sarif\` path is a **directory** containing per-language sarif files (\`codeql-results.sarif/javascript.sarif\`), not a single file. \`jq\` can't parse a directory and exits with code 2 — which the workflow then reports as a failed check, indistinguishable from a real high/critical finding.

Verified this is the actual cause behind the \`Analyze\` failure on essentially every currently-open PR (checked #516, #422, #421, #420, #419, #418, #416, #517).

## Fix

Locate the actual \`.sarif\` file(s) inside the output directory before handing them to \`jq\`, using \`-s\` (slurp) so the count is correctly totaled across however many language sarif files exist, not just the first one found.

## Testing

Verified both branches of the new logic under bash (matching this workflow's \`shell: bash -e {0}\`):
- A sarif directory with only warning-level results → count 0, exits 0 ("No high or critical CodeQL findings detected").
- A sarif directory with a real error-level result → count 1, exits 1, prints the finding (\`- js/sql-injection: ...\`).

No way to trigger a real CodeQL run outside of Actions to test end-to-end, but the shell logic itself is verified correct for the exact directory shape the analyze action produces.