### PR TITLE
feat: add dashboard metrics aggregator to MonitoringModule

### DIFF
--- a/src/modules/monitoring.ts
+++ b/src/modules/monitoring.ts
@@ -17,9 +17,25 @@ import {
   MetricGranularity,
   MetricQueryOptions,
   MonitoringDashboard,
+  ProtocolMetrics,
+  PoolMetrics,
 } from '@/types/monitoring';
 import { ValidationError } from '@/errors';
 import { validateAddress } from '@/utils/validation';
+import { TreasuryModule, TreasuryModuleOptions } from '@/modules/treasury';
+import { SwapModule } from '@/modules/swap';
+
+const STROOP = 1e7;
+/** Cache TTL for getProtocolMetrics()/getPoolMetrics(), per acceptance criteria. */
+const METRICS_CACHE_TTL_MS = 60_000;
+/** Approximate ledger count for a 24h window at Stellar's ~5s ledger close time. */
+const LEDGERS_PER_DAY = 17_280;
+/**
+ * Max swap events fetched per 24h-window query. getSwapHistory() reads a single
+ * RPC page with no pagination, so pools/protocols with more than this many swaps
+ * in 24h will under-count totalSwaps24h/uniqueUsers24h/volume24hUSD.
+ */
+const HISTORY_QUERY_LIMIT = 1000;
 
 // ---------------------------------------------------------------------------
 // Built-in metric definitions
@@ -138,6 +154,10 @@ const DEFAULT_GRANULARITY: MetricGranularity = '1h';
  * const health = await monitor.checkSystemHealth();
  * const poolHealth = await monitor.getPoolHealth('CA3D...');
  *
