### PR TITLE
fix: remove duplicate examples:alert-setup script key

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "examples:alert-setup": "ts-node --transpile-only --require tsconfig-paths/register examples/alert-setup.ts",
     "examples:rwa-pool": "ts-node examples/rwa-pool.ts",
     "examples:governance-vote": "ts-node examples/governance-vote.ts",
-    "examples:alert-setup": "ts-node --transpile-only --require tsconfig-paths/register examples/alert-setup.ts",
     "docs": "typedoc",
     "fuzz": "jest --testPathPattern=fuzz --no-coverage",
     "benchmark": "ts-node benchmarks/run.ts",


### PR DESCRIPTION
Closes #439

Removed the duplicate `examples:alert-setup` entry in `package.json`'s `scripts` block to keep it clean and consistent.