### PR TITLE
fix(errors): reconciled overlapping Router and Factory contract error code ranges

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -470,6 +470,12 @@ function extractPairAddress(err: unknown): string {
  *
  * Contract error codes are returned in the format: Error(Contract, #XXX)
  * where XXX is the error code defined in the contract.
+ *
+ * Code ownership is defined once in `src/errors/parser.ts`
+ * (`CONTRACT_ERROR_RANGES`): Pair owns 100-119, Router owns 200-219 and
+ * Factory owns 300-319. The cases below must stay inside those ranges so a
+ * code resolves to the same contract here and in
+ * {@link ErrorParser.parseContractError}.
  */
 function mapContractError(
   code: number,
@@ -534,31 +540,57 @@ function mapContractError(
         contractErrorCode: code,
       });
 
-    // Router contract errors (300-306)
-    case 300: // Pair not found
-      return new PairNotFoundError("unknown", "unknown");
-    case 301: // Invalid path
+    // Router contract errors (200-207)
+    case 200: // Router already initialized
+      return new InvalidOperationError(message || "Router already initialized", {
+        contractErrorCode: code,
+      });
+    case 201: // Invalid swap path
       return new ValidationError(message || "Invalid swap path", {
         contractErrorCode: code,
       });
-    case 302: // Slippage exceeded
+    case 202: // Insufficient output amount (slippage)
       return new SlippageError(0n, 0n, 0, {
         contractErrorCode: code,
         message,
       });
-    case 303: // Deadline exceeded
+    case 203: // Excessive input amount
+      return new ValidationError(message || "Excessive input amount", {
+        contractErrorCode: code,
+      });
+    case 204: // Expired deadline
       return new DeadlineError(0);
-    case 304: // Insufficient liquidity
+    case 205: // Insufficient liquidity
       return new InsufficientLiquidityError(extractPairAddress(err), {
         contractErrorCode: code,
         message,
       });
-    case 305: // Excessive input amount
-      return new ValidationError(message || "Excessive input amount", {
+    case 206: // Pair not found
+      return new PairNotFoundError("unknown", "unknown");
+    case 207: // Identical tokens
+      return new ValidationError(message || "Identical tokens", {
         contractErrorCode: code,
       });
-    case 306: // Invalid token
-      return new ValidationError(message || "Invalid token", {
+
+    // Factory contract errors (300-304)
+    case 300: // Factory already initialized
+      return new InvalidOperationError(message || "Factory already initialized", {
+        contractErrorCode: code,
+      });
+    case 301: // Unauthorized caller
+      return new ValidationError(message || "Unauthorized caller", {
+        contractErrorCode: code,
+      });
+    case 302: // Pair already exists
+      return new InvalidOperationError(message || "Pair already exists", {
+        contractErrorCode: code,
+      });
+    case 303: // Zero address provided
+      return new ValidationError(message || "Zero address provided", {
+        contractErrorCode: code,
+      });
+    case 304: // Invalid fee configuration
+      return new ValidationError(message || "Invalid fee configuration", {
         contractErrorCode: code,
       });
 

--- a/src/errors/parser.ts
+++ b/src/errors/parser.ts
@@ -2,6 +2,11 @@
  * Mappings for CoralSwap contract error codes to human-readable messages.
  *
  * These codes are defined in the Soroban contracts using #[contracterror].
+ *
+ * This module is the single source of truth for contract error code ranges.
+ * Both {@link ErrorParser.parseContractError} and the typed-error mapping in
+ * `src/errors.ts` resolve codes through {@link CONTRACT_ERROR_RANGES}, so a
+ * single code can never be claimed by two different contracts.
  */
 
 /** Error codes for Pair contracts (100-119) */
@@ -43,11 +48,52 @@ export const FACTORY_ERROR_MAP: Record<number, string> = {
     304: 'Invalid fee configuration',
 };
 
+/** The contract that owns a given block of error codes. */
+export type ContractScope = 'pair' | 'router' | 'factory';
+
+/** A half-open [start, end) block of error codes owned by one contract. */
+export interface ContractErrorRange {
+    /** The contract that owns this block. */
+    scope: ContractScope;
+    /** First code in the block (inclusive). */
+    start: number;
+    /** First code after the block (exclusive). */
+    end: number;
+    /** Code-to-message lookup for this block. */
+    map: Record<number, string>;
+}
+
+/**
+ * Canonical, non-overlapping contract error code ranges.
+ *
+ * Every consumer that needs to know which contract a numeric code came from
+ * must resolve it through this table rather than hard-coding range checks,
+ * so the ranges can only ever be changed in one place.
+ */
+export const CONTRACT_ERROR_RANGES: readonly ContractErrorRange[] = [
+    { scope: 'pair', start: 100, end: 120, map: PAIR_ERROR_MAP },
+    { scope: 'router', start: 200, end: 220, map: ROUTER_ERROR_MAP },
+    { scope: 'factory', start: 300, end: 320, map: FACTORY_ERROR_MAP },
+];
+
 /**
  * Utility for parsing numerical Soroban contract error codes and 
  * converting them into descriptive labels.
  */
 export class ErrorParser {
+    /**
+     * Resolve which contract a numeric error code belongs to.
+     *
+     * @param code - The numerical error code (e.g. 206).
+     * @returns The owning contract scope, or null if the code is out of range.
+     */
+    static resolveScope(code: number): ContractScope | null {
+        const range = CONTRACT_ERROR_RANGES.find(
+            (candidate) => code >= candidate.start && code < candidate.end,
+        );
+        return range ? range.scope : null;
+    }
+
     /**
      * Resolve a contract error code to a descriptive message.
      *
@@ -55,10 +101,11 @@ export class ErrorParser {
      * @returns A descriptive message, or null if the code is unrecognized.
      */
     static parseContractError(code: number): string | null {
-        if (code >= 100 && code < 120) return PAIR_ERROR_MAP[code] || null;
-        if (code >= 200 && code < 220) return ROUTER_ERROR_MAP[code] || null;
-        if (code >= 300 && code < 320) return FACTORY_ERROR_MAP[code] || null;
-        return null;
+        const range = CONTRACT_ERROR_RANGES.find(
+            (candidate) => code >= candidate.start && code < candidate.end,
+        );
+        if (!range) return null;
+        return range.map[code] || null;
     }
 
     /**

--- a/tests/error-code-ranges.test.ts
+++ b/tests/error-code-ranges.test.ts
@@ -1,0 +1,96 @@
+import {
+  CONTRACT_ERROR_RANGES,
+  ErrorParser,
+} from "../src/errors/parser";
+import {
+  mapError,
+  InvalidOperationError,
+  PairNotFoundError,
+} from "../src/errors";
+
+describe("Contract error code ranges", () => {
+  it("declares exactly one range per contract", () => {
+    expect(CONTRACT_ERROR_RANGES.map((range) => range.scope)).toEqual([
+      "pair",
+      "router",
+      "factory",
+    ]);
+  });
+
+  it("never lets two ranges overlap", () => {
+    for (let i = 0; i < CONTRACT_ERROR_RANGES.length; i += 1) {
+      for (let j = i + 1; j < CONTRACT_ERROR_RANGES.length; j += 1) {
+        const a = CONTRACT_ERROR_RANGES[i];
+        const b = CONTRACT_ERROR_RANGES[j];
+        const overlaps = a.start < b.end && b.start < a.end;
+        expect(overlaps).toBe(false);
+      }
+    }
+  });
+
+  it("keeps every mapped code inside its own range", () => {
+    for (const range of CONTRACT_ERROR_RANGES) {
+      for (const key of Object.keys(range.map)) {
+        const code = Number(key);
+        expect(code).toBeGreaterThanOrEqual(range.start);
+        expect(code).toBeLessThan(range.end);
+        expect(ErrorParser.resolveScope(code)).toBe(range.scope);
+      }
+    }
+  });
+
+  describe("resolveScope boundaries", () => {
+    it("resolves the pair range", () => {
+      expect(ErrorParser.resolveScope(99)).toBeNull();
+      expect(ErrorParser.resolveScope(100)).toBe("pair");
+      expect(ErrorParser.resolveScope(119)).toBe("pair");
+      expect(ErrorParser.resolveScope(120)).toBeNull();
+    });
+
+    it("resolves the router range", () => {
+      expect(ErrorParser.resolveScope(199)).toBeNull();
+      expect(ErrorParser.resolveScope(200)).toBe("router");
+      expect(ErrorParser.resolveScope(219)).toBe("router");
+      expect(ErrorParser.resolveScope(220)).toBeNull();
+    });
+
+    it("resolves the factory range", () => {
+      expect(ErrorParser.resolveScope(299)).toBeNull();
+      expect(ErrorParser.resolveScope(300)).toBe("factory");
+      expect(ErrorParser.resolveScope(319)).toBe("factory");
+      expect(ErrorParser.resolveScope(320)).toBeNull();
+    });
+  });
+
+  describe("code 300 resolves consistently across both mappers", () => {
+    it("belongs to the factory contract, not the router", () => {
+      expect(ErrorParser.resolveScope(300)).toBe("factory");
+      expect(ErrorParser.parseContractError(300)).toBe(
+        "Factory already initialized",
+      );
+    });
+
+    it("maps to a typed error that matches the parsed message", () => {
+      const err = mapError(new Error("Error(Contract, #300)"));
+      expect(err).toBeInstanceOf(InvalidOperationError);
+      expect(err).not.toBeInstanceOf(PairNotFoundError);
+      expect(err.message).toBe("Factory already initialized");
+      expect(err.details?.contractErrorCode).toBe(300);
+    });
+
+    it("keeps pair-not-found on the router code that owns it", () => {
+      expect(ErrorParser.parseContractError(206)).toBe("Pair not found");
+      expect(mapError(new Error("Error(Contract, #206)"))).toBeInstanceOf(
+        PairNotFoundError,
+      );
+    });
+  });
+
+  it("leaves in-range codes with no message unresolved", () => {
+    expect(ErrorParser.resolveScope(305)).toBe("factory");
+    expect(ErrorParser.parseContractError(305)).toBeNull();
+    expect(mapError(new Error("Error(Contract, #305)")).code).toBe(
+      "UNKNOWN_ERROR",
+    );
+  });
+});

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -12,6 +12,7 @@ import {
   ValidationError,
   FlashLoanError,
   SignerError,
+  InvalidOperationError,
   mapError,
 } from "../src/errors";
 
@@ -397,49 +398,91 @@ describe("Error Hierarchy", () => {
         });
       });
 
-      describe("Router contract errors (300-306)", () => {
-        it("maps error code 300 - Pair not found", () => {
-          const err = mapError(new Error("Error(Contract, #300)"));
+      describe("Router contract errors (200-207)", () => {
+        it("maps error code 200 - Router already initialized", () => {
+          const err = mapError(new Error("Error(Contract, #200)"));
+          expect(err.code).toBe("INVALID_OPERATION");
+          expect(err).toBeInstanceOf(InvalidOperationError);
+          expect(err.details?.contractErrorCode).toBe(200);
+        });
+
+        it("maps error code 201 - Invalid swap path", () => {
+          const err = mapError(new Error("Error(Contract, #201)"));
+          expect(err.code).toBe("VALIDATION_ERROR");
+          expect(err.details?.contractErrorCode).toBe(201);
+        });
+
+        it("maps error code 202 - Insufficient output amount", () => {
+          const err = mapError(new Error("Error(Contract, #202)"));
+          expect(err.code).toBe("SLIPPAGE_EXCEEDED");
+          expect(err).toBeInstanceOf(SlippageError);
+          expect(err.details?.contractErrorCode).toBe(202);
+        });
+
+        it("maps error code 203 - Excessive input amount", () => {
+          const err = mapError(new Error("Error(Contract, #203)"));
+          expect(err.code).toBe("VALIDATION_ERROR");
+          expect(err.details?.contractErrorCode).toBe(203);
+        });
+
+        it("maps error code 204 - Expired deadline", () => {
+          const err = mapError(new Error("Error(Contract, #204)"));
+          expect(err.code).toBe("DEADLINE_EXCEEDED");
+          expect(err).toBeInstanceOf(DeadlineError);
+        });
+
+        it("maps error code 205 - Insufficient liquidity", () => {
+          const err = mapError(new Error("Error(Contract, #205)"));
+          expect(err.code).toBe("INSUFFICIENT_LIQUIDITY");
+          expect(err).toBeInstanceOf(InsufficientLiquidityError);
+          expect(err.details?.contractErrorCode).toBe(205);
+        });
+
+        it("maps error code 206 - Pair not found", () => {
+          const err = mapError(new Error("Error(Contract, #206)"));
           expect(err.code).toBe("PAIR_NOT_FOUND");
           expect(err).toBeInstanceOf(PairNotFoundError);
         });
 
-        it("maps error code 301 - Invalid path", () => {
+        it("maps error code 207 - Identical tokens", () => {
+          const err = mapError(new Error("Error(Contract, #207)"));
+          expect(err.code).toBe("VALIDATION_ERROR");
+          expect(err.details?.contractErrorCode).toBe(207);
+        });
+      });
+
+      describe("Factory contract errors (300-304)", () => {
+        it("maps error code 300 - Factory already initialized", () => {
+          const err = mapError(new Error("Error(Contract, #300)"));
+          expect(err.code).toBe("INVALID_OPERATION");
+          expect(err).toBeInstanceOf(InvalidOperationError);
+          expect(err.message).toBe("Factory already initialized");
+          expect(err.details?.contractErrorCode).toBe(300);
+        });
+
+        it("maps error code 301 - Unauthorized caller", () => {
           const err = mapError(new Error("Error(Contract, #301)"));
           expect(err.code).toBe("VALIDATION_ERROR");
           expect(err.details?.contractErrorCode).toBe(301);
         });
 
-        it("maps error code 302 - Slippage exceeded", () => {
+        it("maps error code 302 - Pair already exists", () => {
           const err = mapError(new Error("Error(Contract, #302)"));
-          expect(err.code).toBe("SLIPPAGE_EXCEEDED");
-          expect(err).toBeInstanceOf(SlippageError);
+          expect(err.code).toBe("INVALID_OPERATION");
+          expect(err).toBeInstanceOf(InvalidOperationError);
           expect(err.details?.contractErrorCode).toBe(302);
         });
 
-        it("maps error code 303 - Deadline exceeded", () => {
+        it("maps error code 303 - Zero address provided", () => {
           const err = mapError(new Error("Error(Contract, #303)"));
-          expect(err.code).toBe("DEADLINE_EXCEEDED");
-          expect(err).toBeInstanceOf(DeadlineError);
+          expect(err.code).toBe("VALIDATION_ERROR");
+          expect(err.details?.contractErrorCode).toBe(303);
         });
 
-        it("maps error code 304 - Insufficient liquidity", () => {
+        it("maps error code 304 - Invalid fee configuration", () => {
           const err = mapError(new Error("Error(Contract, #304)"));
-          expect(err.code).toBe("INSUFFICIENT_LIQUIDITY");
-          expect(err).toBeInstanceOf(InsufficientLiquidityError);
+          expect(err.code).toBe("VALIDATION_ERROR");
           expect(err.details?.contractErrorCode).toBe(304);
-        });
-
-        it("maps error code 305 - Excessive input amount", () => {
-          const err = mapError(new Error("Error(Contract, #305)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(305);
-        });
-
-        it("maps error code 306 - Invalid token", () => {
-          const err = mapError(new Error("Error(Contract, #306)"));
-          expect(err.code).toBe("VALIDATION_ERROR");
-          expect(err.details?.contractErrorCode).toBe(306);
         });
       });
 


### PR DESCRIPTION
## Description

`src/errors.ts` and `src/errors/parser.ts` disagreed about which contract owns the `300+` error codes, so the same numeric code produced two different answers depending on which entry point a caller used.

- `src/errors/parser.ts` declares three self-consistent `#[contracterror]` tables: Pair `100-119`, Router `200-219`, Factory `300-319`. Under this table, code `300` is `Factory already initialized`.
- `src/errors.ts` `mapContractError()` carried a block commented `// Router contract errors (300-306)` and mapped `300` to `PairNotFoundError`, with no Factory handling at all.

Cross-referencing the two files shows `errors.ts` was holding the **Router** table at the wrong offset -- each of its `300-306` cases has an exact counterpart in `ROUTER_ERROR_MAP`:

| `errors.ts` case | Meaning | Actual Router code |
|---|---|---|
| 300 | Pair not found | **206** |
| 301 | Invalid swap path | **201** |
| 302 | Insufficient output / slippage | **202** |
| 303 | Expired deadline | **204** |
| 304 | Insufficient liquidity | **205** |
| 305 | Excessive input amount | **203** |
| 306 | Identical / invalid token | **207** |

`parser.ts` is treated as authoritative here: it is the only place that models all three contracts, its ranges are non-overlapping, and it places the Router at `200` in line with the contract definitions. The Router cases in `errors.ts` have therefore been moved to `200-207`, and the `300-304` block now maps the real Factory errors.

## Related Issue

Closes #428

## Changes Made

- `src/errors/parser.ts`
  - Added `CONTRACT_ERROR_RANGES`, a single canonical table of half-open `[start, end)` ranges per contract, plus the `ContractScope` / `ContractErrorRange` types.
  - Added `ErrorParser.resolveScope(code)` so callers can ask which contract owns a code instead of hard-coding range checks.
  - `parseContractError()` now resolves through `CONTRACT_ERROR_RANGES` rather than inline `if (code >= 100 && code < 120)` comparisons. Behaviour is unchanged.
- `src/errors.ts`
  - Moved the Router mappings from `300-306` to their real codes `200-207` (`200` -> `InvalidOperationError`, `206` -> `PairNotFoundError`, etc.).
  - Added Factory mappings for `300-304` (`300` and `302` -> `InvalidOperationError`, the rest -> `ValidationError`).
  - Documented on `mapContractError()` that code ownership is defined once in `parser.ts` and that cases must stay inside those ranges.
  - The Pair block (`100-113`) is untouched.
- `tests/errors.test.ts` -- the `Router contract errors (300-306)` block asserted the buggy mapping, so it has been renumbered to `Router contract errors (200-207)` and a `Factory contract errors (300-304)` block added.
- `tests/error-code-ranges.test.ts` (new) -- covers the invariant and the boundaries.

## Testing

New `tests/error-code-ranges.test.ts` covers:

- No two ranges overlap, and every code in every map falls inside its own range.
- `resolveScope` boundaries either side of each range: `99/100/119/120`, `199/200/219/220`, `299/300/319/320`.
- The regression itself -- `300` resolves to the Factory scope, parses to `Factory already initialized`, and `mapError('Error(Contract, #300)')` returns an `InvalidOperationError` that is explicitly **not** a `PairNotFoundError`.
- `Pair not found` still reachable via the Router code that owns it (`206`).
- An in-range code with no message (`305`) resolves to a scope but yields `null` from `parseContractError` and `UNKNOWN_ERROR` from `mapError`.

- [x] Tests added or updated
- [x] Existing tests pass

## Checklist

- [x] Tests added where applicable
- [x] Lint passes
- [x] Commit messages are clear and follow the project convention

### Breaking change note

This is a behavioural fix, so it is breaking for anyone matching on the old codes: `Error(Contract, #300)` no longer yields `PairNotFoundError` (use `#206`), and `#305`/`#306` are no longer mapped (use `#203`/`#207`). That is the point of the issue -- the old numbers were the Router table at the wrong offset -- but happy to gate it behind a deprecation shim that keeps `300-306` recognised for one minor release if you would prefer a softer landing.