+ * // Dashboard aggregator (cached for 60s)
+ * const metrics = await monitor.getProtocolMetrics();
+ * const poolMetrics = await monitor.getPoolMetrics('CA3D...');
+ *
  * // Custom metric collection
  * const id = await monitor.registerMetric({
  *   name: 'CORAL-USDC TVL', category: 'liquidity',
@@ -146,13 +166,167 @@ const DEFAULT_GRANULARITY: MetricGranularity = '1h';
  * await monitor.collect(id);
  * const dashboard = await monitor.getDashboard();
  * ```
+ *
+ * ### USD pricing note
+ * `getProtocolMetrics()`/`getPoolMetrics()` price reserves and swap volume in
+ * USD using the same stablecoin-anchored spot pricing as
+ * {@link TreasuryModule}/`PortfolioModule` (reserve ratios against
+ * caller-supplied `stableAddresses`), not RedStone. RedStone in this SDK is a
+ * per-swap price *guard* that requires the caller to supply a signed
+ * `RedStonePayload` keyed by feed symbol (see `utils/redstone.ts`); it isn't a
+ * queryable price source the SDK can call on its own, and it has no built-in
+ * mapping from arbitrary token addresses to feed symbols. Pass
+ * `stableAddresses` in the constructor options to enable USD valuations;
+ * without at least one, all USD fields are 0.
  */
 export class MonitoringModule {
   private readonly client: CoralSwapClient;
   private readonly metrics: Map<string, MetricInstance> = new Map();
+  private readonly pricing: TreasuryModule;
+  private readonly swap: SwapModule;
+  private readonly cache: Map<string, { value: unknown; expiresAt: number }> = new Map();
 
-  constructor(client: CoralSwapClient) {
+  constructor(client: CoralSwapClient, options: TreasuryModuleOptions = {}) {
     this.client = client;
+    this.pricing = new TreasuryModule(client, options);
+    this.swap = new SwapModule(client);
+  }
+
+  private getCached<T>(key: string): T | undefined {
+    const entry = this.cache.get(key);
+    if (!entry || entry.expiresAt < Date.now()) return undefined;
+    return entry.value as T;
+  }
+
+  private setCached(key: string, value: unknown): void {
+    this.cache.set(key, { value, expiresAt: Date.now() + METRICS_CACHE_TTL_MS });
+  }
+
+  // -----------------------------------------------------------------------
+  // Dashboard aggregator (protocol + per-pool metrics, 60s cache)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Aggregate key protocol-wide metrics for a dashboard: TVL, 24h volume,
+   * active pool count, unique users, swap count, and average swap size.
+   *
+   * Cached for 60 seconds to avoid redundant RPC calls.
+   */
+  async getProtocolMetrics(): Promise<ProtocolMetrics> {
+    const cached = this.getCached<ProtocolMetrics>('protocol');
+    if (cached) return cached;
+
+    const allPairs = await this.client.factory.getAllPairs();
+    const priceMap = await this.pricing.getSpotPriceMap(allPairs);
+
+    let tvlUSD = 0;
+    let activePools = 0;
+
+    await Promise.all(
+      allPairs.map(async (pairAddress) => {
+        try {
+          const pair = this.client.pair(pairAddress);
+          const [{ token0, token1 }, { reserve0, reserve1 }] = await Promise.all([
+            pair.getTokens(),
+            pair.getReserves(),
+          ]);
+          if (reserve0 === 0n || reserve1 === 0n) return;
+          activePools++;
+          const price0 = priceMap.get(token0) ?? 0;
+          const price1 = priceMap.get(token1) ?? 0;
+          tvlUSD += (Number(reserve0) / STROOP) * price0 + (Number(reserve1) / STROOP) * price1;
+        } catch {
+          // Skip pools we can't read; don't fail the whole aggregate.
+        }
+      }),
+    );
+
+    const currentLedger = await this.client.getCurrentLedger();
+    const fromLedger = Math.max(0, currentLedger - LEDGERS_PER_DAY);
+    const events = await this.swap.getSwapHistory({
+      fromLedger,
+      toLedger: currentLedger,
+      limit: HISTORY_QUERY_LIMIT,
+    });
+
+    const totalSwaps24h = events.length;
+    const uniqueUsers24h = new Set(events.map((e) => e.sender)).size;
+    const volume24hUSD = events.reduce((sum, e) => {
+      const price = priceMap.get(e.tokenIn) ?? 0;
+      return sum + (Number(e.amountIn) / STROOP) * price;
+    }, 0);
+    const avgSwapSizeUSD = totalSwaps24h > 0 ? volume24hUSD / totalSwaps24h : 0;
+
+    const result: ProtocolMetrics = {
+      tvlUSD,
+      volume24hUSD,
+      activePools,
+      uniqueUsers24h,
+      totalSwaps24h,
+      avgSwapSizeUSD,
+      computedAt: Date.now(),
+    };
+    this.setCached('protocol', result);
+    return result;
+  }
+
+  /**
+   * Detailed metrics for a single pool: TVL, 24h volume, swap count, unique
+   * users, average swap size, reserves, and current fee.
+   *
+   * Cached for 60 seconds to avoid redundant RPC calls.
+   */
+  async getPoolMetrics(pairAddress: string): Promise<PoolMetrics> {
+    validateAddress(pairAddress, 'pairAddress');
+    const cacheKey = `pool:${pairAddress}`;
+    const cached = this.getCached<PoolMetrics>(cacheKey);
+    if (cached) return cached;
+
+    const allPairs = await this.client.factory.getAllPairs();
+    const priceMap = await this.pricing.getSpotPriceMap(allPairs);
+
+    const pair = this.client.pair(pairAddress);
+    const [{ token0, token1 }, { reserve0, reserve1 }, feeBps] = await Promise.all([
+      pair.getTokens(),
+      pair.getReserves(),
+      pair.getDynamicFee(),
+    ]);
+
+    const price0 = priceMap.get(token0) ?? 0;
+    const price1 = priceMap.get(token1) ?? 0;
+    const tvlUSD = (Number(reserve0) / STROOP) * price0 + (Number(reserve1) / STROOP) * price1;
+
+    const currentLedger = await this.client.getCurrentLedger();
+    const fromLedger = Math.max(0, currentLedger - LEDGERS_PER_DAY);
+    const events = await this.swap.getSwapHistory({
+      pairAddress,
+      fromLedger,
+      toLedger: currentLedger,
+      limit: HISTORY_QUERY_LIMIT,
+    });
+
+    const totalSwaps24h = events.length;
+    const uniqueUsers24h = new Set(events.map((e) => e.sender)).size;
+    const volume24hUSD = events.reduce((sum, e) => {
+      const price = priceMap.get(e.tokenIn) ?? 0;
+      return sum + (Number(e.amountIn) / STROOP) * price;
+    }, 0);
+    const avgSwapSizeUSD = totalSwaps24h > 0 ? volume24hUSD / totalSwaps24h : 0;
+
+    const result: PoolMetrics = {
+      pairAddress,
+      tvlUSD,
+      volume24hUSD,
+      totalSwaps24h,
+      uniqueUsers24h,
+      avgSwapSizeUSD,
+      reserve0,
+      reserve1,
+      feeBps,
+      computedAt: Date.now(),
+    };
+    this.setCached(cacheKey, result);
+    return result;
   }
 
   // -----------------------------------------------------------------------

--- a/src/modules/treasury.ts
+++ b/src/modules/treasury.ts
@@ -362,6 +362,15 @@ export class TreasuryModule {
   }
 
   /**
+   * Public wrapper around {@link buildPriceMap} for callers outside this
+   * module hierarchy (e.g. MonitoringModule) that need the same
+   * stablecoin-anchored spot pricing used for treasury/portfolio valuations.
+   */
+  async getSpotPriceMap(allPairs: string[]): Promise<Map<string, number>> {
+    return this.buildPriceMap(allPairs);
+  }
+
+  /**
    * Build a token-address → USD-price map using spot rates from pairs.
    * Stablecoin addresses (set at construction) are anchored at $1.
    * Other token prices are derived from stablecoin-paired reserves.

--- a/src/types/monitoring.ts
+++ b/src/types/monitoring.ts
@@ -50,3 +50,53 @@ export interface MetricQueryOptions {
   granularity?: MetricGranularity;
   limit?: number;
 }
+
+/**
+ * Protocol-wide dashboard metrics, aggregated across all pools.
+ *
+ * USD values are derived from on-chain spot prices anchored to caller-supplied
+ * stablecoin addresses (the same convention used by TreasuryModule/PortfolioModule),
+ * not RedStone -- see MonitoringModule's class doc for why.
+ */
+export interface ProtocolMetrics {
+  /** Total value locked across all pools, in USD. */
+  tvlUSD: number;
+  /** Total swap volume across all pools over the trailing ~24h window, in USD. */
+  volume24hUSD: number;
+  /** Number of pools with non-zero reserves on both sides. */
+  activePools: number;
+  /** Count of distinct sender addresses that swapped in the trailing ~24h window. */
+  uniqueUsers24h: number;
+  /** Count of swap events across all pools in the trailing ~24h window. */
+  totalSwaps24h: number;
+  /** Average USD size per swap over the trailing ~24h window. */
+  avgSwapSizeUSD: number;
+  /** Unix ms timestamp when this snapshot was computed. */
+  computedAt: number;
+}
+
+/**
+ * Detailed metrics for a single pool.
+ */
+export interface PoolMetrics {
+  /** Pair contract address. */
+  pairAddress: string;
+  /** Total value locked in this pool, in USD. */
+  tvlUSD: number;
+  /** Swap volume in this pool over the trailing ~24h window, in USD. */
+  volume24hUSD: number;
+  /** Count of swap events in this pool over the trailing ~24h window. */
+  totalSwaps24h: number;
+  /** Count of distinct senders that swapped in this pool over the trailing ~24h window. */
+  uniqueUsers24h: number;
+  /** Average USD size per swap in this pool over the trailing ~24h window. */
+  avgSwapSizeUSD: number;
+  /** Token 0 reserve (smallest unit). */
+  reserve0: bigint;
+  /** Token 1 reserve (smallest unit). */
+  reserve1: bigint;
+  /** Current dynamic fee, in basis points. */
+  feeBps: number;
+  /** Unix ms timestamp when this snapshot was computed. */
+  computedAt: number;
+}

--- a/tests/monitoring-module.test.ts
+++ b/tests/monitoring-module.test.ts
@@ -1,0 +1,225 @@
+import { MonitoringModule } from '../src/modules/monitoring';
+import { CoralSwapClient } from '../src/client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STABLE_ADDR = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const TOKEN_A = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4';
+const TOKEN_B = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM';
+const PAIR_ADDR_1 = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const PAIR_ADDR_2 = 'CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR7CHFDYSFDBILE';
+
+interface PairSpec {
+  reserve0?: bigint;
+  reserve1?: bigint;
+  token0?: string;
+  token1?: string;
+  feeBps?: number;
+}
+
+function makeMockPair(spec: PairSpec = {}) {
+  return {
+    getReserves: jest.fn().mockResolvedValue({
+      reserve0: spec.reserve0 ?? 100_000_000n, // 10 units (7 decimals)
+      reserve1: spec.reserve1 ?? 100_000_000n,
+    }),
+    getTokens: jest.fn().mockResolvedValue({
+      token0: spec.token0 ?? STABLE_ADDR,
+      token1: spec.token1 ?? TOKEN_A,
+    }),
+    getDynamicFee: jest.fn().mockResolvedValue(spec.feeBps ?? 30),
+  };
+}
+
+function makeSwapEvent(ledger: number, amountIn: bigint, feeBps: number, tokenIn: string, sender: string) {
+  const makeI128 = (n: bigint) => ({
+    i128: () => ({ hi: () => ({ toString: () => (n >> 64n).toString() }), lo: () => ({ toString: () => (n & ((1n << 64n) - 1n)).toString() }) }),
+  });
+  const makeU32 = (n: number) => ({ u32: () => n });
+  const makeAddr = (s: string) => ({ address: () => ({ toString: () => s }) });
+
+  const entries = [
+    { key: { sym: () => ({ toString: () => 'amount_in' }) }, val: makeI128(amountIn) },
+    { key: { sym: () => ({ toString: () => 'fee_bps' }) }, val: makeU32(feeBps) },
+    { key: { sym: () => ({ toString: () => 'token_in' }) }, val: makeAddr(tokenIn) },
+    { key: { sym: () => ({ toString: () => 'amount_out' }) }, val: makeI128(amountIn - (amountIn * BigInt(feeBps)) / 10000n) },
+    { key: { sym: () => ({ toString: () => 'token_out' }) }, val: makeAddr(TOKEN_B) },
+    { key: { sym: () => ({ toString: () => 'sender' }) }, val: makeAddr(sender) },
+  ];
+
+  return {
+    topic: ['swap'],
+    value: { map: () => entries },
+    ledger,
+    contractId: PAIR_ADDR_1,
+    txHash: `txhash_${ledger}`,
+    ledgerClosedAt: new Date(ledger * 5000).toISOString(),
+  };
+}
+
+function createMockClient(opts: {
+  pairs?: string[];
+  pairSpecs?: Record<string, PairSpec>;
+  currentLedger?: number;
+  eventsByContractId?: Record<string, ReturnType<typeof makeSwapEvent>[]>;
+} = {}) {
+  const { pairs = [], pairSpecs = {}, currentLedger = 100_000, eventsByContractId = {} } = opts;
+
+  const getEvents = jest.fn().mockImplementation(
+    (req: { filters?: Array<{ contractIds?: string[] }> }) => {
+      const id = req?.filters?.[0]?.contractIds?.[0] ?? '';
+      return Promise.resolve({ events: eventsByContractId[id] ?? [] });
+    },
+  );
+
+  const client = {
+    factory: {
+      getAllPairs: jest.fn().mockResolvedValue(pairs),
+    },
+    pair: jest.fn().mockImplementation((addr: string) => makeMockPair(pairSpecs[addr] ?? {})),
+    server: { getEvents },
+    getCurrentLedger: jest.fn().mockResolvedValue(currentLedger),
+  } as unknown as CoralSwapClient;
+
+  return { client, getEvents };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MonitoringModule', () => {
+  describe('getProtocolMetrics()', () => {
+    it('aggregates TVL and active pool count across pools, pricing via stableAddresses', async () => {
+      const { client } = createMockClient({
+        pairs: [PAIR_ADDR_1, PAIR_ADDR_2],
+        pairSpecs: {
+          [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A, reserve0: 100_000_000n, reserve1: 100_000_000n },
+          [PAIR_ADDR_2]: { token0: STABLE_ADDR, token1: TOKEN_B, reserve0: 0n, reserve1: 0n }, // empty pool
+        },
+      });
+      const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const metrics = await monitor.getProtocolMetrics();
+
+      // Pair 1: 10 USDC + 10 TOKEN_A, TOKEN_A priced at $1 via reserve ratio = $20 TVL
+      expect(metrics.tvlUSD).toBeCloseTo(20, 5);
+      // Pair 2 has zero reserves -- excluded from active pool count
+      expect(metrics.activePools).toBe(1);
+      expect(metrics.computedAt).toBeGreaterThan(0);
+    });
+
+    it('derives totalSwaps24h, uniqueUsers24h, volume24hUSD, avgSwapSizeUSD from swap history', async () => {
+      const events = [
+        makeSwapEvent(99_500, 10_000_000n, 30, STABLE_ADDR, 'GALICE'), // 1 USDC in
+        makeSwapEvent(99_600, 20_000_000n, 30, STABLE_ADDR, 'GBOB'), // 2 USDC in
+        makeSwapEvent(99_700, 10_000_000n, 30, STABLE_ADDR, 'GALICE'), // same sender again
+      ];
+      const { client } = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        pairSpecs: { [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A } },
+        eventsByContractId: { '': events }, // protocol-wide query has no contractId filter
+      });
+      const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const metrics = await monitor.getProtocolMetrics();
+
+      expect(metrics.totalSwaps24h).toBe(3);
+      expect(metrics.uniqueUsers24h).toBe(2); // GALICE + GBOB
+      expect(metrics.volume24hUSD).toBeCloseTo(4, 5); // 1 + 2 + 1 USDC
+      expect(metrics.avgSwapSizeUSD).toBeCloseTo(4 / 3, 5);
+    });
+
+    it('returns cached results within the 60s TTL without re-querying RPC', async () => {
+      const { client } = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        pairSpecs: { [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A } },
+      });
+      const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const first = await monitor.getProtocolMetrics();
+      const callCountAfterFirst = (client.factory.getAllPairs as jest.Mock).mock.calls.length;
+      const second = await monitor.getProtocolMetrics();
+
+      expect(second).toBe(first); // same cached object reference
+      expect((client.factory.getAllPairs as jest.Mock).mock.calls.length).toBe(callCountAfterFirst);
+    });
+
+    it('sets tvlUSD to 0 when no stableAddresses are configured', async () => {
+      const { client } = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        pairSpecs: { [PAIR_ADDR_1]: {} },
+      });
+      const monitor = new MonitoringModule(client); // no stableAddresses
+
+      const metrics = await monitor.getProtocolMetrics();
+
+      expect(metrics.tvlUSD).toBe(0);
+    });
+  });
+
+  describe('getPoolMetrics()', () => {
+    it('returns reserves, fee, and USD valuation for a single pool', async () => {
+      const { client } = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        pairSpecs: {
+          [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A, reserve0: 50_000_000n, reserve1: 50_000_000n, feeBps: 25 },
+        },
+      });
+      const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const metrics = await monitor.getPoolMetrics(PAIR_ADDR_1);
+
+      expect(metrics.pairAddress).toBe(PAIR_ADDR_1);
+      expect(metrics.reserve0).toBe(50_000_000n);
+      expect(metrics.reserve1).toBe(50_000_000n);
+      expect(metrics.feeBps).toBe(25);
+      expect(metrics.tvlUSD).toBeCloseTo(10, 5); // 5 USDC + 5 TOKEN_A @ $1
+    });
+
+    it('scopes swap history to the given pair', async () => {
+      const events = [makeSwapEvent(99_900, 30_000_000n, 30, STABLE_ADDR, 'GCAROL')];
+      const { client, getEvents } = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        pairSpecs: { [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A } },
+        eventsByContractId: { [PAIR_ADDR_1]: events },
+      });
+      const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const metrics = await monitor.getPoolMetrics(PAIR_ADDR_1);
+
+      expect(metrics.totalSwaps24h).toBe(1);
+      expect(metrics.uniqueUsers24h).toBe(1);
+      expect(metrics.volume24hUSD).toBeCloseTo(3, 5);
+      expect(getEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: [expect.objectContaining({ contractIds: [PAIR_ADDR_1] })],
+        }),
+      );
+    });
+
+    it('caches per-pool results within the 60s TTL', async () => {
+      const { client } = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        pairSpecs: { [PAIR_ADDR_1]: {} },
+      });
+      const monitor = new MonitoringModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const first = await monitor.getPoolMetrics(PAIR_ADDR_1);
+      const callCountAfterFirst = (client.pair as jest.Mock).mock.calls.length;
+      const second = await monitor.getPoolMetrics(PAIR_ADDR_1);
+
+      expect(second).toBe(first);
+      expect((client.pair as jest.Mock).mock.calls.length).toBe(callCountAfterFirst);
+    });
+
+    it('throws ValidationError for an invalid pair address', async () => {
+      const { client } = createMockClient();
+      const monitor = new MonitoringModule(client);
+
+      await expect(monitor.getPoolMetrics('')).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`src/modules/monitoring.ts` already existed (health checks, custom metric registration/dashboards) but had no single dashboard-aggregator entry point. This adds it:

- `getProtocolMetrics()` → `{ tvlUSD, volume24hUSD, activePools, uniqueUsers24h, totalSwaps24h, avgSwapSizeUSD, computedAt }`, aggregated across all pools.
- `getPoolMetrics(pairAddress)` → detailed single-pool metrics (`tvlUSD`, `volume24hUSD`, `totalSwaps24h`, `uniqueUsers24h`, `avgSwapSizeUSD`, `reserve0`, `reserve1`, `feeBps`, `computedAt`).
- Both are cached for 60 seconds (per-key in-memory TTL cache) to avoid redundant RPC calls — verified in tests that a second call within the TTL returns the identical cached object without re-invoking `factory.getAllPairs()`/`client.pair()`.
- 24h volume/swap-count/unique-users are derived from real on-chain swap events via `SwapModule.getSwapHistory()` over an ~24h ledger window (17,280 ledgers at Stellar's ~5s ledger close time).
- `MonitoringModule` already exports from `src/modules/index.ts`; new types (`ProtocolMetrics`, `PoolMetrics`) are exported from `src/types/monitoring.ts`.

## ⚠️ USD pricing note (please read)
The issue asks for USD values to use RedStone price feeds. In this SDK, RedStone (`utils/redstone.ts`) is a per-swap price **guard** — the caller supplies a signed `RedStonePayload` keyed by feed symbol (e.g. `"XLM"`) at swap time; it's not a queryable price source the SDK can call on its own, and there's no existing address→symbol registry for arbitrary tokens across a whole protocol.

Instead, `tvlUSD`/`volume24hUSD`/`avgSwapSizeUSD` reuse the same stablecoin-anchored spot pricing already used by `TreasuryModule`/`PortfolioModule` (reserve ratios against caller-supplied `stableAddresses`, passed as constructor options — same pattern as `PortfolioModule`). I added a small public `getSpotPriceMap()` wrapper to `TreasuryModule` ([src/modules/treasury.ts](src/modules/treasury.ts)) so `MonitoringModule` can reuse the existing pricing logic instead of duplicating it. This keeps USD valuation consistent across the SDK rather than inventing a second, RedStone-based pricing path with no address/symbol mapping. If real RedStone wiring is wanted here, that's a separate design decision (needs a token-address-to-feed-symbol registry and a way to supply/refresh payloads).

## Known limitation
`getSwapHistory()` reads a single RPC page with no pagination (documented in `swap.ts`), so pools/protocols with more than ~1000 swaps in the trailing 24h will under-count `totalSwaps24h`/`uniqueUsers24h`/`volume24hUSD`. Documented in code comments.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint src/modules/monitoring.ts src/modules/treasury.ts src/types/monitoring.ts` — no errors
- [x] Added `tests/monitoring-module.test.ts` (8 tests): TVL/active-pool aggregation, swap-history-derived metrics, 60s cache hit behavior for both methods, zero-stableAddress fallback, per-pool scoping, address validation
- [x] Full suite: `npx jest --config jest.config.js` — 1329/1329 passing (no regressions)

Closes #284
