### PR TITLE
fix(stop-loss): Enforce oracle staleness checks in enrichOrder paths

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -17,7 +17,7 @@ export {
 } from './health-check';
 export { RouterModule } from './router';
 export { TreasuryModule } from './treasury';
-export { StopLossModule } from './stop-loss';
+export { StopLossModule, DEFAULT_STALE_AFTER_MS } from './stop-loss';
 export type { TreasuryModuleOptions } from './treasury';
 export { AlertsModule, AlertModule } from './alerts';
 export { WebhookModule } from './webhooks';

--- a/src/modules/stop-loss.ts
+++ b/src/modules/stop-loss.ts
@@ -26,6 +26,13 @@ import {
   xdr,
 } from '@stellar/stellar-sdk';
 
+/**
+ * Default maximum age for oracle prices (in milliseconds).
+ * Prices older than this are considered stale and will trigger a StaleOracleError.
+ * Set to 5 minutes to align with TWAP minimum window.
+ */
+export const DEFAULT_STALE_AFTER_MS = 5 * 60 * 1000; // 5 minutes
+
 type DecodedStopLossOrder = Omit<StopLossOrder, 'currentPrice' | 'triggered' | 'distancePercent'>;
 
 interface OraclePriceSnapshot {
@@ -186,7 +193,10 @@ export class StopLossModule {
    * @returns The order state plus the live `currentPrice` and `triggered` flag
    * @throws {ValidationError} If `orderId` is empty or no order exists
    */
-  async getStopLoss(orderId: string): Promise<StopLossOrder> {
+  async getStopLoss(
+    orderId: string,
+    options: TriggerEvaluationOptions = {},
+  ): Promise<StopLossOrder> {
     if (!orderId || orderId.trim().length === 0) {
       throw new ValidationError('orderId must not be empty');
     }
@@ -204,7 +214,7 @@ export class StopLossModule {
     }
 
     const order = this.decodeOrder(sim.returnValue);
-    return this.enrichOrder(order);
+    return this.enrichOrder(order, options);
   }
 
   /**
@@ -214,6 +224,7 @@ export class StopLossModule {
   async getStopLossOrders(
     address: string,
     query: StopLossOrderQuery = {},
+    options: TriggerEvaluationOptions = {},
   ): Promise<StopLossOrder[]> {
     validateAddress(address, 'address');
 
@@ -232,7 +243,7 @@ export class StopLossModule {
     const rawOrders = Array.isArray(native) ? native : [];
     const enriched = await Promise.all(
       rawOrders.map((item) =>
-        this.enrichOrder(this.decodeOrder(nativeToScVal(item))),
+        this.enrichOrder(this.decodeOrder(nativeToScVal(item)), options),
       ),
     );
 
@@ -248,7 +259,8 @@ export class StopLossModule {
     options: TriggerEvaluationOptions = {},
   ): Promise<boolean> {
     const snapshot = await this.getOraclePrice(order.oracleAsset);
-    this.assertOracleFresh(snapshot, order.oracleAsset, options.staleAfterMs);
+    const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    this.assertOracleFresh(snapshot, order.oracleAsset, staleAfterMs);
     return snapshot.price <= order.triggerPrice;
   }
 
@@ -279,8 +291,16 @@ export class StopLossModule {
     }
   }
 
-  private async enrichOrder(order: DecodedStopLossOrder): Promise<StopLossOrder> {
+  private async enrichOrder(
+    order: DecodedStopLossOrder,
+    options: TriggerEvaluationOptions = {},
+  ): Promise<StopLossOrder> {
     const snapshot = await this.getOraclePrice(order.oracleAsset);
+    
+    // Enforce oracle freshness by default to prevent stale price usage
+    const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    this.assertOracleFresh(snapshot, order.oracleAsset, staleAfterMs);
+    
     const distancePercent =
       order.triggerPrice > 0n
         ? Number(
@@ -342,9 +362,11 @@ export class StopLossModule {
   private assertOracleFresh(
     snapshot: OraclePriceSnapshot,
     asset: string,
-    staleAfterMs?: number,
+    staleAfterMs: number,
   ): void {
-    if (staleAfterMs === undefined || snapshot.timestamp === undefined) {
+    if (snapshot.timestamp === undefined) {
+      // No timestamp available - cannot verify freshness
+      // This could happen with certain oracle implementations
       return;
     }
 

--- a/tests/stop-loss.test.ts
+++ b/tests/stop-loss.test.ts
@@ -622,3 +622,227 @@ describe('StopLossModule', () => {
     });
   });
 });
+
+describe('Oracle Staleness Checks on Enrichment Paths', () => {
+  describe('getStopLoss() with stale oracle', () => {
+    it('throws StaleOracleError by default when oracle is stale', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(makeSimResult(makeOrderNative()))
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '8500000',
+            timestamp: NOW_MS - 6 * 60 * 1000, // 6 minutes old (> DEFAULT_STALE_AFTER_MS)
+          }),
+        );
+
+      await expect(stopLoss.getStopLoss('order-1')).rejects.toThrow(
+        StaleOracleError,
+      );
+    });
+
+    it('throws StaleOracleError with custom staleness threshold', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(makeSimResult(makeOrderNative()))
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '8500000',
+            timestamp: NOW_MS - 2 * 60 * 1000, // 2 minutes old
+          }),
+        );
+
+      await expect(
+        stopLoss.getStopLoss('order-1', { staleAfterMs: 60_000 }), // 1 minute threshold
+      ).rejects.toThrow(StaleOracleError);
+    });
+
+    it('accepts fresh oracle price within default threshold', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(makeSimResult(makeOrderNative()))
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '8500000',
+            timestamp: NOW_MS - 4 * 60 * 1000, // 4 minutes old (< DEFAULT_STALE_AFTER_MS)
+          }),
+        );
+
+      const order = await stopLoss.getStopLoss('order-1');
+
+      expect(order.currentPrice).toBe(8_500_000n);
+      expect(order.triggered).toBe(true);
+    });
+
+    it('accepts oracle price at exact staleness boundary', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(makeSimResult(makeOrderNative()))
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '8500000',
+            timestamp: NOW_MS - 5 * 60 * 1000, // Exactly 5 minutes old
+          }),
+        );
+
+      const order = await stopLoss.getStopLoss('order-1');
+
+      expect(order.currentPrice).toBe(8_500_000n);
+    });
+  });
+
+  describe('getStopLossOrders() with stale oracle', () => {
+    it('throws StaleOracleError by default when any oracle is stale', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(
+          makeSimResult([
+            makeOrderNative({ id: 'order-1' }),
+            makeOrderNative({ id: 'order-2' }),
+          ]),
+        )
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '10000000',
+            timestamp: NOW_MS - 4 * 60 * 1000, // Fresh
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '10000000',
+            timestamp: NOW_MS - 6 * 60 * 1000, // Stale
+          }),
+        );
+
+      await expect(stopLoss.getStopLossOrders(OWNER)).rejects.toThrow(
+        StaleOracleError,
+      );
+    });
+
+    it('accepts all orders when all oracles are fresh', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(
+          makeSimResult([
+            makeOrderNative({ id: 'order-1' }),
+            makeOrderNative({ id: 'order-2' }),
+          ]),
+        )
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '10000000',
+            timestamp: NOW_MS - 2 * 60 * 1000, // 2 minutes
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '9500000',
+            timestamp: NOW_MS - 3 * 60 * 1000, // 3 minutes
+          }),
+        );
+
+      const orders = await stopLoss.getStopLossOrders(OWNER);
+
+      expect(orders).toHaveLength(2);
+      expect(orders[0].currentPrice).toBe(10_000_000n);
+      expect(orders[1].currentPrice).toBe(9_500_000n);
+    });
+
+    it('respects custom staleness threshold for all orders', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(
+          makeSimResult([makeOrderNative({ id: 'order-1' })]),
+        )
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '10000000',
+            timestamp: NOW_MS - 90_000, // 90 seconds old
+          }),
+        );
+
+      await expect(
+        stopLoss.getStopLossOrders(OWNER, {}, { staleAfterMs: 60_000 }),
+      ).rejects.toThrow(StaleOracleError);
+    });
+  });
+
+  describe('isStopLossTriggered() with default staleness', () => {
+    it('throws StaleOracleError by default when oracle is stale', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '8500000',
+          timestamp: NOW_MS - 6 * 60 * 1000, // 6 minutes old
+        }),
+      );
+
+      await expect(
+        stopLoss.isStopLossTriggered(makeOrder()),
+      ).rejects.toThrow(StaleOracleError);
+    });
+
+    it('accepts fresh oracle by default', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '8500000',
+          timestamp: NOW_MS - 4 * 60 * 1000, // 4 minutes old
+        }),
+      );
+
+      await expect(
+        stopLoss.isStopLossTriggered(makeOrder()),
+      ).resolves.toBe(true);
+    });
+
+    it('still respects explicit staleness override', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '8500000',
+          timestamp: NOW_MS - 2 * 60 * 1000, // 2 minutes old
+        }),
+      );
+
+      // Should pass with default (5min)
+      await expect(
+        stopLoss.isStopLossTriggered(makeOrder()),
+      ).resolves.toBe(true);
+
+      // Should fail with 1min threshold
+      await expect(
+        stopLoss.isStopLossTriggered(makeOrder(), { staleAfterMs: 60_000 }),
+      ).rejects.toThrow(StaleOracleError);
+    });
+  });
+
+  describe('Oracle without timestamp', () => {
+    it('allows enrichment when oracle has no timestamp', async () => {
+      jest
+        .spyOn(client, 'simulateTransaction')
+        .mockResolvedValueOnce(makeSimResult(makeOrderNative()))
+        .mockResolvedValueOnce(
+          makeSimResult({
+            price: '8500000',
+            // No timestamp field
+          }),
+        );
+
+      const order = await stopLoss.getStopLoss('order-1');
+
+      expect(order.currentPrice).toBe(8_500_000n);
+      expect(order.triggered).toBe(true);
+    });
+
+    it('allows trigger check when oracle has no timestamp', async () => {
+      jest.spyOn(client, 'simulateTransaction').mockResolvedValue(
+        makeSimResult({
+          price: '8500000',
+          // No timestamp field
+        }),
+      );
+
+      await expect(
+        stopLoss.isStopLossTriggered(makeOrder()),
+      ).resolves.toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #499

## Summary
This PR addresses the critical security issue #499 where enrichOrder(), getStopLoss(), and getStopLossOrders() were bypassing oracle staleness checks, potentially using stale price data to determine stop-loss trigger states.

## Changes

### Mandatory Staleness Enforcement
- Added DEFAULT_STALE_AFTER_MS constant (5 minutes / 300,000ms) aligned with TWAP minimum window
- Modified enrichOrder() to always enforce oracle freshness with default threshold
- Updated assertOracleFresh() signature to require staleAfterMs parameter (no more opt-in/opt-out)
- Updated isStopLossTriggered() to use default staleness threshold
- Updated getStopLoss() and getStopLossOrders() to accept TriggerEvaluationOptions and pass to enrichOrder()

### Graceful Handling
- Oracle prices without timestamps skip freshness checks (cannot verify what doesn't exist)
- Users can still override default threshold via options parameter for stricter or looser requirements

### Security Improvements
- enrichOrder() path now has same staleness protection as explicit isStopLossTriggered() calls
- getStopLoss() and getStopLossOrders() surface StaleOracleError instead of silently using old prices
- No path can bypass staleness checks by omitting the parameter

## Tests
- Added comprehensive tests for staleness enforcement on getStopLoss()
- Added tests for staleness enforcement on getStopLossOrders() (fails on any stale oracle)
- Added tests for isStopLossTriggered() default behavior
- Added tests for custom staleness thresholds
- Added tests for oracles without timestamps
- All existing staleness tests still pass

## Acceptance Criteria
- [x] enrichOrder() enforces oracle freshness by default, not only when caller opts in
- [x] getStopLoss() / getStopLossOrders() surface a clear stale-oracle signal rather than silently trusting old price
- [x] New test covers the previously-unprotected enrichment path with a stale price feed
- [x] Existing isStopLossTriggered() staleness tests still pass unchanged