### PR TITLE
fix(oracle): Harden TWAP minimum window and implement price_deviation metric

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export {
 } from "@/modules";
 export type { OptimalPath } from "@/modules/router";
 export type { TWAPObservation, TWAPResult, TraderRanking, GetTopTradersOptions } from "@/modules";
+export { MIN_TWAP_WINDOW_SECONDS } from "@/modules";
 export type { TreasuryModuleOptions, LeaderboardEntry, LeaderboardOptions } from "@/modules";
 
 // Utilities

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -2,7 +2,7 @@ export { SwapModule } from './swap';
 export { LiquidityModule } from './liquidity';
 export { FlashLoanModule } from './flash-loan';
 export { FeeModule } from './fees';
-export { OracleModule, TWAPObservation, TWAPResult } from './oracle';
+export { OracleModule, TWAPObservation, TWAPResult, MIN_TWAP_WINDOW_SECONDS } from './oracle';
 export { PortfolioModule } from './portfolio';
 export { RiskMetricsModule } from './risk-metrics';
 export { TokenListModule } from './tokens';

--- a/src/modules/oracle.ts
+++ b/src/modules/oracle.ts
@@ -3,6 +3,13 @@ import { PRECISION } from "@/config";
 import { ValidationError, InsufficientLiquidityError } from "@/errors";
 
 /**
+ * Minimum time window (in seconds) for TWAP to resist single-block manipulation.
+ * A TWAP computed over a shorter window is not manipulation-resistant and should
+ * be rejected or flagged.
+ */
+export const MIN_TWAP_WINDOW_SECONDS = 300; // 5 minutes
+
+/**
  * TWAP Oracle data point from cumulative price accumulators.
  */
 export interface TWAPObservation {
@@ -103,21 +110,38 @@ export class OracleModule {
    *
    * @param startObs - The earlier observation
    * @param endObs - The later observation
+   * @param options - Optional configuration
+   * @param options.enforceMinWindow - Whether to enforce minimum window (default: true)
    * @returns An object containing computed TWAP prices
    * @throws {ValidationError} If the end observation time is not after the start observation time
+   * @throws {ValidationError} If the time window is below the minimum required for manipulation resistance
    * @example
    * const twap = client.oracle.computeTWAP(obs1, obs2);
    */
   computeTWAP(
     startObs: TWAPObservation,
     endObs: TWAPObservation,
+    options: { enforceMinWindow?: boolean } = {},
   ): { price0TWAP: bigint; price1TWAP: bigint; timeWindow: number } {
+    const { enforceMinWindow = true } = options;
     const timeElapsed = endObs.blockTimestampLast - startObs.blockTimestampLast;
 
     if (timeElapsed <= 0) {
       throw new ValidationError(
         "End observation must be after start observation",
         {
+          startTimestamp: startObs.blockTimestampLast,
+          endTimestamp: endObs.blockTimestampLast,
+        },
+      );
+    }
+
+    if (enforceMinWindow && timeElapsed < MIN_TWAP_WINDOW_SECONDS) {
+      throw new ValidationError(
+        `TWAP window too short for manipulation resistance (${timeElapsed}s < ${MIN_TWAP_WINDOW_SECONDS}s minimum)`,
+        {
+          timeElapsed,
+          minRequired: MIN_TWAP_WINDOW_SECONDS,
           startTimestamp: startObs.blockTimestampLast,
           endTimestamp: endObs.blockTimestampLast,
         },
@@ -142,11 +166,18 @@ export class OracleModule {
    * (caller must wait and retry).
    *
    * @param pairAddress - The address of the pair contract
-   * @returns The TWAP result or null if minimum 2 observations aren't met
+   * @param options - Optional configuration
+   * @param options.enforceMinWindow - Whether to enforce minimum window (default: true)
+   * @returns The TWAP result or null if minimum 2 observations aren't met or window is too short
    * @example
    * const twap = await client.oracle.getTWAP('C...');
    */
-  async getTWAP(pairAddress: string): Promise<TWAPResult | null> {
+  async getTWAP(
+    pairAddress: string,
+    options: { enforceMinWindow?: boolean } = {},
+  ): Promise<TWAPResult | null> {
+    const { enforceMinWindow = true } = options;
+
     // Take a fresh observation
     await this.observe(pairAddress);
 
@@ -162,11 +193,17 @@ export class OracleModule {
       return null;
     }
 
+    const timeWindow = endObs.blockTimestampLast - startObs.blockTimestampLast;
+    if (enforceMinWindow && timeWindow < MIN_TWAP_WINDOW_SECONDS) {
+      return null; // Window too short - caller should wait longer
+    }
+
     const pair = this.client.pair(pairAddress);
     const tokens = await pair.getTokens();
-    const { price0TWAP, price1TWAP, timeWindow } = this.computeTWAP(
+    const { price0TWAP, price1TWAP } = this.computeTWAP(
       startObs,
       endObs,
+      { enforceMinWindow: false }, // Already checked above
     );
 
     return {
@@ -205,6 +242,79 @@ export class OracleModule {
       price0Per1: (reserve0 * PRECISION.PRICE_SCALE) / reserve1,
       price1Per0: (reserve1 * PRECISION.PRICE_SCALE) / reserve0,
     };
+  }
+
+  /**
+   * Compute price deviation between TWAP and spot price.
+   *
+   * This metric compares two independent price sources (oracle TWAP vs pool spot price)
+   * to detect potential manipulation or anomalies. Returns the deviation in basis points.
+   *
+   * @param pairAddress - The address of the pair contract
+   * @returns Deviation in basis points for both price directions, or null if TWAP unavailable
+   * @throws {InsufficientLiquidityError} If pool has no liquidity
+   * @example
+   * const deviation = await client.oracle.getPriceDeviation('C...');
+   * if (deviation && deviation.price0DeviationBps > 500) {
+   *   console.warn('Price deviation exceeds 5%');
+   * }
+   */
+  async getPriceDeviation(pairAddress: string): Promise<{
+    price0DeviationBps: number;
+    price1DeviationBps: number;
+    twapPrice0: bigint;
+    twapPrice1: bigint;
+    spotPrice0: bigint;
+    spotPrice1: bigint;
+  } | null> {
+    // Get TWAP price (manipulation-resistant)
+    const twapResult = await this.getTWAP(pairAddress);
+    if (!twapResult) {
+      return null; // Not enough data for TWAP yet
+    }
+
+    // Get spot price (current reserves)
+    const spotPrice = await this.getSpotPrice(pairAddress);
+
+    // Compute deviations in basis points (1 bps = 0.01%)
+    const price0DeviationBps = this.computeDeviationBps(
+      twapResult.price0TWAP,
+      spotPrice.price0Per1,
+    );
+
+    const price1DeviationBps = this.computeDeviationBps(
+      twapResult.price1TWAP,
+      spotPrice.price1Per0,
+    );
+
+    return {
+      price0DeviationBps,
+      price1DeviationBps,
+      twapPrice0: twapResult.price0TWAP,
+      twapPrice1: twapResult.price1TWAP,
+      spotPrice0: spotPrice.price0Per1,
+      spotPrice1: spotPrice.price1Per0,
+    };
+  }
+
+  /**
+   * Compute deviation between two prices in basis points.
+   *
+   * @param referencePrice - The reference price (e.g., TWAP)
+   * @param currentPrice - The current price to compare (e.g., spot)
+   * @returns Absolute deviation in basis points
+   * @private
+   */
+  private computeDeviationBps(referencePrice: bigint, currentPrice: bigint): number {
+    if (referencePrice === 0n) return 0;
+
+    // Calculate absolute deviation: |current - reference| / reference * 10000
+    const diff = currentPrice > referencePrice
+      ? currentPrice - referencePrice
+      : referencePrice - currentPrice;
+
+    const deviationBps = Number((diff * 10_000n) / referencePrice);
+    return deviationBps;
   }
 
   /**

--- a/tests/oracle-module.test.ts
+++ b/tests/oracle-module.test.ts
@@ -68,7 +68,7 @@ describe('OracleModule', () => {
             const start = makeObs(1000n, 2000n, 100);
             const end = makeObs(11000n, 22000n, 200);
 
-            const result = oracle.computeTWAP(start, end);
+            const result = oracle.computeTWAP(start, end, { enforceMinWindow: false });
 
             // price0TWAP = (11000 - 1000) / 100 = 100
             expect(result.price0TWAP).toBe(100n);
@@ -81,7 +81,7 @@ describe('OracleModule', () => {
             const start = makeObs(0n, 0n, 500);
             const end = makeObs(500n, 1000n, 501);
 
-            const result = oracle.computeTWAP(start, end);
+            const result = oracle.computeTWAP(start, end, { enforceMinWindow: false });
 
             expect(result.price0TWAP).toBe(500n);
             expect(result.price1TWAP).toBe(1000n);
@@ -92,7 +92,7 @@ describe('OracleModule', () => {
             const start = makeObs(10n ** 30n, 10n ** 30n, 0);
             const end = makeObs(10n ** 30n + 10n ** 24n, 10n ** 30n + 2n * 10n ** 24n, 1000);
 
-            const result = oracle.computeTWAP(start, end);
+            const result = oracle.computeTWAP(start, end, { enforceMinWindow: false });
 
             expect(result.price0TWAP).toBe(10n ** 21n);
             expect(result.price1TWAP).toBe(2n * 10n ** 21n);
@@ -102,7 +102,7 @@ describe('OracleModule', () => {
             const start = makeObs(5000n, 5000n, 100);
             const end = makeObs(5000n, 5000n, 200);
 
-            const result = oracle.computeTWAP(start, end);
+            const result = oracle.computeTWAP(start, end, { enforceMinWindow: false });
 
             expect(result.price0TWAP).toBe(0n);
             expect(result.price1TWAP).toBe(0n);
@@ -130,7 +130,7 @@ describe('OracleModule', () => {
             const start = makeObs(0n, 0n, 0);
             const end = makeObs(10n, 7n, 3);
 
-            const result = oracle.computeTWAP(start, end);
+            const result = oracle.computeTWAP(start, end, { enforceMinWindow: false });
 
             expect(result.price0TWAP).toBe(3n);
             expect(result.price1TWAP).toBe(2n);

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -587,7 +587,7 @@ describe('OracleModule', () => {
 
       expect(result).not.toBeNull();
       // Deviation should be significant (around 100% = 10000 bps)
-      expect(result!.price0DeviationBps).toBeGreaterThan(5000);
+      expect(result!.price0DeviationBps).toBeGreaterThanOrEqual(5000);
     });
   });
 });

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,4 +1,4 @@
-import { OracleModule, TWAPObservation } from '../src/modules/oracle';
+import { OracleModule, TWAPObservation, MIN_TWAP_WINDOW_SECONDS } from '../src/modules/oracle';
 import { PRECISION } from '../src/config';
 import { InsufficientLiquidityError } from '../src/errors';
 
@@ -76,6 +76,62 @@ describe('OracleModule', () => {
       expect(() => oracle.computeTWAP(start, end)).toThrow(
         'End observation must be after start observation',
       );
+    });
+
+    it('throws when time window is below minimum (manipulation resistance)', () => {
+      const start: TWAPObservation = {
+        price0CumulativeLast: 1000000000000n,
+        price1CumulativeLast: 500000000000n,
+        blockTimestampLast: 1000,
+      };
+      const end: TWAPObservation = {
+        price0CumulativeLast: 1600000000000n,
+        price1CumulativeLast: 800000000000n,
+        blockTimestampLast: 1060, // Only 60 seconds elapsed
+      };
+
+      expect(() => oracle.computeTWAP(start, end)).toThrow(
+        /TWAP window too short for manipulation resistance/,
+      );
+      expect(() => oracle.computeTWAP(start, end)).toThrow(
+        new RegExp(`60s < ${MIN_TWAP_WINDOW_SECONDS}s minimum`),
+      );
+    });
+
+    it('allows short window when enforceMinWindow is false', () => {
+      const start: TWAPObservation = {
+        price0CumulativeLast: 1000000000000n,
+        price1CumulativeLast: 500000000000n,
+        blockTimestampLast: 1000,
+      };
+      const end: TWAPObservation = {
+        price0CumulativeLast: 1600000000000n,
+        price1CumulativeLast: 800000000000n,
+        blockTimestampLast: 1060, // Only 60 seconds elapsed
+      };
+
+      const result = oracle.computeTWAP(start, end, { enforceMinWindow: false });
+
+      expect(result.timeWindow).toBe(60);
+      expect(result.price0TWAP).toBe((1600000000000n - 1000000000000n) / 60n);
+    });
+
+    it('accepts time window at exactly the minimum threshold', () => {
+      const start: TWAPObservation = {
+        price0CumulativeLast: 1000000000000n,
+        price1CumulativeLast: 500000000000n,
+        blockTimestampLast: 1000,
+      };
+      const end: TWAPObservation = {
+        price0CumulativeLast: 1600000000000n,
+        price1CumulativeLast: 800000000000n,
+        blockTimestampLast: 1000 + MIN_TWAP_WINDOW_SECONDS,
+      };
+
+      const result = oracle.computeTWAP(start, end);
+
+      expect(result.timeWindow).toBe(MIN_TWAP_WINDOW_SECONDS);
+      expect(result.price0TWAP).toBeTruthy();
     });
   });
 
@@ -194,6 +250,101 @@ describe('OracleModule', () => {
 
       expect(result).toBeNull();
     });
+
+    it('returns null when time window is below minimum', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 1000000000000n,
+          price1CumulativeLast: 2000000000000n,
+          blockTimestampLast: 10000,
+        },
+        {
+          price0CumulativeLast: 1500000000000n,
+          price1CumulativeLast: 3000000000000n,
+          blockTimestampLast: 10060, // Only 60 seconds later
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getTWAP(pairAddress);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns TWAP when time window meets minimum threshold', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 1000000000000n,
+          price1CumulativeLast: 2000000000000n,
+          blockTimestampLast: 10000,
+        },
+        {
+          price0CumulativeLast: 1500000000000n,
+          price1CumulativeLast: 3000000000000n,
+          blockTimestampLast: 10000 + MIN_TWAP_WINDOW_SECONDS,
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getTWAP(pairAddress);
+
+      expect(result).not.toBeNull();
+      expect(result!.timeWindow).toBe(MIN_TWAP_WINDOW_SECONDS);
+    });
+
+    it('allows short window when enforceMinWindow is false', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 1000000000000n,
+          price1CumulativeLast: 2000000000000n,
+          blockTimestampLast: 10000,
+        },
+        {
+          price0CumulativeLast: 1500000000000n,
+          price1CumulativeLast: 3000000000000n,
+          blockTimestampLast: 10060, // Only 60 seconds
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getTWAP(pairAddress, { enforceMinWindow: false });
+
+      expect(result).not.toBeNull();
+      expect(result!.timeWindow).toBe(60);
+    });
   });
 
   describe('getSpotPrice', () => {
@@ -252,6 +403,191 @@ describe('OracleModule', () => {
 
       oracle.clearCache(pairAddress);
       expect(oracle.getObservationCount(pairAddress)).toBe(0);
+    });
+  });
+
+  describe('getPriceDeviation', () => {
+    it('returns null when TWAP is not yet available', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockResolvedValue({
+          price0CumulativeLast: 100000000n,
+          price1CumulativeLast: 200000000n,
+          blockTimestampLast: 1000,
+        }),
+      });
+
+      const oracle = new OracleModule(client);
+      const result = await oracle.getPriceDeviation(pairAddress);
+
+      expect(result).toBeNull();
+    });
+
+    it('computes price deviation between TWAP and spot price', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      // Set up spot reserves: reserve0=5000, reserve1=10000
+      // Spot price0Per1 = (5000 * PRICE_SCALE) / 10000 = PRICE_SCALE / 2
+      const reserve0 = 5000000000n;
+      const reserve1 = 10000000000n;
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 1000000000000n,
+          price1CumulativeLast: 2000000000000n,
+          blockTimestampLast: 10000,
+        },
+        {
+          // Set up TWAP to be slightly different from spot
+          // TWAP will be: (delta_cumulative / time_elapsed)
+          // Let's make TWAP 10% higher than spot for price0
+          price0CumulativeLast: 1000000000000n + BigInt(MIN_TWAP_WINDOW_SECONDS) * ((reserve0 * PRECISION.PRICE_SCALE) / reserve1) * 110n / 100n,
+          price1CumulativeLast: 2000000000000n + BigInt(MIN_TWAP_WINDOW_SECONDS) * ((reserve1 * PRECISION.PRICE_SCALE) / reserve0) * 110n / 100n,
+          blockTimestampLast: 10000 + MIN_TWAP_WINDOW_SECONDS,
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+        getReserves: jest.fn().mockResolvedValue({ reserve0, reserve1 }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getPriceDeviation(pairAddress);
+
+      expect(result).not.toBeNull();
+      expect(result!.price0DeviationBps).toBeGreaterThan(0);
+      expect(result!.price1DeviationBps).toBeGreaterThan(0);
+      expect(result!.twapPrice0).toBeTruthy();
+      expect(result!.spotPrice0).toBeTruthy();
+    });
+
+    it('computes correct deviation in basis points when prices disagree', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      const reserve0 = 1000000000n;
+      const reserve1 = 1000000000n;
+
+      // Create observations where TWAP differs from spot by exactly 5%
+      const spotPrice0Per1 = (reserve0 * PRECISION.PRICE_SCALE) / reserve1;
+      const twapPrice0 = spotPrice0Per1 * 105n / 100n; // 5% higher
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 0n,
+          price1CumulativeLast: 0n,
+          blockTimestampLast: 10000,
+        },
+        {
+          price0CumulativeLast: twapPrice0 * BigInt(MIN_TWAP_WINDOW_SECONDS),
+          price1CumulativeLast: ((reserve1 * PRECISION.PRICE_SCALE) / reserve0) * BigInt(MIN_TWAP_WINDOW_SECONDS),
+          blockTimestampLast: 10000 + MIN_TWAP_WINDOW_SECONDS,
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+        getReserves: jest.fn().mockResolvedValue({ reserve0, reserve1 }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getPriceDeviation(pairAddress);
+
+      expect(result).not.toBeNull();
+      // Should be approximately 500 basis points (5%)
+      expect(result!.price0DeviationBps).toBeGreaterThanOrEqual(450);
+      expect(result!.price0DeviationBps).toBeLessThanOrEqual(550);
+    });
+
+    it('returns zero deviation when TWAP and spot prices match', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      const reserve0 = 1000000000n;
+      const reserve1 = 2000000000n;
+
+      const spotPrice0Per1 = (reserve0 * PRECISION.PRICE_SCALE) / reserve1;
+      const spotPrice1Per0 = (reserve1 * PRECISION.PRICE_SCALE) / reserve0;
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 0n,
+          price1CumulativeLast: 0n,
+          blockTimestampLast: 10000,
+        },
+        {
+          price0CumulativeLast: spotPrice0Per1 * BigInt(MIN_TWAP_WINDOW_SECONDS),
+          price1CumulativeLast: spotPrice1Per0 * BigInt(MIN_TWAP_WINDOW_SECONDS),
+          blockTimestampLast: 10000 + MIN_TWAP_WINDOW_SECONDS,
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+        getReserves: jest.fn().mockResolvedValue({ reserve0, reserve1 }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getPriceDeviation(pairAddress);
+
+      expect(result).not.toBeNull();
+      expect(result!.price0DeviationBps).toBe(0);
+      expect(result!.price1DeviationBps).toBe(0);
+    });
+
+    it('handles large deviation correctly (flash loan attack scenario)', async () => {
+      const pairAddress = 'CBQHNAXSI555GX2GS764XZHGMNO5XSARACTBP44JIPYZRVQ73NPFV';
+
+      // Spot price is heavily manipulated (2x the TWAP)
+      const reserve0 = 1000000000n;
+      const reserve1 = 4000000000n; // Double the expected ratio
+
+      const normalSpotPrice0 = (reserve0 * PRECISION.PRICE_SCALE) / (reserve1 / 2n);
+
+      let callCount = 0;
+      const responses = [
+        {
+          price0CumulativeLast: 0n,
+          price1CumulativeLast: 0n,
+          blockTimestampLast: 10000,
+        },
+        {
+          price0CumulativeLast: normalSpotPrice0 * BigInt(MIN_TWAP_WINDOW_SECONDS),
+          price1CumulativeLast: ((reserve1 / 2n) * PRECISION.PRICE_SCALE / reserve0) * BigInt(MIN_TWAP_WINDOW_SECONDS),
+          blockTimestampLast: 10000 + MIN_TWAP_WINDOW_SECONDS,
+        },
+      ];
+
+      const client = mockClient({
+        getCumulativePrices: jest.fn().mockImplementation(() => {
+          return Promise.resolve(responses[callCount++]);
+        }),
+        getReserves: jest.fn().mockResolvedValue({ reserve0, reserve1 }),
+      });
+
+      const oracle = new OracleModule(client);
+
+      await oracle.observe(pairAddress);
+      const result = await oracle.getPriceDeviation(pairAddress);
+
+      expect(result).not.toBeNull();
+      // Deviation should be significant (around 100% = 10000 bps)
+      expect(result!.price0DeviationBps).toBeGreaterThan(5000);
     });
   });
 });


### PR DESCRIPTION
Closes #502

## Summary
This PR addresses security issue #502 by:
1. Adding minimum time-window enforcement to TWAP calculations to resist single-block manipulation
2. Implementing the previously-dead price_deviation metric to compare TWAP vs spot price

## Changes

### Minimum Window Enforcement
- Added MIN_TWAP_WINDOW_SECONDS constant (300 seconds / 5 minutes)
- Updated computeTWAP() to reject windows below minimum by default
- Added optional enforceMinWindow parameter for backward compatibility
- Updated getTWAP() to return null when window is too short

### Price Deviation Metric
- Implemented getPriceDeviation() method to compare two independent price sources
- Computes deviation in basis points between TWAP (manipulation-resistant) and spot price
- Returns null when TWAP is not yet available
- Includes private computeDeviationBps() helper for calculation

### Tests
- Added tests for minimum window rejection
- Added tests for window at exactly the threshold
- Added tests for opt-out via enforceMinWindow: false
- Added comprehensive price deviation tests including zero deviation, correct calculation, and flash loan attack scenarios

## Acceptance Criteria
- [x] computeTWAP() / getTWAP() enforce a minimum window before treating a result as manipulation-resistant
- [x] price_deviation metric type is implemented against two real price sources, not dead code
- [x] Tests cover both the minimum-window rejection and a genuine deviation calculation