### PR TITLE
[SDK] Idempotent resubmission for stake/unstake

### DIFF
--- a/src/modules/staking.ts
+++ b/src/modules/staking.ts
@@ -1,4 +1,4 @@
-import {
+import { idempotentResubmit } from "@/utils/idempotent-resubmit";
   Contract,
   SorobanRpc,
   TransactionBuilder,
@@ -65,35 +65,38 @@ export class StakingModule {
    * const txHash = await staking.stake('CAAAA...', 1000n, mySigner);
    * ```
    */
-  async stake(
-    lpTokenAddress: string,
-    amount: bigint,
-    signer: Signer,
-  ): Promise<string> {
-    validateAddress(lpTokenAddress, "lpTokenAddress");
-    validatePositiveAmount(amount, "amount");
+  aasync stake(lpTokenAddress: string, amount: bigint, signer: Signer): Promise<string> {
+  validateAddress(lpTokenAddress, "lpTokenAddress");
+  validatePositiveAmount(amount, "amount");
 
-    const publicKey = await signer.publicKey();
-    const contract = new Contract(lpTokenAddress);
+  const publicKey = await signer.publicKey();
+  const contract = new Contract(lpTokenAddress);
+  const op = contract.call(
+    "stake",
+    nativeToScVal(Address.fromString(publicKey), { type: "address" }),
+    nativeToScVal(amount, { type: "i128" }),
+  );
 
-    const op = contract.call(
-      "stake",
-      nativeToScVal(Address.fromString(publicKey), { type: "address" }),
-      nativeToScVal(amount, { type: "i128" }),
-    );
+  const balanceBefore = await this.getStakedBalance(publicKey, lpTokenAddress);
 
-    const result = await this.client.submitTransaction([op]);
-
-    if (!result.success) {
-      throw new TransactionError(
-        `Stake failed: ${result.error?.message ?? "Unknown error"}`,
-        result.txHash,
-      );
-    }
-
-    return result.txHash!;
-  }
-
+  return idempotentResubmit(
+    async () => {
+      const result = await this.client.submitTransaction([op]);
+      if (!result.success) {
+        throw new TransactionError(
+          `Stake failed: ${result.error?.message ?? "Unknown error"}`,
+          result.txHash,
+        );
+      }
+      return result.txHash!;
+    },
+    async () => {
+      const balanceAfter = await this.getStakedBalance(publicKey, lpTokenAddress);
+      return balanceAfter.amount >= balanceBefore.amount + amount ? "landed" : null;
+    },
+    { maxRetries: 3, baseDelayMs: 1000, deadlineMs: Date.now() + 30_000 },
+  );
+}
   /**
    * Get the staked LP token position for an address.
    *
@@ -289,53 +292,50 @@ export class StakingModule {
    * const txHash = await staking.unstake('CAAAA...', 500n, mySigner);
    * ```
    */
-  async unstake(
-    lpTokenAddress: string,
-    amount: bigint,
-    signer: Signer,
-  ): Promise<string> {
-    validateAddress(lpTokenAddress, "lpTokenAddress");
-    validatePositiveAmount(amount, "amount");
+ async unstake(lpTokenAddress: string, amount: bigint, signer: Signer): Promise<string> {
+  validateAddress(lpTokenAddress, "lpTokenAddress");
+  validatePositiveAmount(amount, "amount");
 
-    const publicKey = await signer.publicKey();
+  const publicKey = await signer.publicKey();
 
-    // Enforce cooldown period
-    const cooldownStatus = await this.getCooldownStatus(publicKey, lpTokenAddress);
-    if (cooldownStatus.isInCooldown) {
-      throw new CooldownError(BigInt(cooldownStatus.cooldownEnd));
-    }
-
-    // Validate unstake amount does not exceed staked balance
-    const position = await this.getStakedBalance(publicKey, lpTokenAddress);
-    if (amount > position.amount) {
-      throw new StakingError(
-        `Unstake amount ${amount} exceeds staked balance ${position.amount}`,
-        {
-          requested: amount.toString(),
-          staked: position.amount.toString(),
-        },
-      );
-    }
-
-    const contract = new Contract(lpTokenAddress);
-
-    const op = contract.call(
-      "unstake",
-      nativeToScVal(Address.fromString(publicKey), { type: "address" }),
-      nativeToScVal(amount, { type: "i128" }),
-    );
-
-    const result = await this.client.submitTransaction([op]);
-
-    if (!result.success) {
-      throw new TransactionError(
-        `Unstake failed: ${result.error?.message ?? "Unknown error"}`,
-        result.txHash,
-      );
-    }
-
-    return result.txHash!;
+  const cooldownStatus = await this.getCooldownStatus(publicKey, lpTokenAddress);
+  if (cooldownStatus.isInCooldown) {
+    throw new CooldownError(BigInt(cooldownStatus.cooldownEnd));
   }
+
+  const position = await this.getStakedBalance(publicKey, lpTokenAddress);
+  if (amount > position.amount) {
+    throw new StakingError(
+      `Unstake amount ${amount} exceeds staked balance ${position.amount}`,
+      { requested: amount.toString(), staked: position.amount.toString() },
+    );
+  }
+
+  const contract = new Contract(lpTokenAddress);
+  const op = contract.call(
+    "unstake",
+    nativeToScVal(Address.fromString(publicKey), { type: "address" }),
+    nativeToScVal(amount, { type: "i128" }),
+  );
+
+  return idempotentResubmit(
+    async () => {
+      const result = await this.client.submitTransaction([op]);
+      if (!result.success) {
+        throw new TransactionError(
+          `Unstake failed: ${result.error?.message ?? "Unknown error"}`,
+          result.txHash,
+        );
+      }
+      return result.txHash!;
+    },
+    async () => {
+      const balanceAfter = await this.getStakedBalance(publicKey, lpTokenAddress);
+      return balanceAfter.amount <= position.amount - amount ? "landed" : null;
+    },
+    { maxRetries: 3, baseDelayMs: 1000, deadlineMs: Date.now() + 30_000 },
+  );
+}
 
   /**
    * Get the cooldown status for a staker's position.

--- a/src/utils/idempotent-resubmit.ts
+++ b/src/utils/idempotent-resubmit.ts
@@ -1,0 +1,80 @@
+import {
+  isRetryable,
+  sleep,
+  getCircuitBreaker,
+  DEFAULT_RETRY_CONFIG,
+  DeadlineError,
+} from "@/utils/retry";
+import type { RetryOptions } from "@/utils/retry";
+import { Logger } from "@/types/common";
+
+/**
+ * Wraps a state-changing submission (stake/unstake) so that a retryable
+ * failure (timeout, 503, etc.) never causes a blind resubmission of an
+ * operation that actually landed on-chain.
+ *
+ * Reuses the existing retry/backoff/circuit-breaker infra from retry.ts,
+ * adding an on-chain landed-check between attempts.
+ *
+ * @param submit - Executes the state-changing call, returns its tx hash.
+ * @param checkLanded - Called after a retryable failure. Returns a tx hash
+ *   (or synthetic marker) if the prior attempt is confirmed to have landed,
+ *   or null if it did not.
+ */
+export async function idempotentResubmit(
+  submit: () => Promise<string>,
+  checkLanded: () => Promise<string | null>,
+  options: RetryOptions,
+  logger?: Logger,
+  label: string = "idempotent-resubmit",
+): Promise<string> {
+  const baseDelayMs = options.baseDelayMs ?? options.retryDelayMs ?? DEFAULT_RETRY_CONFIG.baseDelayMs;
+  const backoffMultiplier = options.backoffMultiplier ?? DEFAULT_RETRY_CONFIG.backoffMultiplier;
+  const maxDelayMs = options.maxDelayMs ?? options.maxRetryDelayMs ?? DEFAULT_RETRY_CONFIG.maxDelayMs;
+  const maxRetries = options.maxRetries;
+
+  const breaker = getCircuitBreaker(label, options.circuitBreaker);
+  breaker.beforeRequest();
+
+  let lastError: unknown;
+
+  try {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (typeof options.deadlineMs === "number" && Date.now() >= options.deadlineMs) {
+        throw new DeadlineError(options.deadlineMs);
+      }
+      try {
+        const txHash = await submit();
+        breaker.onSuccess();
+        return txHash;
+      } catch (err: unknown) {
+        lastError = err;
+        if (!isRetryable(err) || attempt === maxRetries) throw err;
+
+        // Don't blindly resubmit — check real state first.
+        const landedTxHash = await checkLanded();
+        if (landedTxHash) {
+          breaker.onSuccess();
+          return landedTxHash;
+        }
+
+        const rawBackoff = baseDelayMs * Math.pow(backoffMultiplier, attempt);
+        const delay = Math.min(maxDelayMs, rawBackoff);
+
+        logger?.debug(`${label}: retrying after ${Math.round(delay)}ms (landed=false)`, {
+          attempt: attempt + 1,
+          maxRetries,
+          error: (err as Error).message,
+        });
+
+        await sleep(delay);
+      }
+    }
+  } catch (err) {
+    breaker.onFailure();
+    throw err;
+  }
+
+  breaker.onFailure();
+  throw lastError;
+}

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -608,3 +608,40 @@ describe("StakingModule", () => {
     });
   });
 });
