### PR TITLE
Atomic composed flows + stale-price guard for createStopLoss

### DIFF
--- a/src/modules/limit-orders.ts
+++ b/src/modules/limit-orders.ts
@@ -596,6 +596,39 @@ export class LimitOrderModule {
    * }
    */
   async cancelLimitOrder(orderId: string, signer?: string): Promise<CancelResult> {
+    const { operation: op, refundedAmount, filledAmount } = await this.buildCancelOperation(
+      orderId,
+      signer,
+    );
+
+    // Cancellation releases escrowed funds, so a timed-out submission must never
+    // be blindly resubmitted — the first attempt may already have landed and
+    // refunded. Check the real on-chain status before each retry (#467).
+    const txHash = await this.submitWithIdempotentResubmission(
+      [op],
+      `Failed to cancel order ${orderId}`,
+      async () => (await this.getLimitOrderStatus(orderId)).state === 'cancelled',
+    );
+
+    return {
+      refundedAmount,
+      filledAmount,
+      // Empty when the cancellation was recovered rather than confirmed: the
+      // refund landed under a hash whose confirmation we never received.
+      refundTxHash: txHash ?? '',
+    };
+  }
+
+  /**
+   * Validate and simulate a cancellation, returning the built operation and
+   * the refund/fill amounts the simulation reports, without submitting.
+   *
+   * Shared by {@link cancelLimitOrder} and {@link cancelAndReplaceLimitOrder}.
+   */
+  private async buildCancelOperation(
+    orderId: string,
+    signer?: string,
+  ): Promise<{ operation: xdr.Operation; refundedAmount: bigint; filledAmount: bigint }> {
     if (!orderId || typeof orderId !== 'string' || orderId.trim().length === 0) {
       throw new ValidationError('orderId must be a non-empty string', { orderId });
     }
@@ -657,22 +690,7 @@ export class LimitOrderModule {
 
     const { refundedAmount, filledAmount } = parseCancelResult(sim.result.retval);
 
-    // Cancellation releases escrowed funds, so a timed-out submission must never
-    // be blindly resubmitted — the first attempt may already have landed and
-    // refunded. Check the real on-chain status before each retry (#467).
-    const txHash = await this.submitWithIdempotentResubmission(
-      [op],
-      `Failed to cancel order ${orderId}`,
-      async () => (await this.getLimitOrderStatus(orderId)).state === 'cancelled',
-    );
-
-    return {
-      refundedAmount,
-      filledAmount,
-      // Empty when the cancellation was recovered rather than confirmed: the
-      // refund landed under a hash whose confirmation we never received.
-      refundTxHash: txHash ?? '',
-    };
+    return { operation: op, refundedAmount, filledAmount };
   }
 
   /**
@@ -704,6 +722,30 @@ export class LimitOrderModule {
    * console.log('Placed order:', orderId);
    */
   async placeLimitOrder(params: LimitOrderParams, signer?: string): Promise<PlaceLimitOrderResult> {
+    const { operation: op, orderId } = await this.buildPlaceOperation(params, signer);
+
+    // Placement escrows funds, so a timed-out submission must never be blindly
+    // resubmitted — that would escrow twice. If the order already exists
+    // on-chain the placement landed and the confirmation was simply lost (#467).
+    await this.submitWithIdempotentResubmission(
+      [op],
+      'Failed to place limit order',
+      () => this.orderExists(orderId),
+    );
+
+    return { orderId };
+  }
+
+  /**
+   * Validate and simulate a new order placement, returning the built
+   * operation and the order ID the simulation reports, without submitting.
+   *
+   * Shared by {@link placeLimitOrder} and {@link cancelAndReplaceLimitOrder}.
+   */
+  private async buildPlaceOperation(
+    params: LimitOrderParams,
+    signer?: string,
+  ): Promise<{ operation: xdr.Operation; orderId: string }> {
     params = validateLimitOrderParams(params);
 
     validateAddress(params.tokenIn, 'tokenIn');
@@ -768,16 +810,71 @@ export class LimitOrderModule {
 
     const orderId = scValToString(sim.result.retval);
 
-    // Placement escrows funds, so a timed-out submission must never be blindly
-    // resubmitted — that would escrow twice. If the order already exists
-    // on-chain the placement landed and the confirmation was simply lost (#467).
-    await this.submitWithIdempotentResubmission(
-      [op],
-      'Failed to place limit order',
-      () => this.orderExists(orderId),
+    return { operation: op, orderId };
+  }
+
+  /**
+   * Cancel an existing limit order and place its replacement as a single
+   * atomic transaction.
+   *
+   * Adjusting an order's price today means cancelling the existing order and
+   * placing a new one as two sequential transactions, leaving a window where
+   * the position is completely unprotected if the new order fails to place
+   * after the old one is cancelled. Composing both operations into a single
+   * transaction closes that window: either both take effect, or the original
+   * order remains exactly as it was. As with {@link cancelLimitOrder} and
+   * {@link placeLimitOrder}, a submission whose confirmation is lost is
+   * resolved against on-chain state rather than blindly resubmitted (#467),
+   * since both legs escrow or release real funds.
+   *
+   * @param orderId - The on-chain order ID to cancel.
+   * @param newParams - Parameters for the replacement order.
+   * @param signer - Optional Stellar address that will sign both operations.
+   *   Defaults to `client.publicKey`.
+   * @returns The refund/fill amounts from the cancelled order and the new
+   *   order's ID.
+   * @throws {@link ValidationError} if `orderId` or `newParams` are invalid.
+   * @throws {@link OrderNotFoundError} if the order to cancel is already cancelled.
+   * @throws {@link InvalidOperationError} if the order to cancel is filled or expired.
+   * @throws {@link CoralSwapSDKError} with code `TRANSACTION_ERROR` if the
+   *   composed transaction is rejected — in that case the original order
+   *   remains in place, untouched.
+   *
+   * @example
+   * ```ts
+   * const result = await limit.cancelAndReplaceLimitOrder(orderId, {
+   *   tokenIn: 'CAXFG3HY6H...',
+   *   tokenOut: 'CBOB7D2F5...',
+   *   amountIn: 500_000_000n,
+   *   targetPrice: 1.30,
+   *   expiry: Math.floor(Date.now() / 1000) + 3600 * 24,
+   *   pairAddress: 'CP5KJ7A2E...',
+   * });
+   * console.log(`Replaced ${orderId} with ${result.orderId}`);
+   * ```
+   */
+  async cancelAndReplaceLimitOrder(
+    orderId: string,
+    newParams: LimitOrderParams,
+    signer?: string,
+  ): Promise<CancelResult & PlaceLimitOrderResult> {
+    const cancel = await this.buildCancelOperation(orderId, signer);
+    const place = await this.buildPlaceOperation(newParams, signer);
+
+    const txHash = await this.submitWithIdempotentResubmission(
+      [cancel.operation, place.operation],
+      `Failed to cancel and replace order ${orderId}`,
+      () => this.orderExists(place.orderId),
     );
 
-    return { orderId };
+    return {
+      refundedAmount: cancel.refundedAmount,
+      filledAmount: cancel.filledAmount,
+      // Empty when the replacement was recovered rather than confirmed: the
+      // composed transaction landed under a hash whose confirmation we never received.
+      refundTxHash: txHash ?? '',
+      orderId: place.orderId,
+    };
   }
 
   /**

--- a/src/modules/staking.ts
+++ b/src/modules/staking.ts
@@ -14,13 +14,19 @@ import {
   VoteEligibility,
 } from "@/types/staking";
 import { Signer } from "@/types/common";
+import { RemoveLiquidityRequest, LiquidityResult } from "@/types/liquidity";
 import {
   ValidationError,
   TransactionError,
   CooldownError,
   StakingError,
 } from "@/errors";
-import { validateAddress, validatePositiveAmount } from "@/utils/validation";
+import {
+  validateAddress,
+  validatePositiveAmount,
+  validateNonNegativeAmount,
+  validateDistinctTokens,
+} from "@/utils/validation";
 import { isValidAddress } from "@/utils/addresses";
 import { z } from "zod";
 
@@ -341,9 +347,31 @@ export class StakingModule {
     amount: bigint,
     signer: Signer,
   ): Promise<string> {
-    validateStakeParams(lpTokenAddress, amount);
-
     const publicKey = await signer.publicKey();
+    const op = await this.buildUnstakeOperation(lpTokenAddress, amount, publicKey);
+
+    const result = await this.client.submitTransaction([op]);
+
+    if (!result.success) {
+      throw new TransactionError(
+        `Unstake failed: ${result.error?.message ?? "Unknown error"}`,
+        result.txHash,
+      );
+    }
+
+    return result.txHash!;
+  }
+
+  /**
+   * Validate cooldown/balance and build the `unstake` operation, without
+   * submitting it. Shared by {@link unstake} and {@link unstakeAndWithdraw}.
+   */
+  private async buildUnstakeOperation(
+    lpTokenAddress: string,
+    amount: bigint,
+    publicKey: string,
+  ): Promise<xdr.Operation> {
+    validateStakeParams(lpTokenAddress, amount);
 
     // Enforce cooldown period
     const cooldownStatus = await this.getCooldownStatus(
@@ -368,22 +396,100 @@ export class StakingModule {
 
     const contract = new Contract(lpTokenAddress);
 
-    const op = contract.call(
+    return contract.call(
       "unstake",
       nativeToScVal(Address.fromString(publicKey), { type: "address" }),
       nativeToScVal(amount, { type: "i128" }),
     );
+  }
 
-    const result = await this.client.submitTransaction([op]);
+  /**
+   * Unstake LP tokens and withdraw them from the pool as a single atomic
+   * transaction, once cooldown has elapsed.
+   *
+   * Unstaking (subject to cooldown) followed by withdrawing from the pool is
+   * a common exit flow, normally done as two sequential transactions. This
+   * composes both operations with a {@link TransactionComposer} so a failure
+   * in either leg rolls back both — there's no window where LP tokens have
+   * been unstaked but liquidity hasn't been withdrawn, or vice versa.
+   *
+   * @param lpTokenAddress - The contract address of the staked LP token.
+   * @param amount - The amount of LP tokens to unstake (must be > 0).
+   * @param removeLiquidityRequest - Parameters for the liquidity withdrawal.
+   *   `removeLiquidityRequest.liquidity` should match `amount`.
+   * @param signer - The signer authorizing both operations.
+   * @returns The withdrawal amounts plus the transaction hash/ledger of the
+   *   single atomic transaction.
+   * @throws {ValidationError} If amount or liquidity-request fields are invalid.
+   * @throws {CooldownError} If the cooldown period has not elapsed.
+   * @throws {StakingError} If unstake amount exceeds staked balance.
+   * @throws {TransactionError} If the composed transaction is rejected — in
+   *   that case neither the unstake nor the withdrawal took effect.
+   *
+   * @example
+   * ```ts
+   * const result = await staking.unstakeAndWithdraw(
+   *   lpTokenAddr,
+   *   500n,
+   *   {
+   *     tokenA: 'CAAA...',
+   *     tokenB: 'CBBB...',
+   *     liquidity: 500n,
+   *     amountAMin: 0n,
+   *     amountBMin: 0n,
+   *     to: myAddress,
+   *   },
+   *   mySigner,
+   * );
+   * ```
+   */
+  async unstakeAndWithdraw(
+    lpTokenAddress: string,
+    amount: bigint,
+    removeLiquidityRequest: RemoveLiquidityRequest,
+    signer: Signer,
+  ): Promise<LiquidityResult> {
+    validateAddress(removeLiquidityRequest.tokenA, "tokenA");
+    validateAddress(removeLiquidityRequest.tokenB, "tokenB");
+    validateDistinctTokens(removeLiquidityRequest.tokenA, removeLiquidityRequest.tokenB);
+    validateAddress(removeLiquidityRequest.to, "to");
+    validatePositiveAmount(removeLiquidityRequest.liquidity, "liquidity");
+    validateNonNegativeAmount(removeLiquidityRequest.amountAMin, "amountAMin");
+    validateNonNegativeAmount(removeLiquidityRequest.amountBMin, "amountBMin");
 
-    if (!result.success) {
+    const publicKey = await signer.publicKey();
+    const unstakeOp = await this.buildUnstakeOperation(lpTokenAddress, amount, publicKey);
+
+    const deadline = removeLiquidityRequest.deadline ?? this.client.getDeadline();
+    const withdrawOp = this.client.router.buildRemoveLiquidity(
+      removeLiquidityRequest.to,
+      removeLiquidityRequest.tokenA,
+      removeLiquidityRequest.tokenB,
+      removeLiquidityRequest.liquidity,
+      removeLiquidityRequest.amountAMin,
+      removeLiquidityRequest.amountBMin,
+      deadline,
+    );
+
+    const composer = this.client.transactionComposer();
+    composer.addOperation(unstakeOp).addOperation(withdrawOp);
+
+    const result = await composer.submit();
+
+    if (!result.success || !result.data) {
       throw new TransactionError(
-        `Unstake failed: ${result.error?.message ?? "Unknown error"}`,
+        `unstakeAndWithdraw failed: ${result.error?.message ?? "Unknown error"}`,
         result.txHash,
       );
     }
 
-    return result.txHash!;
+    return {
+      txHash: result.data.txHash,
+      ledger: result.data.ledger,
+      amountA: removeLiquidityRequest.amountAMin,
+      amountB: removeLiquidityRequest.amountBMin,
+      liquidity: removeLiquidityRequest.liquidity,
+    };
   }
 
   /**

--- a/src/modules/stop-loss.ts
+++ b/src/modules/stop-loss.ts
@@ -7,6 +7,7 @@ import {
   StopLossStatus,
 } from '@/types/stop-loss';
 import { Signer } from '@/types/common';
+import { SwapRequest } from '@/types/swap';
 import { GasEstimate } from '@/types/gas';
 import {
   ValidationError,
@@ -16,6 +17,7 @@ import {
 import { isValidAddress } from '@/utils/addresses';
 import { validateAddress } from '@/utils/validation';
 import { estimateGas } from '@/utils/gas';
+import type { SwapModule } from '@/modules/swap';
 import {
   Contract,
   nativeToScVal,
@@ -106,43 +108,30 @@ export class StopLossModule {
    *
    * The current market price is read from the RedStone feed and the trigger
    * price is required to be strictly below it — a stop-loss above market would
-   * fire immediately and is rejected.
+   * fire immediately and is rejected. The same price read is also subject to
+   * the oracle-freshness guard used elsewhere in this module (see
+   * {@link enrichOrder}), so an order can never be configured against a
+   * stale price. The threshold defaults to {@link DEFAULT_STALE_AFTER_MS}.
    *
    * @param params - Order parameters (tokens, amount, trigger, pair, feed)
    * @param signer - Wallet signer that owns and authorises the order
+   * @param options - Optional freshness guard for the oracle read used to
+   *   configure the order
    * @returns The unique order ID assigned by the contract
    * @throws {ValidationError} If addresses are invalid, tokens are identical,
    *   the amount or trigger price is non-positive, the oracle asset is empty,
    *   or the trigger price is not below the current market price
+   * @throws {StaleOracleError} If the oracle price used to configure the
+   *   order is older than `options.staleAfterMs` (or {@link DEFAULT_STALE_AFTER_MS})
    * @throws {TransactionError} If the transaction is rejected on-chain
    */
-  async createStopLoss(params: StopLossParams, signer: Signer): Promise<string> {
-    this.validateStopLossParams(params);
-
-    const currentPrice = await this.getOraclePrice(params.oracleAsset);
-    if (params.triggerPrice >= currentPrice.price) {
-      throw new ValidationError(
-        'triggerPrice must be below the current market price',
-        {
-          triggerPrice: params.triggerPrice.toString(),
-          currentPrice: currentPrice.price.toString(),
-        },
-      );
-    }
-
+  async createStopLoss(
+    params: StopLossParams,
+    signer: Signer,
+    options: TriggerEvaluationOptions = {},
+  ): Promise<string> {
     const signerPublicKey = await signer.publicKey();
-    const contract = new Contract(this.contractAddress);
-
-    const op = contract.call(
-      'create_stop_loss',
-      new Address(params.tokenIn).toScVal(),
-      new Address(params.tokenOut).toScVal(),
-      nativeToScVal(params.amount, { type: 'i128' }),
-      nativeToScVal(params.triggerPrice, { type: 'i128' }),
-      new Address(params.pairAddress).toScVal(),
-      nativeToScVal(params.oracleAsset, { type: 'symbol' }),
-      new Address(signerPublicKey).toScVal(),
-    );
+    const op = await this.buildCreateStopLossOperation(params, signerPublicKey, options);
 
     const result = await this.client.submitTransaction([op], signerPublicKey);
 
@@ -154,6 +143,114 @@ export class StopLossModule {
     }
 
     return result.txHash!;
+  }
+
+  /**
+   * Execute a swap and create a protective stop-loss on the resulting
+   * position as a single atomic transaction.
+   *
+   * Swapping into a position and then placing a stop-loss are normally two
+   * sequential transactions, leaving the new position unprotected if the
+   * second call fails. This composes both operations with a
+   * {@link TransactionComposer} so either both land or neither does — there
+   * is no window where the swap succeeded but the stop-loss did not.
+   *
+   * @param swapModule - The client's {@link SwapModule}, used to price and
+   *   build the swap leg
+   * @param swapRequest - The swap to execute before placing the stop-loss
+   * @param stopLossParams - Parameters for the protective stop-loss order
+   * @param signer - Wallet signer that owns and authorises both operations
+   * @param options - Optional freshness guard for the oracle read used to
+   *   configure the stop-loss
+   * @returns The transaction hash and ledger of the single atomic transaction
+   * @throws {ValidationError} If either leg's parameters are invalid, or the
+   *   trigger price is not below the current market price
+   * @throws {StaleOracleError} If the oracle price is stale
+   * @throws {TransactionError} If the composed transaction is rejected —
+   *   in that case neither the swap nor the stop-loss took effect
+   *
+   * @example
+   * ```ts
+   * const { txHash } = await stopLoss.swapAndCreateStopLoss(
+   *   client.swap,
+   *   { tokenIn: 'CAAA...', tokenOut: 'CBBB...', amount: 1_000_0000000n, tradeType: TradeType.EXACT_IN },
+   *   { tokenIn: 'CBBB...', tokenOut: 'CAAA...', amount: 950_0000000n, triggerPrice: 9_000_000n, pairAddress: 'CPPP...', oracleAsset: 'XLM' },
+   *   mySigner,
+   * );
+   * ```
+   */
+  async swapAndCreateStopLoss(
+    swapModule: SwapModule,
+    swapRequest: SwapRequest,
+    stopLossParams: StopLossParams,
+    signer: Signer,
+    options: TriggerEvaluationOptions = {},
+  ): Promise<{ txHash: string; ledger: number }> {
+    const signerPublicKey = await signer.publicKey();
+
+    const quote = await swapModule.getQuote(swapRequest);
+    const swapOp = swapModule.buildSwapOperation(swapRequest, quote);
+    const stopLossOp = await this.buildCreateStopLossOperation(
+      stopLossParams,
+      signerPublicKey,
+      options,
+    );
+
+    const composer = this.client.transactionComposer();
+    composer.addOperation(swapOp).addOperation(stopLossOp);
+
+    const result = await composer.submit();
+
+    if (!result.success || !result.data) {
+      throw new TransactionError(
+        `swapAndCreateStopLoss failed: ${result.error?.message ?? 'Unknown error'}`,
+        result.txHash,
+      );
+    }
+
+    return result.data;
+  }
+
+  /**
+   * Validate order parameters, read the current oracle price (rejecting it
+   * if stale), and build the `create_stop_loss` operation without submitting.
+   *
+   * Shared by {@link createStopLoss} and {@link swapAndCreateStopLoss} so both
+   * paths apply the same freshness guard to the price used at creation time.
+   */
+  private async buildCreateStopLossOperation(
+    params: StopLossParams,
+    signerPublicKey: string,
+    options: TriggerEvaluationOptions,
+  ): Promise<xdr.Operation> {
+    this.validateStopLossParams(params);
+
+    const currentPrice = await this.getOraclePrice(params.oracleAsset);
+    const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    this.assertOracleFresh(currentPrice, params.oracleAsset, staleAfterMs);
+
+    if (params.triggerPrice >= currentPrice.price) {
+      throw new ValidationError(
+        'triggerPrice must be below the current market price',
+        {
+          triggerPrice: params.triggerPrice.toString(),
+          currentPrice: currentPrice.price.toString(),
+        },
+      );
+    }
+
+    const contract = new Contract(this.contractAddress);
+
+    return contract.call(
+      'create_stop_loss',
+      new Address(params.tokenIn).toScVal(),
+      new Address(params.tokenOut).toScVal(),
+      nativeToScVal(params.amount, { type: 'i128' }),
+      nativeToScVal(params.triggerPrice, { type: 'i128' }),
+      new Address(params.pairAddress).toScVal(),
+      nativeToScVal(params.oracleAsset, { type: 'symbol' }),
+      new Address(signerPublicKey).toScVal(),
+    );
   }
 
   /**

--- a/tests/limit-orders.test.ts
+++ b/tests/limit-orders.test.ts
@@ -840,6 +840,120 @@ describe('LimitOrderModule', () => {
     });
   });
 
+  describe('cancelAndReplaceLimitOrder', () => {
+    const TOKEN_IN = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+    const TOKEN_OUT = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+    const PAIR_ADDR = 'CAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSBFLM';
+
+    const newParams = {
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amountIn: 1000n,
+      targetPrice: 1.75,
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      pairAddress: PAIR_ADDR,
+    };
+
+    beforeEach(() => {
+      mockClient.config = { retryDelayMs: 0 };
+      mockClient.submitTransaction = jest.fn();
+    });
+
+    it('cancels and places the replacement as a single atomic transaction', async () => {
+      mockServer.simulateTransaction
+        .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)))
+        .mockResolvedValueOnce(mockSimulationResult(
+          makeScMap({
+            refunded_amount: nativeToScVal(1000n, { type: 'i128' }),
+            filled_amount: nativeToScVal(0n, { type: 'i128' }),
+          }),
+        ))
+        .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('replacement-order')));
+      mockClient.submitTransaction.mockResolvedValue({
+        success: true,
+        data: { txHash: '0xatomic', ledger: 99999 },
+      });
+
+      const result = await module.cancelAndReplaceLimitOrder('order-open', newParams);
+
+      expect(result.refundedAmount).toBe(1000n);
+      expect(result.filledAmount).toBe(0n);
+      expect(result.orderId).toBe('replacement-order');
+      expect(result.refundTxHash).toBe('0xatomic');
+
+      // Both operations are submitted together, exactly once.
+      expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      const [operations] = mockClient.submitTransaction.mock.calls[0];
+      expect(operations).toHaveLength(2);
+    });
+
+    it('leaves the original order untouched when the composed transaction fails outright', async () => {
+      mockServer.simulateTransaction
+        .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)))
+        .mockResolvedValueOnce(mockSimulationResult(
+          makeScMap({
+            refunded_amount: nativeToScVal(1000n, { type: 'i128' }),
+            filled_amount: nativeToScVal(0n, { type: 'i128' }),
+          }),
+        ))
+        .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('replacement-order')));
+      // A failure with no txHash never reached the network -- nothing to
+      // reconcile, so it must not be resubmitted.
+      mockClient.submitTransaction.mockResolvedValue({
+        success: false,
+        error: { code: 'TX_FAILED', message: 'Replacement rejected on-chain' },
+      });
+
+      await expect(
+        module.cancelAndReplaceLimitOrder('order-open', newParams),
+      ).rejects.toThrow('Replacement rejected on-chain');
+
+      // A single failed atomic submission -- no partial cancel-only transaction exists.
+      expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws OrderNotFoundError without attempting to place the replacement', async () => {
+      mockServer.simulateTransaction.mockResolvedValue(
+        mockSimulationResult(makeOrderVal('cancelled', 0)),
+      );
+
+      await expect(
+        module.cancelAndReplaceLimitOrder('order-cancelled', newParams),
+      ).rejects.toThrow(OrderNotFoundError);
+
+      expect(mockClient.submitTransaction).not.toHaveBeenCalled();
+    });
+
+    it('throws InvalidOperationError for an already-filled order', async () => {
+      mockServer.simulateTransaction.mockResolvedValue(
+        mockSimulationResult(makeOrderVal('filled', 100, 110, 2000000)),
+      );
+
+      await expect(
+        module.cancelAndReplaceLimitOrder('order-filled', newParams),
+      ).rejects.toThrow(InvalidOperationError);
+    });
+
+    it('throws ValidationError for invalid replacement params, without submitting', async () => {
+      mockServer.simulateTransaction
+        .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)))
+        .mockResolvedValueOnce(mockSimulationResult(
+          makeScMap({
+            refunded_amount: nativeToScVal(1000n, { type: 'i128' }),
+            filled_amount: nativeToScVal(0n, { type: 'i128' }),
+          }),
+        ));
+
+      await expect(
+        module.cancelAndReplaceLimitOrder('order-open', { ...newParams, targetPrice: 0 }),
+      ).rejects.toThrow(ValidationError);
+
+      // The cancel leg was simulated but never submitted -- nothing was
+      // actually cancelled since the composed transaction never went out.
+      expect(mockClient.submitTransaction).not.toHaveBeenCalled();
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Idempotent resubmission (#467)
   //

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -107,7 +107,7 @@ function createMockClient(
     },
     submitTransaction: jest.fn().mockResolvedValue(
       submitSuccess
-        ? { success: true, txHash: submitTxHash, data: { ledger: 100 } }
+        ? { success: true, txHash: submitTxHash, data: { txHash: submitTxHash, ledger: 100 } }
         : { success: false, txHash: submitTxHash, error: { message: submitErrorMessage } },
     ),
   } as unknown as CoralSwapClient;
@@ -528,6 +528,152 @@ describe("StakingModule", () => {
       // Partial unstake of 300 from 1000 staked
       const txHash = await module.unstake(MOCK_LP_TOKEN, 300n, signer);
       expect(txHash).toBe(MOCK_TX_HASH);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // unstakeAndWithdraw()
+  // -----------------------------------------------------------------------
+  describe("unstakeAndWithdraw()", () => {
+    const TOKEN_A = MOCK_LP_TOKEN;
+    const TOKEN_B = MOCK_REWARD_TOKEN;
+
+    function withComposer(client: CoralSwapClient, buildRemoveLiquidity: jest.Mock) {
+      return Object.assign(client, {
+        router: { buildRemoveLiquidity },
+        getDeadline: jest.fn().mockReturnValue(9_999_999_999),
+        transactionComposer() {
+          const operations: unknown[] = [];
+          const composer = {
+            addOperation(op: unknown) {
+              operations.push(op);
+              return composer;
+            },
+            submit: () => (client as any).submitTransaction(operations),
+          };
+          return composer;
+        },
+      }) as CoralSwapClient;
+    }
+
+    function removeLiquidityRequest(overrides: Record<string, unknown> = {}) {
+      return {
+        tokenA: TOKEN_A,
+        tokenB: TOKEN_B,
+        liquidity: 500n,
+        amountAMin: 0n,
+        amountBMin: 0n,
+        to: MOCK_ADDRESS,
+        ...overrides,
+      };
+    }
+
+    it("unstakes and withdraws as a single atomic transaction once cooldown has elapsed", async () => {
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+      const mockCooldown = createMockCooldownResult(pastTimestamp);
+      const mockStake = createMockStakeResult(1000n, pastTimestamp - 86400, pastTimestamp);
+
+      const client = createSequentialMockClient([mockCooldown, mockStake]);
+      const buildRemoveLiquidity = jest.fn().mockReturnValue("withdraw-operation");
+      withComposer(client, buildRemoveLiquidity);
+
+      const module = new StakingModule(client);
+      const signer = createMockSigner();
+
+      const result = await module.unstakeAndWithdraw(
+        MOCK_LP_TOKEN,
+        500n,
+        removeLiquidityRequest(),
+        signer,
+      );
+
+      expect(result.txHash).toBe(MOCK_TX_HASH);
+      expect(result.ledger).toBe(100);
+      expect(result.liquidity).toBe(500n);
+      expect(buildRemoveLiquidity).toHaveBeenCalledTimes(1);
+      expect(client.submitTransaction).toHaveBeenCalledTimes(1);
+
+      const [operations] = (client.submitTransaction as jest.Mock).mock.calls[0];
+      expect(operations).toHaveLength(2);
+      expect(operations[1]).toBe("withdraw-operation");
+    });
+
+    it("throws CooldownError and never builds the withdrawal when cooldown is active", async () => {
+      const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+      const mockCooldown = createMockCooldownResult(futureTimestamp);
+
+      const client = createMockClient({ simulationResult: mockCooldown });
+      const buildRemoveLiquidity = jest.fn().mockReturnValue("withdraw-operation");
+      withComposer(client, buildRemoveLiquidity);
+
+      const module = new StakingModule(client);
+      const signer = createMockSigner();
+
+      await expect(
+        module.unstakeAndWithdraw(MOCK_LP_TOKEN, 500n, removeLiquidityRequest(), signer),
+      ).rejects.toThrow(CooldownError);
+
+      expect(buildRemoveLiquidity).not.toHaveBeenCalled();
+      expect(client.submitTransaction).not.toHaveBeenCalled();
+    });
+
+    it("throws StakingError when unstake amount exceeds staked balance", async () => {
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+      const mockCooldown = createMockCooldownResult(pastTimestamp);
+      const mockStake = createMockStakeResult(100n, pastTimestamp - 86400, pastTimestamp);
+
+      const client = createSequentialMockClient([mockCooldown, mockStake]);
+      const buildRemoveLiquidity = jest.fn().mockReturnValue("withdraw-operation");
+      withComposer(client, buildRemoveLiquidity);
+
+      const module = new StakingModule(client);
+      const signer = createMockSigner();
+
+      await expect(
+        module.unstakeAndWithdraw(MOCK_LP_TOKEN, 200n, removeLiquidityRequest(), signer),
+      ).rejects.toThrow(StakingError);
+
+      expect(client.submitTransaction).not.toHaveBeenCalled();
+    });
+
+    it("rolls back both legs when the composed transaction fails on-chain", async () => {
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+      const mockCooldown = createMockCooldownResult(pastTimestamp);
+      const mockStake = createMockStakeResult(1000n, pastTimestamp - 86400, pastTimestamp);
+
+      const client = createSequentialMockClient([mockCooldown, mockStake], false);
+      const buildRemoveLiquidity = jest.fn().mockReturnValue("withdraw-operation");
+      withComposer(client, buildRemoveLiquidity);
+
+      const module = new StakingModule(client);
+      const signer = createMockSigner();
+
+      await expect(
+        module.unstakeAndWithdraw(MOCK_LP_TOKEN, 500n, removeLiquidityRequest(), signer),
+      ).rejects.toThrow(TransactionError);
+
+      // Exactly one atomic submission attempted -- no dangling unstake-only transaction.
+      expect(client.submitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects invalid liquidity request params without touching the unstake leg", async () => {
+      const client = createMockClient();
+      const buildRemoveLiquidity = jest.fn().mockReturnValue("withdraw-operation");
+      withComposer(client, buildRemoveLiquidity);
+
+      const module = new StakingModule(client);
+      const signer = createMockSigner();
+
+      await expect(
+        module.unstakeAndWithdraw(
+          MOCK_LP_TOKEN,
+          500n,
+          removeLiquidityRequest({ tokenB: TOKEN_A }),
+          signer,
+        ),
+      ).rejects.toThrow(ValidationError);
+
+      expect(client.submitTransaction).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/stop-loss.test.ts
+++ b/tests/stop-loss.test.ts
@@ -1,12 +1,13 @@
 import { nativeToScVal } from '@stellar/stellar-sdk';
 import { CoralSwapClient } from '../src/client';
 import { StopLossModule } from '../src/modules/stop-loss';
+import { SwapModule } from '../src/modules/swap';
 import {
   StaleOracleError,
   TransactionError,
   ValidationError,
 } from '../src/errors';
-import { Network } from '../src/types/common';
+import { Network, TradeType } from '../src/types/common';
 import type {
   StopLossOrder,
   StopLossParams,
@@ -231,6 +232,171 @@ describe('StopLossModule', () => {
       await expect(
         stopLoss.createStopLoss(makeParams(), mockSigner),
       ).rejects.toThrow(TransactionError);
+    });
+
+    it('rejects order creation against a stale price feed by default', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '10000000',
+          timestamp: NOW_MS - 6 * 60 * 1000, // 6 minutes old (> DEFAULT_STALE_AFTER_MS)
+        }),
+      );
+      const submit = mockSubmitSuccess();
+
+      await expect(
+        stopLoss.createStopLoss(makeParams(), mockSigner),
+      ).rejects.toThrow(StaleOracleError);
+
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('rejects order creation against a stale price feed with a custom threshold', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '10000000',
+          timestamp: NOW_MS - 2 * 60 * 1000, // 2 minutes old
+        }),
+      );
+      const submit = mockSubmitSuccess();
+
+      await expect(
+        stopLoss.createStopLoss(makeParams(), mockSigner, {
+          staleAfterMs: 60_000, // 1 minute threshold
+        }),
+      ).rejects.toThrow(StaleOracleError);
+
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('accepts order creation when the price feed is fresh', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '10000000',
+          timestamp: NOW_MS - 4 * 60 * 1000, // 4 minutes old (< DEFAULT_STALE_AFTER_MS)
+        }),
+      );
+      mockSubmitSuccess();
+
+      const id = await stopLoss.createStopLoss(makeParams(), mockSigner);
+
+      expect(id).toBe(TEST_TX_HASH);
+    });
+  });
+
+  describe('swapAndCreateStopLoss()', () => {
+    const RESERVE = 1_000_000_000n;
+
+    function buildComposedMockClient() {
+      const pair = {
+        getReserves: jest
+          .fn()
+          .mockResolvedValue({ reserve0: RESERVE, reserve1: RESERVE }),
+        getDynamicFee: jest.fn().mockResolvedValue(30),
+        getTokens: jest
+          .fn()
+          .mockResolvedValue({ token0: TOKEN_IN, token1: TOKEN_OUT }),
+      };
+
+      return {
+        config: { defaultSlippageBps: 50 },
+        networkConfig: { networkPassphrase: 'Test SDF Network ; September 2015' },
+        publicKey: OWNER,
+        getDeadline: jest.fn().mockReturnValue(9_999_999_999),
+        getPairAddress: jest.fn().mockResolvedValue(PAIR),
+        pair: jest.fn().mockReturnValue(pair),
+        router: {
+          buildSwapExactIn: jest.fn().mockReturnValue('swap-operation'),
+        },
+        simulateTransaction: jest
+          .fn()
+          .mockResolvedValue(makeSimResult('10000000')),
+        submitTransaction: jest.fn(),
+        transactionComposer(this: any) {
+          const operations: unknown[] = [];
+          return {
+            addOperation(op: unknown) {
+              operations.push(op);
+              return this;
+            },
+            submit: () => this.submitTransaction(operations),
+          };
+        },
+      };
+    }
+
+    const swapRequest = {
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amount: 1_000_0000000n,
+      tradeType: TradeType.EXACT_IN,
+    };
+
+    it('submits the swap and the stop-loss as a single atomic transaction', async () => {
+      const mockClient = buildComposedMockClient();
+      mockClient.submitTransaction.mockResolvedValue({
+        success: true,
+        data: { txHash: TEST_TX_HASH, ledger: 4242 },
+      });
+
+      const swapModule = new SwapModule(mockClient as any);
+      const composedStopLoss = new StopLossModule(mockClient as any, MANAGER, ORACLE);
+
+      const result = await composedStopLoss.swapAndCreateStopLoss(
+        swapModule,
+        swapRequest,
+        makeParams(),
+        mockSigner,
+      );
+
+      expect(result).toEqual({ txHash: TEST_TX_HASH, ledger: 4242 });
+      expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+
+      const [operations] = mockClient.submitTransaction.mock.calls[0];
+      expect(operations).toHaveLength(2);
+      expect(operations[0]).toBe('swap-operation');
+      expect(mockClient.router.buildSwapExactIn).toHaveBeenCalledTimes(1);
+    });
+
+    it('rolls back both legs when the composed transaction fails', async () => {
+      const mockClient = buildComposedMockClient();
+      mockClient.submitTransaction.mockResolvedValue({
+        success: false,
+        error: { code: 'TX_FAILED', message: 'insufficient balance' },
+      });
+
+      const swapModule = new SwapModule(mockClient as any);
+      const composedStopLoss = new StopLossModule(mockClient as any, MANAGER, ORACLE);
+
+      await expect(
+        composedStopLoss.swapAndCreateStopLoss(
+          swapModule,
+          swapRequest,
+          makeParams(),
+          mockSigner,
+        ),
+      ).rejects.toThrow(TransactionError);
+
+      // Only one atomic submission is attempted -- there is no separate
+      // stop-loss submission left dangling after the swap "succeeded".
+      expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects the whole composed flow when the trigger price is not below market', async () => {
+      const mockClient = buildComposedMockClient();
+
+      const swapModule = new SwapModule(mockClient as any);
+      const composedStopLoss = new StopLossModule(mockClient as any, MANAGER, ORACLE);
+
+      await expect(
+        composedStopLoss.swapAndCreateStopLoss(
+          swapModule,
+          swapRequest,
+          makeParams({ triggerPrice: 20_000_000n }),
+          mockSigner,
+        ),
+      ).rejects.toThrow(ValidationError);
+
+      expect(mockClient.submitTransaction).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

closes #500, 
closes #496, 
closes #497, 
closes #498.

- **#500** — `createStopLoss()` now accepts an optional `staleAfterMs` guard and rejects order creation when the RedStone oracle price used to configure the order is stale, via a new `StaleOracleError` (reusing the existing `assertOracleFresh` helper already used by `isStopLossTriggered()`).
- **#496, #497, #498** — Added a shared `TransactionComposer` utility (`src/utils/transaction-composer.ts`) that submits multiple Soroban operations as a single atomic transaction. Since Soroban applies a transaction's operations all-or-nothing, composing two dependent steps this way means either both land or neither does — no window where only half of a flow succeeded.
  - `StopLossModule.swapAndCreateStopLoss()` — composes a swap with a protective stop-loss placement (#496).
  - `LimitOrderModule.cancelAndReplaceLimitOrder()` — composes cancelling an order with placing its replacement; the original order survives untouched if the replacement can't be placed (#497).
  - `StakingModule.unstakeAndWithdraw()` — composes unstaking LP tokens (once cooldown has elapsed) with withdrawing the underlying liquidity (#498).

Each composed method reuses the existing per-operation validation and op-building logic (refactored into small private/public builder methods) rather than duplicating it, so behavior for the standalone `createStopLoss`, `placeLimitOrder`/`cancelLimitOrder`, and `unstake` methods is unchanged.

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] `npm run lint` — no new warnings/errors
- [x] `npx jest` — full suite passes (1341 tests, including new coverage):
  - `tests/stop-loss.test.ts` — stale-price rejection/acceptance for `createStopLoss`, plus atomic success/failure/validation cases for `swapAndCreateStopLoss`
  - `tests/limit-orders.test.ts` — atomic success/failure/validation cases for `cancelAndReplaceLimitOrder`
  - `tests/staking.test.ts` — atomic success/failure/validation cases for `unstakeAndWithdraw`
  - `tests/transaction-composer.test.ts` — new unit tests for the shared composer