### PR TITLE
feat: idempotent resubmission for liquidity add/remove

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ export {
   batchRequest,
   batchRequestOrThrow,
   DEFAULT_BATCH_CONCURRENCY,
+  submitIdempotent,
 } from './utils';
 
 
@@ -137,6 +138,7 @@ export type {
   SimulateFn,
   BatchRequestOptions,
   BatchResult,
+  SubmitIdempotentClient,
 } from "./utils";
 
 // Errors

--- a/src/modules/liquidity.ts
+++ b/src/modules/liquidity.ts
@@ -16,6 +16,7 @@ import {
   validateDistinctTokens,
 } from "@/utils/validation";
 import { estimateGas } from "@/utils/gas";
+import { submitIdempotent } from "@/utils/submit-idempotent";
 
 /**
  * Liquidity module -- manages LP positions in CoralSwap pools.
@@ -155,7 +156,7 @@ export class LiquidityModule {
       return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
     }
 
-    const result = await this.client.submitTransaction([op]);
+    const result = await submitIdempotent(this.client, [op]);
 
     if (!result.success) {
       throw new TransactionError(
@@ -217,7 +218,7 @@ export class LiquidityModule {
       return estimateGas((ops) => this.client.simulateTransaction(ops, {}), [op]);
     }
 
-    const result = await this.client.submitTransaction([op]);
+    const result = await submitIdempotent(this.client, [op]);
 
     if (!result.success) {
       throw new TransactionError(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -93,3 +93,6 @@ export type { VotingPower, VotingPowerQueryProvider, VotingPowerQueryResult } fr
 
 export { checkCompatibility } from './migration';
 export type { BreakingChange, CompatibilityReport } from './migration';
+
+export { submitIdempotent } from './submit-idempotent';
+export type { SubmitIdempotentClient } from './submit-idempotent';

--- a/src/utils/submit-idempotent.ts
+++ b/src/utils/submit-idempotent.ts
@@ -1,0 +1,124 @@
+import { SorobanRpc, xdr } from "@stellar/stellar-sdk";
+import { Result } from "../types/common";
+
+/**
+ * Minimal interface that `submitIdempotent` needs from the client so the
+ * utility stays decoupled from the full CoralSwapClient type.
+ */
+export interface SubmitIdempotentClient {
+  /**
+   * Build, simulate, sign and submit a transaction.
+   *
+   * Should return `{ success: false, error: { code: 'TX_TIMEOUT', ... }, txHash }` when
+   * the transaction was submitted but confirmation polling timed out.
+   */
+  submitTransaction(
+    operations: xdr.Operation[],
+    source?: string,
+  ): Promise<Result<{ txHash: string; ledger: number }>>;
+
+  /**
+   * Access to the underlying Soroban RPC server for post-timeout status checks.
+   */
+  server: {
+    getTransaction(hash: string): Promise<SorobanRpc.Api.GetTransactionResponse>;
+  };
+}
+
+/**
+ * Submit a transaction with idempotent-resubmission protection.
+ *
+ * The problem this solves:
+ *
+ *   When a client-side polling timeout fires, the transaction may have
+ *   already landed on-chain.  Blindly resubmitting would create a
+ *   duplicate operation (double-spend, double deposit, double withdrawal).
+ *
+ * Behaviour:
+ *
+ *  1. Calls `client.submitTransaction(operations)` normally.
+ *  2. If the result is a `TX_TIMEOUT` error **and** we have a `txHash`:
+ *       a. Queries `getTransaction(txHash)` for the definitive on-chain status.
+ *       b. `SUCCESS`  → returns the landed result (no resubmission needed).
+ *       c. `FAILED`   → returns a failure result so the caller can handle/retry.
+ *       d. `NOT_FOUND` → the transaction has expired; returns the original timeout
+ *                        result so the caller can resubmit a fresh transaction.
+ *  3. Any other error is propagated as-is.
+ *
+ * @param client     - Object exposing `submitTransaction` and `server.getTransaction`.
+ * @param operations - Soroban XDR operations to include in the transaction.
+ * @param source     - Optional source account override.
+ * @returns A `Result` that is either the landed transaction or an error.
+ *
+ * @example
+ * const result = await submitIdempotent(client, [addLiquidityOp]);
+ * if (!result.success && result.error?.code === 'TX_NOT_FOUND_AFTER_TIMEOUT') {
+ *   // Safe to resubmit — transaction definitely did not land.
+ *   result = await submitIdempotent(client, [addLiquidityOp]);
+ * }
+ */
+export async function submitIdempotent(
+  client: SubmitIdempotentClient,
+  operations: xdr.Operation[],
+  source?: string,
+): Promise<Result<{ txHash: string; ledger: number }>> {
+  const result = await client.submitTransaction(operations, source);
+
+  // Happy path — transaction confirmed, or failed for a non-timeout reason.
+  if (result.success || result.error?.code !== "TX_TIMEOUT") {
+    return result;
+  }
+
+  // Polling timed out.  If we have the hash, check whether it landed.
+  const txHash = result.txHash;
+  if (!txHash) {
+    // No hash means we never even submitted — propagate the original result.
+    return result;
+  }
+
+  let statusResponse: SorobanRpc.Api.GetTransactionResponse;
+  try {
+    statusResponse = await client.server.getTransaction(txHash);
+  } catch {
+    // RPC error during the status check — return the timeout as-is; the
+    // caller should decide whether to retry.
+    return result;
+  }
+
+  if (statusResponse.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+    // Transaction landed despite the client-side timeout.
+    const ledger =
+      (statusResponse as SorobanRpc.Api.GetSuccessfulTransactionResponse)
+        .ledger ?? 0;
+    return {
+      success: true,
+      data: { txHash, ledger },
+      txHash,
+    };
+  }
+
+  if (statusResponse.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+    return {
+      success: false,
+      error: {
+        code: "TX_FAILED",
+        message: "Transaction failed on-chain (detected after timeout)",
+        details: { txHash },
+      },
+      txHash,
+    };
+  }
+
+  // NOT_FOUND — transaction was not seen by the network (expired).
+  // It is safe to resubmit a fresh transaction.
+  return {
+    success: false,
+    error: {
+      code: "TX_NOT_FOUND_AFTER_TIMEOUT",
+      message:
+        "Transaction timed out and was not found on-chain — safe to resubmit",
+      details: { txHash },
+    },
+    txHash,
+  };
+}

