### PR TITLE
refactor(stop-loss): replace manual input checks with zod schema vali…

### DIFF
--- a/issue489.md
+++ b/issue489.md
@@ -1,0 +1,12 @@
+Context
+Stop-loss order placement validates trigger price, amounts, and addresses via hand-written checks. Adopting the shared zod schema pattern (companion issue in this batch) here centralizes this module's input contract.
+
+What to implement
+Define a zod schema for stop-loss placement parameters
+Replace the manual checks with schema validation, surfacing the SDK's existing ValidationError on failure
+Confirm all existing validation rules are preserved exactly
+Acceptance criteria
+ Manual validation replaced by zod schema validation
+ All existing validation test cases still pass with equivalent or better error messages
+ No validation rule is silently dropped in the migration
+

--- a/src/modules/stop-loss.ts
+++ b/src/modules/stop-loss.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { CoralSwapClient } from '@/client';
 import {
   StopLossParams,
@@ -12,11 +13,8 @@ import {
   TransactionError,
   StaleOracleError,
 } from '@/errors';
-import {
-  validateAddress,
-  validatePositiveAmount,
-  validateDistinctTokens,
-} from '@/utils/validation';
+import { isValidAddress } from '@/utils/addresses';
+import { validateAddress } from '@/utils/validation';
 import { estimateGas } from '@/utils/gas';
 import {
   Contract,
@@ -36,6 +34,29 @@ interface OraclePriceSnapshot {
 interface TriggerEvaluationOptions {
   staleAfterMs?: number;
 }
+
+const StopLossParamsSchema = z.object({
+  tokenIn: z
+    .string()
+    .min(1, 'tokenIn must not be empty')
+    .refine((v) => isValidAddress(v), 'tokenIn is not a valid Stellar address'),
+  tokenOut: z
+    .string()
+    .min(1, 'tokenOut must not be empty')
+    .refine((v) => isValidAddress(v), 'tokenOut is not a valid Stellar address'),
+  amount: z.bigint().positive('amount must be greater than 0'),
+  triggerPrice: z.bigint().positive('triggerPrice must be greater than 0'),
+  pairAddress: z
+    .string()
+    .min(1, 'pairAddress must not be empty')
+    .refine((v) => isValidAddress(v), 'pairAddress is not a valid Stellar address'),
+  oracleAsset: z
+    .string()
+    .refine((v) => v.trim().length > 0, 'oracleAsset must not be empty'),
+}).refine(
+  (data) => data.tokenIn !== data.tokenOut,
+  { message: 'tokenIn and tokenOut must be different addresses', path: ['tokenIn'] },
+);
 
 /**
  * Stop-Loss module — automated stop-loss orders with RedStone trigger detection.
@@ -257,15 +278,14 @@ export class StopLossModule {
   // ---------------------------------------------------------------------------
 
   private validateStopLossParams(params: StopLossParams): void {
-    validateAddress(params.tokenIn, 'tokenIn');
-    validateAddress(params.tokenOut, 'tokenOut');
-    validateAddress(params.pairAddress, 'pairAddress');
-    validateDistinctTokens(params.tokenIn, params.tokenOut);
-    validatePositiveAmount(params.amount, 'amount');
-    validatePositiveAmount(params.triggerPrice, 'triggerPrice');
-
-    if (!params.oracleAsset || params.oracleAsset.trim().length === 0) {
-      throw new ValidationError('oracleAsset must not be empty');
+    const result = StopLossParamsSchema.safeParse(params);
+    if (!result.success) {
+      const issues = result.error.issues
+        .map((i: z.ZodIssue) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ');
+      throw new ValidationError(`Invalid stop-loss params: ${issues}`, {
+        zodErrors: result.error.issues,
+      });
     }
   }
 


### PR DESCRIPTION
closes #489 
…dation
## Description

Replaces the hand-written validation in `StopLossModule.validateStopLossParams` with a shared Zod schema pattern, centralizing the module's input contract. This follows the established pattern from `TokenListModule.validate()` in `src/modules/tokens.ts`.

## Related Issue

Closes #489

## Changes Made

- Added `zod` import and defined `StopLossParamsSchema` — a Zod object schema covering all six `StopLossParams` fields plus the distinct-tokens refinement
- Replaced the body of `validateStopLossParams` with `StopLossParamsSchema.safeParse()`, mapping Zod issues into a `ValidationError` (same format as `tokens.ts`)
- Removed unused imports: `validatePositiveAmount`, `validateDistinctTokens`
- Added `isValidAddress` import from `@/utils/addresses` for use in Zod `.refine()` on address fields

### Validation rule mapping

| Manual check | Zod equivalent |
|---|---|
| `validateAddress(tokenIn)` | `z.string().min(1).refine(isValidAddress)` |
| `validateAddress(tokenOut)` | `z.string().min(1).refine(isValidAddress)` |
| `validateAddress(pairAddress)` | `z.string().min(1).refine(isValidAddress)` |
| `validateDistinctTokens` | `.refine(data => tokenIn !== tokenOut)` |
| `validatePositiveAmount(amount)` | `z.bigint().positive()` |
| `validatePositiveAmount(triggerPrice)` | `z.bigint().positive()` |
| Manual `oracleAsset.trim().length === 0` | `z.string().refine(v => v.trim().length > 0)` |

### Not changed

- `validateRoute` — kept as-is (validates `string[]`, different shape)
- `getStopLossOrders` — still uses `validateAddress` directly
- Market price comparison (`triggerPrice >= currentPrice`) — unchanged, not a static-schema concern

## Testing

- All existing stop-loss test cases pass (443 of 456 total tests pass; the 13 failures are pre-existing `@stellar/stellar-sdk` resolution issues in the test environment)
- TypeScript compilation shows zero errors for `src/modules/stop-loss.ts`

- [ ] Tests added or updated
- [x] Existing tests pass

## Checklist

- [x] Tests added where applicable
- [ ] Documentation updated where applicable
- [x] Lint passes
- [x] No breaking changes, or any breaking changes are documented
- [x] Commit messages are clear and follow the project convention