+it("does not resubmit a timed-out stake that actually landed", async () => {
+  const balanceBefore = createMockStakeResult(0n, 0, 0);
+  const balanceAfterLanded = createMockStakeResult(1000n, Math.floor(Date.now() / 1000), 0);
+
+  const client = createSequentialMockClient([balanceBefore, balanceAfterLanded]);
+  (client.submitTransaction as jest.Mock).mockReset();
+  (client.submitTransaction as jest.Mock).mockRejectedValueOnce(
+    Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }),
+  );
+
+  const module = new StakingModule(client);
+  const signer = createMockSigner();
+
+  const txHash = await module.stake(MOCK_LP_TOKEN, 1000n, signer);
+
+  expect(txHash).toBe("landed");
+  expect(client.submitTransaction).toHaveBeenCalledTimes(1);
+});
+
+it("resubmits a stake when it genuinely did not land after timeout", async () => {
+  const balanceBefore = createMockStakeResult(0n, 0, 0);
+  const balanceStillZero = createMockStakeResult(0n, 0, 0);
+
+  const client = createSequentialMockClient([balanceBefore, balanceStillZero]);
+  (client.submitTransaction as jest.Mock).mockReset();
+  (client.submitTransaction as jest.Mock)
+    .mockRejectedValueOnce(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }))
+    .mockResolvedValueOnce({ success: true, txHash: MOCK_TX_HASH });
+
+  const module = new StakingModule(client);
+  const signer = createMockSigner();
+
+  const txHash = await module.stake(MOCK_LP_TOKEN, 1000n, signer);
+
+  expect(txHash).toBe(MOCK_TX_HASH);
+  expect(client.submitTransaction).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
Closes #469

Adds idempotent resubmission for stake() and unstake() using the 
existing retry/circuit-breaker infra in retry.ts. On a retryable 
failure, checks real staked balance before resubmitting instead of 
blindly retrying.