--- a/tests/liquidity.test.ts
+++ b/tests/liquidity.test.ts
@@ -992,4 +992,301 @@ describe("LiquidityModule", () => {
       expect(positions[0].token1Amount).toBe(0n);
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Idempotent resubmission — addLiquidity & removeLiquidity
+  //
+  // These tests verify that a client-side polling timeout does not cause a
+  // duplicate on-chain operation when the transaction already landed.
+  // -----------------------------------------------------------------------
+  describe("idempotent resubmission", () => {
+    const TOKEN_A = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+    const TOKEN_B = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4";
+    const TO_ADDRESS = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM";
+    const LANDED_TX_HASH = "landed-tx-hash-abc123";
+    const LANDED_LEDGER = 99999;
+
+    /** Build a mock client whose submitTransaction and server.getTransaction are jest fns. */
+    function buildIdempotentMockClient({
+      submitResult,
+      getTransactionStatus,
+    }: {
+      submitResult: object;
+      getTransactionStatus?: string; // 'SUCCESS' | 'FAILED' | 'NOT_FOUND'
+    }) {
+      const getTransactionMock = jest.fn().mockResolvedValue(
+        getTransactionStatus === "SUCCESS"
+          ? {
+              status: "SUCCESS",
+              ledger: LANDED_LEDGER,
+              latestLedger: LANDED_LEDGER,
+              latestLedgerCloseTime: 0,
+              oldestLedger: 1,
+              oldestLedgerCloseTime: 0,
+            }
+          : getTransactionStatus === "FAILED"
+            ? {
+                status: "FAILED",
+                ledger: LANDED_LEDGER,
+                latestLedger: LANDED_LEDGER,
+                latestLedgerCloseTime: 0,
+                oldestLedger: 1,
+                oldestLedgerCloseTime: 0,
+              }
+            : {
+                status: "NOT_FOUND",
+                latestLedger: LANDED_LEDGER,
+                latestLedgerCloseTime: 0,
+                oldestLedger: 1,
+                oldestLedgerCloseTime: 0,
+              },
+      );
+
+      return {
+        router: {
+          buildAddLiquidity: jest.fn().mockReturnValue({}),
+          buildRemoveLiquidity: jest.fn().mockReturnValue({}),
+        },
+        submitTransaction: jest.fn().mockResolvedValue(submitResult),
+        getDeadline: jest.fn().mockReturnValue(1234567890),
+        server: { getTransaction: getTransactionMock },
+        _getTransactionMock: getTransactionMock,
+      } as any;
+    }
+
+    // ------------------------------------------------------------------ //
+    //  addLiquidity — timeout-after-landed
+    // ------------------------------------------------------------------ //
+    describe("addLiquidity()", () => {
+      it("detects a timed-out-but-landed tx and returns it without resubmitting", async () => {
+        // submitTransaction returns TX_TIMEOUT (polling timed out)
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "TX_TIMEOUT", message: "Transaction confirmation timed out" },
+            txHash: LANDED_TX_HASH,
+          },
+          // But the transaction actually landed
+          getTransactionStatus: "SUCCESS",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          amountADesired: 1000n,
+          amountBDesired: 2000n,
+          amountAMin: 900n,
+          amountBMin: 1800n,
+          to: TO_ADDRESS,
+        };
+
+        const result = await module.addLiquidity(request);
+
+        // Should resolve successfully using the landed tx hash
+        expect(result.txHash).toBe(LANDED_TX_HASH);
+        expect(result.ledger).toBe(LANDED_LEDGER);
+
+        // submitTransaction was called exactly once — no resubmission
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+
+        // getTransaction was called to verify on-chain status after timeout
+        expect(mockClient.server.getTransaction).toHaveBeenCalledWith(LANDED_TX_HASH);
+      });
+
+      it("throws TransactionError when the tx genuinely failed (non-timeout error)", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "INSUFFICIENT_BALANCE", message: "Insufficient balance" },
+            txHash: "failed-tx-hash",
+          },
+          // getTransaction should NOT be called for non-timeout failures
+          getTransactionStatus: "NOT_FOUND",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          amountADesired: 1000n,
+          amountBDesired: 2000n,
+          amountAMin: 900n,
+          amountBMin: 1800n,
+          to: TO_ADDRESS,
+        };
+
+        await expect(module.addLiquidity(request)).rejects.toThrow(TransactionError);
+        await expect(module.addLiquidity(request)).rejects.toThrow("Insufficient balance");
+
+        // getTransaction should NOT be called because the error was not TX_TIMEOUT
+        expect(mockClient.server.getTransaction).not.toHaveBeenCalled();
+      });
+
+      it("throws TransactionError when tx timed out and was NOT found on-chain", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "TX_TIMEOUT", message: "Transaction confirmation timed out" },
+            txHash: LANDED_TX_HASH,
+          },
+          // Transaction was not seen on-chain — expired
+          getTransactionStatus: "NOT_FOUND",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          amountADesired: 1000n,
+          amountBDesired: 2000n,
+          amountAMin: 900n,
+          amountBMin: 1800n,
+          to: TO_ADDRESS,
+        };
+
+        // Should throw so the caller knows it can resubmit safely
+        await expect(module.addLiquidity(request)).rejects.toThrow(TransactionError);
+        // status check was performed
+        expect(mockClient.server.getTransaction).toHaveBeenCalledWith(LANDED_TX_HASH);
+      });
+
+      it("throws TransactionError when tx timed out and was FAILED on-chain", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "TX_TIMEOUT", message: "Transaction confirmation timed out" },
+            txHash: LANDED_TX_HASH,
+          },
+          getTransactionStatus: "FAILED",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          amountADesired: 1000n,
+          amountBDesired: 2000n,
+          amountAMin: 900n,
+          amountBMin: 1800n,
+          to: TO_ADDRESS,
+        };
+
+        await expect(module.addLiquidity(request)).rejects.toThrow(TransactionError);
+        expect(mockClient.server.getTransaction).toHaveBeenCalledWith(LANDED_TX_HASH);
+      });
+    });
+
+    // ------------------------------------------------------------------ //
+    //  removeLiquidity — timeout-after-landed
+    // ------------------------------------------------------------------ //
+    describe("removeLiquidity()", () => {
+      it("detects a timed-out-but-landed tx and returns it without resubmitting", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "TX_TIMEOUT", message: "Transaction confirmation timed out" },
+            txHash: LANDED_TX_HASH,
+          },
+          getTransactionStatus: "SUCCESS",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          liquidity: 500n,
+          amountAMin: 400n,
+          amountBMin: 800n,
+          to: TO_ADDRESS,
+        };
+
+        const result = await module.removeLiquidity(request);
+
+        expect(result.txHash).toBe(LANDED_TX_HASH);
+        expect(result.ledger).toBe(LANDED_LEDGER);
+
+        // submitTransaction was called exactly once — no resubmission
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+
+        // getTransaction was called to verify on-chain status after timeout
+        expect(mockClient.server.getTransaction).toHaveBeenCalledWith(LANDED_TX_HASH);
+      });
+
+      it("throws TransactionError when the tx genuinely failed (non-timeout error)", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "INSUFFICIENT_LP_BALANCE", message: "Insufficient LP balance" },
+            txHash: "failed-remove-hash",
+          },
+          getTransactionStatus: "NOT_FOUND",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          liquidity: 500n,
+          amountAMin: 400n,
+          amountBMin: 800n,
+          to: TO_ADDRESS,
+        };
+
+        await expect(module.removeLiquidity(request)).rejects.toThrow(TransactionError);
+        await expect(module.removeLiquidity(request)).rejects.toThrow("Insufficient LP balance");
+
+        // getTransaction should NOT be called because the error was not TX_TIMEOUT
+        expect(mockClient.server.getTransaction).not.toHaveBeenCalled();
+      });
+
+      it("throws TransactionError when tx timed out and was NOT found on-chain", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "TX_TIMEOUT", message: "Transaction confirmation timed out" },
+            txHash: LANDED_TX_HASH,
+          },
+          getTransactionStatus: "NOT_FOUND",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          liquidity: 500n,
+          amountAMin: 400n,
+          amountBMin: 800n,
+          to: TO_ADDRESS,
+        };
+
+        await expect(module.removeLiquidity(request)).rejects.toThrow(TransactionError);
+        expect(mockClient.server.getTransaction).toHaveBeenCalledWith(LANDED_TX_HASH);
+      });
+
+      it("throws TransactionError when tx timed out and was FAILED on-chain", async () => {
+        const mockClient = buildIdempotentMockClient({
+          submitResult: {
+            success: false,
+            error: { code: "TX_TIMEOUT", message: "Transaction confirmation timed out" },
+            txHash: LANDED_TX_HASH,
+          },
+          getTransactionStatus: "FAILED",
+        });
+
+        const module = new LiquidityModule(mockClient);
+        const request = {
+          tokenA: TOKEN_A,
+          tokenB: TOKEN_B,
+          liquidity: 500n,
+          amountAMin: 400n,
+          amountBMin: 800n,
+          to: TO_ADDRESS,
+        };
+
+        await expect(module.removeLiquidity(request)).rejects.toThrow(TransactionError);
+        expect(mockClient.server.getTransaction).toHaveBeenCalledWith(LANDED_TX_HASH);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Introduce submitIdempotent utility that checks on-chain transaction status after a client-side polling timeout, preventing duplicate deposits or withdrawals when the transaction already landed.

- Add src/utils/submit-idempotent.ts with submitIdempotent() and SubmitIdempotentClient interface
- Export submitIdempotent from src/utils/index.ts and src/index.ts
- Use submitIdempotent in LiquidityModule.addLiquidity and removeLiquidity
- Add 8 tests covering timeout-after-landed, genuine failure, timeout+ NOT_FOUND, and timeout+FAILED for both add and remove paths

## Description

Describe what this PR changes and why it is needed.

## Related Issue

Closes #XXX

Replace `XXX` with the issue number this PR resolves. If there is no linked issue, explain why.

## Changes Made

- List the key changes included in this PR.

## Testing

Describe the tests or manual checks performed for this change.

- [ ] Tests added or updated
- [ ] Existing tests pass

## Checklist

- [ ] Tests added where applicable
- [ ] Documentation updated where applicable
- [ ] Lint passes
- [ ] No breaking changes, or any breaking changes are documented
- [ ] Commit messages are clear and follow the project convention

closes #466