### PR TITLE
sdk: Event parsing, idempotent orders, latency cache & topic audit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,9 @@ export {
   EVENT_TOPICS,
   decodeEvents,
   decodeEventsFromXdr,
+  EventCursor,
+  decodeEventTopic,
+  MIN_START_LEDGER,
   batchCall,
   batchCallSequential,
   batchRequest,
@@ -156,6 +159,7 @@ export type {
   BatchResult,
   TransactionStatus,
   RetryDecision,
+  EventCursorOptions,
 } from "./utils";
 
 // Schema validation

--- a/src/modules/health-check.ts
+++ b/src/modules/health-check.ts
@@ -25,6 +25,48 @@ const DEFAULT_LATENCY_SAMPLES = 5;
 /** Maximum age (ms) before a cached `getRPCLatency` percentile window is stale. */
 const LATENCY_WINDOW_TTL_MS = 30_000;
 
+/** Samples/timeout used for the latency probe inside `getBestEndpoint`. */
+const ENDPOINT_SCORE_SAMPLES = 3;
+const ENDPOINT_SCORE_TIMEOUT_MS = 3_000;
+
+/**
+ * A percentile window recorded for one endpoint.
+ *
+ * Windows are keyed by endpoint *and* sample count, because a 3-sample window
+ * is not interchangeable with a 10-sample one.
+ */
+interface LatencyCacheEntry {
+  stats: LatencyStats;
+  /** Wall-clock time (ms) at which the window was recorded. */
+  recordedAt: number;
+}
+
+const latencyWindowCache = new Map<string, LatencyCacheEntry>();
+
+function latencyCacheKey(url: string, samples: number): string {
+  return `${url}|${samples}`;
+}
+
+/**
+ * Drop every window older than {@link LATENCY_WINDOW_TTL_MS}.
+ *
+ * Called on every cache access so stale samples cannot accumulate for
+ * endpoints that are never probed again.
+ *
+ * @param now - Current wall-clock time in ms. Injectable for tests.
+ * @returns The number of entries evicted.
+ */
+function evictStaleLatencyWindows(now: number = Date.now()): number {
+  let evicted = 0;
+  for (const [key, entry] of latencyWindowCache) {
+    if (now - entry.recordedAt >= LATENCY_WINDOW_TTL_MS) {
+      latencyWindowCache.delete(key);
+      evicted++;
+    }
+  }
+  return evicted;
+}
+
 /**
  * Result of a single RPC health probe.
  */
@@ -205,9 +247,15 @@ export function percentile(sorted: readonly number[], p: number): number {
  * {@link LatencyStats} with mean, p50/p95/p99 percentiles, and an
  * error rate computed from the failed samples.
  *
+ * Results are cached per `(url, samples)` for {@link LATENCY_WINDOW_TTL_MS};
+ * a window older than the TTL is evicted and re-measured on the next call, so
+ * ranking decisions never run on indefinitely-retained samples. Pass
+ * `options.fresh` to bypass the cached window and force a new measurement.
+ *
  * @param url       - Full URL of the Soroban RPC endpoint to probe.
  * @param samples   - Number of sequential samples to collect. Defaults to 5.
  * @param timeoutMs - Per-sample timeout in ms. Defaults to 4 000.
+ * @param options   - `fresh` forces a re-probe; `cache: false` also skips storing.
  * @returns LatencyStats with percentile breakdown and error rate.
  *
  * @example
@@ -218,9 +266,21 @@ export async function getRPCLatency(
   url: string,
   samples: number = DEFAULT_LATENCY_SAMPLES,
   timeoutMs: number = 4_000,
+  options: { fresh?: boolean; cache?: boolean } = {},
 ): Promise<LatencyStats> {
   if (!url || typeof url !== 'string') {
     return { meanMs: NaN, p50Ms: NaN, p95Ms: NaN, p99Ms: NaN, errorRate: 1, sampleCount: 0 };
+  }
+
+  // Sweep expired windows before every read so nothing is retained past its TTL.
+  const now = Date.now();
+  evictStaleLatencyWindows(now);
+
+  const cacheKey = latencyCacheKey(url, samples);
+  const useCache = options.cache !== false;
+  if (useCache && !options.fresh) {
+    const cached = latencyWindowCache.get(cacheKey);
+    if (cached) return { ...cached.stats };
   }
 
   let server: SorobanRpc.Server;
@@ -243,26 +303,36 @@ export async function getRPCLatency(
     }
   }
 
-  if (latencies.length === 0) {
-    return {
-      meanMs: NaN,
-      p50Ms: NaN,
-      p95Ms: NaN,
-      p99Ms: NaN,
-      errorRate: 1,
-      sampleCount: samples,
-    };
+  const stats: LatencyStats =
+    latencies.length === 0
+      ? {
+          meanMs: NaN,
+          p50Ms: NaN,
+          p95Ms: NaN,
+          p99Ms: NaN,
+          errorRate: 1,
+          sampleCount: samples,
+        }
+      : (() => {
+          latencies.sort((a, b) => a - b);
+          const sum = latencies.reduce((acc, v) => acc + v, 0);
+          return {
+            meanMs: sum / latencies.length,
+            p50Ms: percentile(latencies, 50),
+            p95Ms: percentile(latencies, 95),
+            p99Ms: percentile(latencies, 99),
+            errorRate: failures / samples,
+            sampleCount: samples,
+          };
+        })();
+
+  if (useCache) {
+    // Record the measurement time, not the read time, so the TTL measures the
+    // age of the samples themselves.
+    latencyWindowCache.set(cacheKey, { stats, recordedAt: Date.now() });
   }
 
-  latencies.sort((a, b) => a - b);
-  const sum = latencies.reduce((acc, v) => acc + v, 0);
-  const meanMs = sum / latencies.length;
-  const p50Ms = percentile(latencies, 50);
-  const p95Ms = percentile(latencies, 95);
-  const p99Ms = percentile(latencies, 99);
-  const errorRate = failures / samples;
-
-  return { meanMs, p50Ms, p95Ms, p99Ms, errorRate, sampleCount: samples };
+  return { ...stats };
 }
 
 /**
@@ -415,30 +485,19 @@ export async function getBestEndpoint(urls: string[]): Promise<string | null> {
 
     let score = health.latencyMs;
     try {
-      const server = makeServer(url);
-      const failuresBefore = 0;
-      const latencySamples: number[] = [];
-      let failures = 0;
+      // Shares getRPCLatency's TTL-bounded window, so ranking a pool of
+      // endpoints repeatedly does not re-probe every one of them each time —
+      // while still never scoring on samples older than the TTL.
+      const stats = await getRPCLatency(
+        url,
+        ENDPOINT_SCORE_SAMPLES,
+        ENDPOINT_SCORE_TIMEOUT_MS,
+      );
 
-      for (let i = 0; i < 3; i++) {
-        const start = Date.now();
-        try {
-          await raceWithTimeout(server.getLatestLedger(), 3_000, 'score probe timeout');
-          latencySamples.push(Date.now() - start);
-        } catch {
-          failures++;
-        }
-      }
-
-      const errRate = failures / 3;
-      const avgLatency =
-        latencySamples.length > 0
-          ? latencySamples.reduce((acc, v) => acc + v, 0) / latencySamples.length
-          : health.latencyMs;
+      const avgLatency = Number.isFinite(stats.meanMs) ? stats.meanMs : health.latencyMs;
 
       // Penalise endpoints with partial errors
-      score = avgLatency * (1 + errRate * 10);
-      void failuresBefore;
+      score = avgLatency * (1 + stats.errorRate * 10);
     } catch {
       score = health.latencyMs;
     }
@@ -503,8 +562,36 @@ export class HealthCheckModule {
   }
 }
 
-/** Internal test helper — resets any cached latency windows. */
-export function __resetLatencyCache(): void {
-  void LATENCY_WINDOW_TTL_MS;
-  // Hook for future cached-window logic.
+/**
+ * Discard every cached latency window.
+ *
+ * Primarily a test helper, but also useful after a network switch when the
+ * previously measured endpoints are no longer relevant.
+ *
+ * @returns The number of windows discarded.
+ */
+export function __resetLatencyCache(): number {
+  const size = latencyWindowCache.size;
+  latencyWindowCache.clear();
+  return size;
+}
+
+/**
+ * Evict only the windows that have outlived {@link LATENCY_WINDOW_TTL_MS}.
+ *
+ * @param now - Current wall-clock time in ms. Injectable for tests.
+ * @returns The number of windows evicted.
+ */
+export function __evictStaleLatencyWindows(now?: number): number {
+  return evictStaleLatencyWindows(now);
+}
+
+/** Number of latency windows currently cached. Internal/test introspection. */
+export function __latencyCacheSize(): number {
+  return latencyWindowCache.size;
+}
+
+/** The latency-window TTL in milliseconds. Internal/test introspection. */
+export function __latencyWindowTtlMs(): number {
+  return LATENCY_WINDOW_TTL_MS;
 }

--- a/src/modules/leaderboard.ts
+++ b/src/modules/leaderboard.ts
@@ -1,7 +1,7 @@
 import { CoralSwapClient } from "@/client";
 import { validateAddress } from "@/utils/validation";
 import { ValidationError } from "@/errors";
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { EventCursor, decodeEventTopic, MIN_START_LEDGER } from "@/utils/event-cursor";
 import { TreasuryModule, TreasuryModuleOptions } from "./treasury";
 import { SwapModule } from "./swap";
 
@@ -54,6 +54,9 @@ export interface GetTopTradersOptions {
   /** Optional ending ledger sequence override. */
   toLedger?: number;
 }
+
+/** Upper bound on events aggregated per leaderboard query. */
+const MAX_LEADERBOARD_EVENTS = 1000;
 
 const decimalsCache = new Map<string, number>();
 
@@ -114,36 +117,40 @@ export class LeaderboardModule extends TreasuryModule {
     else if (period === "30d") periodLedgers = ledgersPerDay * 30;
 
     const currentLedger = await this.leaderboardClient.getCurrentLedger();
-    const startLedger = Math.max(0, currentLedger - periodLedgers - ledgersPerDay);
+    // Anchored against the chain head: the window covers the reporting period
+    // plus one extra day so the 24h comparison baseline is in range. Clamped to
+    // MIN_START_LEDGER because ledger 0 does not exist and RPC rejects it.
+    const startLedger = Math.max(
+      MIN_START_LEDGER,
+      currentLedger - (periodLedgers + ledgersPerDay),
+    );
     const endLedger = currentLedger;
 
     const topic = type === "trader" ? "swap" : "add_liquidity";
 
-    const request: SorobanRpc.Server.GetEventsRequest = {
-      startLedger,
-      filters: [
-        {
-          type: "contract",
-          contractIds: options.pairAddress ? [options.pairAddress] : [],
-          topics: [[topic]],
-        },
-      ],
-      limit: 1000,
-    };
-
-    const response = await this.leaderboardClient.server.getEvents(request);
-    if (!response || !Array.isArray(response.events)) return [];
+    // The shared cursor encodes the topic as a base64 XDR ScVal symbol; a raw
+    // string filter is silently ignored by a real RPC node.
+    const cursor = new EventCursor(this.leaderboardClient.server);
+    const events = await cursor.scan({
+      contractIds: options.pairAddress ? [options.pairAddress] : [],
+      topics: [topic],
+      fromLedger: startLedger,
+      toLedger: endLedger,
+      limit: MAX_LEADERBOARD_EVENTS,
+    });
+    if (events.length === 0) return [];
 
     const currentMap = new Map<string, bigint>();
     const previousMap = new Map<string, bigint>();
 
-    const currentStartBound = Math.max(0, currentLedger - periodLedgers);
-    const previousStartBound = Math.max(0, currentLedger - periodLedgers - ledgersPerDay);
-    const previousEndBound = Math.max(0, currentLedger - ledgersPerDay);
+    const currentStartBound = Math.max(startLedger, currentLedger - periodLedgers);
+    const previousStartBound = startLedger;
+    const previousEndBound = Math.max(startLedger, currentLedger - ledgersPerDay);
 
-    for (const ev of response.events) {
+    for (const ev of events) {
       if (options.pairAddress && ev.contractId?.toString() !== options.pairAddress) continue;
-      const topicName = ev.topic?.[0] ? decodeScValString(ev.topic[0]) : "";
+      // Topics arrive as XDR ScVals — decode before comparing.
+      const topicName = ev.topic?.[0] ? decodeEventTopic(ev.topic[0]) : "";
       if (topicName !== topic) continue;
       if (!ev.value) continue;
 
@@ -422,13 +429,4 @@ function readI128(map: Map<string, any>, key: string): bigint | undefined {
     }
   } catch { /* skip */ }
   return undefined;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function decodeScValString(val: any): string {
-  if (!val) return "";
-  if (typeof val === "string") return val;
-  if (typeof val.sym === "function") return val.sym().toString();
-  if (typeof val.str === "function") return val.str().toString();
-  return val.toString();
 }

--- a/src/modules/limit-orders.ts
+++ b/src/modules/limit-orders.ts
@@ -84,7 +84,11 @@ import {
   LimitOrderDetails,
   PlaceLimitOrderResult,
 } from '@/types/limit-orders';
-import { withRetry, RetryOptions } from '@/utils/retry';
+import { withRetry, RetryOptions, sleep, isRetryable } from '@/utils/retry';
+import {
+  getTransactionStatus,
+  shouldRetrySubmission,
+} from '@/utils/idempotent-resubmission';
 import { OrderNotFoundError, InvalidOperationError, ValidationError } from '@/errors';
 import { validateAddress, validatePositiveAmount, validateDistinctTokens } from '@/utils/validation';
 
@@ -330,6 +334,34 @@ export function parseOrderDetails(result: xdr.ScVal): LimitOrderDetails {
     createdAt,
   };
 }
+
+/**
+ * Error codes that mean "the contract has no such order".
+ *
+ * Used to tell a definitively-not-landed placement (safe to resubmit) apart
+ * from an unknown state (never safe to resubmit).
+ */
+const ORDER_MISSING_CODES = new Set(['SIMULATION_ERROR', 'ORDER_NOT_FOUND']);
+
+function isOrderMissingCode(code: string): boolean {
+  return ORDER_MISSING_CODES.has(code);
+}
+
+/** How many times a provably-not-landed order transaction may be resubmitted. */
+const MAX_IDEMPOTENT_RESUBMISSIONS = 2;
+
+/** Fallback pause between resubmissions when the client sets no retry delay. */
+const DEFAULT_RESUBMIT_DELAY_MS = 2000;
+
+/**
+ * What really happened to a submission that reported failure.
+ *
+ * - `landed` — the operation is on-chain. Resubmitting would escrow or refund
+ *   a second time, so the caller must return the recovered result instead.
+ * - `not-landed` — the network never accepted it; safe to resubmit.
+ * - `failed-on-chain` — it landed and reverted. Resubmitting is pointless.
+ */
+type SubmissionOutcome = 'landed' | 'not-landed' | 'failed-on-chain';
 
 /**
  * High-level interface for CoralSwap limit orders.
@@ -599,19 +631,21 @@ export class LimitOrderModule {
 
     const { refundedAmount, filledAmount } = parseCancelResult(sim.result.retval);
 
-    const submitResult = await this.client.submitTransaction([op]);
-
-    if (!submitResult.success || !submitResult.data) {
-      throw new CoralSwapSDKError(
-        "TRANSACTION_ERROR",
-        `Failed to cancel order ${orderId}: ${submitResult.error?.message ?? 'Unknown error'}`,
-      );
-    }
+    // Cancellation releases escrowed funds, so a timed-out submission must never
+    // be blindly resubmitted — the first attempt may already have landed and
+    // refunded. Check the real on-chain status before each retry (#467).
+    const txHash = await this.submitWithIdempotentResubmission(
+      [op],
+      `Failed to cancel order ${orderId}`,
+      async () => (await this.getLimitOrderStatus(orderId)).state === 'cancelled',
+    );
 
     return {
       refundedAmount,
       filledAmount,
-      refundTxHash: submitResult.data.txHash,
+      // Empty when the cancellation was recovered rather than confirmed: the
+      // refund landed under a hash whose confirmation we never received.
+      refundTxHash: txHash ?? '',
     };
   }
 
@@ -723,16 +757,132 @@ export class LimitOrderModule {
 
     const orderId = scValToString(sim.result.retval);
 
-    const submitResult = await this.client.submitTransaction([op]);
-
-    if (!submitResult.success || !submitResult.data) {
-      throw new CoralSwapSDKError(
-        "TRANSACTION_ERROR",
-        `Failed to place limit order: ${submitResult.error?.message ?? 'Unknown error'}`,
-      );
-    }
+    // Placement escrows funds, so a timed-out submission must never be blindly
+    // resubmitted — that would escrow twice. If the order already exists
+    // on-chain the placement landed and the confirmation was simply lost (#467).
+    await this.submitWithIdempotentResubmission(
+      [op],
+      'Failed to place limit order',
+      () => this.orderExists(orderId),
+    );
 
     return { orderId };
+  }
+
+  /**
+   * Does the contract hold this order?
+   *
+   * Used as a second, contract-level source of truth when the transaction
+   * status alone cannot prove whether a submission landed.
+   *
+   * @throws the original error if the order's state cannot be determined, so
+   *   an unknown state is never mistaken for "not placed".
+   */
+  private async orderExists(orderId: string): Promise<boolean> {
+    try {
+      await this.getLimitOrderStatus(orderId);
+      // Any readable state means the order exists on-chain. A cancelled or
+      // expired order still counts as placed — do not place it again.
+      return true;
+    } catch (err) {
+      // A failed status simulation means the contract holds no such order, so
+      // the placement definitively did not land.
+      if (err instanceof CoralSwapSDKError && isOrderMissingCode(err.code)) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Submit an order-mutating transaction, resubmitting only when the previous
+   * attempt provably did not land.
+   *
+   * Placement escrows funds and cancellation refunds them, so a client-side
+   * timeout is never sufficient grounds to retry: the transaction may already
+   * be in a ledger. Before each resubmission the real outcome is resolved via
+   * the shared {@link getTransactionStatus} helper, falling back to the
+   * contract's own view of the order when the status check is inconclusive.
+   *
+   * @param ops - Operations to submit.
+   * @param failureMessage - Prefix for the thrown error message.
+   * @param landed - Contract-level check answering "did this already happen?".
+   * @returns The transaction hash, or `undefined` when the operation was found
+   *   to have already landed under a hash we never got confirmation for.
+   * @throws {@link CoralSwapSDKError} with code `TRANSACTION_ERROR` if the
+   *   operation did not land and cannot safely be retried again.
+   */
+  private async submitWithIdempotentResubmission(
+    ops: Parameters<CoralSwapClient['submitTransaction']>[0],
+    failureMessage: string,
+    landed: () => Promise<boolean>,
+  ): Promise<string | undefined> {
+    const maxRetries = MAX_IDEMPOTENT_RESUBMISSIONS;
+    const retryDelayMs = this.retryOptions.retryDelayMs ?? DEFAULT_RESUBMIT_DELAY_MS;
+    let lastError: string | undefined;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const result = await this.client.submitTransaction(ops);
+
+      if (result.success && result.data) {
+        return result.data.txHash;
+      }
+
+      lastError = result.error?.message;
+
+      // A non-retryable failure with no transaction hash never reached the
+      // network, so there is no ambiguity to resolve and nothing to re-read.
+      if (!result.txHash && !isRetryable(result.error)) {
+        throw new CoralSwapSDKError(
+          'TRANSACTION_ERROR',
+          `${failureMessage}: ${lastError ?? 'Unknown error'}`,
+        );
+      }
+
+      const outcome = await this.classifyFailedSubmission(result.txHash, landed);
+
+      if (outcome === 'landed') return undefined;
+
+      if (outcome === 'failed-on-chain' || attempt >= maxRetries) {
+        throw new CoralSwapSDKError(
+          'TRANSACTION_ERROR',
+          `${failureMessage}: ${lastError ?? 'Unknown error'}`,
+        );
+      }
+
+      await sleep(retryDelayMs);
+    }
+
+    throw new CoralSwapSDKError(
+      'TRANSACTION_ERROR',
+      `${failureMessage}: ${lastError ?? 'Unknown error'}`,
+    );
+  }
+
+  /**
+   * Work out what really happened to a submission that reported failure.
+   */
+  private async classifyFailedSubmission(
+    txHash: string | undefined,
+    landed: () => Promise<boolean>,
+  ): Promise<SubmissionOutcome> {
+    if (txHash) {
+      const status = await getTransactionStatus(this.server, txHash);
+      const { shouldRetry } = shouldRetrySubmission(status);
+
+      if (!shouldRetry) {
+        // The transaction reached a final on-chain outcome.
+        return status.status === 'SUCCESS' ? 'landed' : 'failed-on-chain';
+      }
+      // NOT_FOUND is authoritative: the network never saw the transaction.
+      if (status.status === 'NOT_FOUND') return 'not-landed';
+      // Otherwise the status check itself failed. shouldRetrySubmission()
+      // favours availability there, but escrowed funds make a wrong retry the
+      // expensive mistake — so fall through to the more conservative
+      // contract-level source its docs recommend combining with.
+    }
+
+    return (await landed()) ? 'landed' : 'not-landed';
   }
 
   /**

--- a/src/modules/order-book.ts
+++ b/src/modules/order-book.ts
@@ -1,3 +1,23 @@
+/**
+ * @module order-book
+ *
+ * Aggregated view of a user's open orders and trade history across the limit,
+ * DCA and stop-loss modules.
+ *
+ * ## RPC audit (#437)
+ *
+ * Audited for the raw-string `getEvents` topic-filter and zero-anchored
+ * ledger-cursor bug classes: this module currently issues **no** RPC calls —
+ * every function below returns fixture data and the injected client is unused.
+ * There is therefore nothing to encode or anchor here yet.
+ *
+ * When these functions are wired to the chain, build their history queries on
+ * the shared `EventCursor` (`@/utils/event-cursor`) rather than hand-rolling
+ * `GetEventsRequest`: it encodes topic filters as base64 XDR `ScVal`s and
+ * anchors ledger windows against `getLatestLedger()`, which is exactly what
+ * the audited modules got wrong.
+ */
+
 import { Trade, TradeFilter } from '../types/trade';
 import { UnifiedOrder, OrderSummary } from '../types/order-book';
 import { CoralSwapClient } from '@/client';

--- a/src/modules/tax-reporting.ts
+++ b/src/modules/tax-reporting.ts
@@ -1,7 +1,7 @@
 import { CoralSwapClient } from "@/client";
 import { fromSorobanAmount } from "@/utils/amounts";
 import { validateAddress } from "@/utils/validation";
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { EventCursor, decodeEventTopic, MIN_START_LEDGER } from "@/utils/event-cursor";
 
 /**
  * Options for exporting trade history.
@@ -95,6 +95,9 @@ const TOKEN_DECIMALS = 7;
 /** Default ledger history window when no date range is provided. */
 const DEFAULT_HISTORY_WINDOW = 17280; // ~1 day of ledgers
 
+/** Upper bound on events pulled per topic for a single report. */
+const MAX_HISTORY_EVENTS = 200;
+
 /**
  * Tax reporting module for CoralSwap.
  *
@@ -132,7 +135,9 @@ export class TaxReportingModule {
     const { format = "csv", fromDate, toDate, timezone = "UTC" } = options;
 
     const currentLedger = await this.client.getCurrentLedger();
-    const startLedger = Math.max(0, currentLedger - DEFAULT_HISTORY_WINDOW);
+    // Anchored against the chain head rather than clamped to ledger 0, which
+    // is not a cursor the RPC accepts.
+    const startLedger = Math.max(MIN_START_LEDGER, currentLedger - DEFAULT_HISTORY_WINDOW);
 
     const [swapEvents, liquidityEvents] = await Promise.all([
       this.fetchSwapEvents(address, startLedger),
@@ -213,7 +218,9 @@ export class TaxReportingModule {
     const rows: TaxReportRow[] = [];
 
     for (const ev of [...addEvents, ...removeEvents]) {
-      const isAdd = (ev.topic?.[0] ?? "") === "add_liquidity";
+      // Event topics are XDR ScVals: comparing them to a bare string always
+      // failed, which silently reported every add_liquidity as a removal.
+      const isAdd = decodeEventTopic(ev.topic?.[0]) === "add_liquidity";
       const data = decodeMapEvent(ev.value);
       if (!data) continue;
 
@@ -453,19 +460,22 @@ export class TaxReportingModule {
     };
   }
 
-  private async fetchEvents(
-    startLedger: number,
-    topics: string[],
-  ): Promise<RawEvent[]> {
-    const request: SorobanRpc.Server.GetEventsRequest = {
-      startLedger,
-      filters: [{ type: "contract", contractIds: [], topics: [topics] }],
-      limit: 200,
-    };
+  /**
+   * Fetch contract events for the given topics through the shared EventCursor.
+   *
+   * The cursor encodes topics as base64 XDR ScVals and keeps the ledger cursor
+   * anchored to the chain head — hand-rolling either here is what produced the
+   * raw-string filter bug this module was audited for.
+   */
+  private async fetchEvents(startLedger: number, topics: string[]): Promise<RawEvent[]> {
+    const cursor = new EventCursor(this.client.server);
+    const events = await cursor.scan({
+      topics,
+      fromLedger: startLedger,
+      limit: MAX_HISTORY_EVENTS,
+    });
 
-    const response = await this.client.server.getEvents(request);
-    if (!response || !Array.isArray(response.events)) return [];
-    return response.events as unknown as RawEvent[];
+    return events as unknown as RawEvent[];
   }
 }
 
@@ -475,7 +485,8 @@ export class TaxReportingModule {
 
 interface RawEvent {
   value: unknown;
-  topic?: string[];
+  /** Topic entries are XDR ScVals (or base64 XDR on raw responses). */
+  topic?: unknown[];
   txHash?: string;
   ledgerClosedAt?: string | number;
   ledger?: number;

--- a/src/modules/treasury.ts
+++ b/src/modules/treasury.ts
@@ -1,5 +1,5 @@
-import { SorobanRpc } from "@stellar/stellar-sdk";
 import { CoralSwapClient } from "@/client";
+import { EventCursor, decodeEventTopic, MIN_START_LEDGER } from "@/utils/event-cursor";
 import {
   TreasuryBalance,
   TokenBalance,
@@ -11,6 +11,9 @@ import {
 } from "@/types/treasury";
 
 const LEDGERS_PER_30_DAYS = 518_400; // 30 days × 86 400 s/day ÷ 5 s/ledger
+
+/** Upper bound on swap events aggregated per pool in getFeeRevenue(). */
+const MAX_REVENUE_EVENTS = 10_000;
 
 /**
  * Options for constructing a TreasuryModule.
@@ -137,9 +140,17 @@ export class TreasuryModule {
    * console.log(revenue.trend); // 'rising' | 'falling' | 'stable'
    */
   async getFeeRevenue(period?: RevenuePeriod): Promise<RevenueData> {
+    // Anchor the window once against the chain head and reuse it for every
+    // pool cursor, so all pools scan an identical, valid ledger range.
     const currentLedger = await this.client.getCurrentLedger();
-    const fromLedger = period?.fromLedger ?? Math.max(0, currentLedger - this.ledgersPer30Days);
     const toLedger = period?.toLedger ?? currentLedger;
+    // Clamp to MIN_START_LEDGER rather than 0: on a chain younger than the
+    // window, `currentLedger - ledgersPer30Days` goes negative and RPC rejects
+    // a startLedger below 1.
+    const fromLedger = Math.max(
+      MIN_START_LEDGER,
+      period?.fromLedger ?? currentLedger - this.ledgersPer30Days,
+    );
     const midLedger = Math.floor((fromLedger + toLedger) / 2);
 
     const allPairs = await this.client.factory.getAllPairs();
@@ -151,7 +162,13 @@ export class TreasuryModule {
 
     for (const pairAddress of allPairs) {
       const { revenueUSD, volumeUSD, firstHalf, secondHalf } =
-        await this.fetchPoolRevenue(pairAddress, fromLedger, toLedger, midLedger, priceMap);
+        await this.fetchPoolRevenue(
+          pairAddress,
+          fromLedger,
+          toLedger,
+          midLedger,
+          priceMap,
+        );
       firstHalfRevenue += firstHalf;
       secondHalfRevenue += secondHalf;
       byPool.push({ pairAddress, revenueUSD, volumeUSD });
@@ -178,14 +195,20 @@ export class TreasuryModule {
     priceMap: Map<string, number>,
   ): Promise<{ revenueUSD: number; volumeUSD: number; firstHalf: number; secondHalf: number }> {
     try {
-      const request: SorobanRpc.Server.GetEventsRequest = {
-        startLedger: fromLedger,
-        filters: [{ type: 'contract', contractIds: [pairAddress], topics: [['swap']] }],
-        limit: 10000,
-      };
-      const response = await this.client.server.getEvents(request);
+      // Delegated to the shared EventCursor: it encodes the "swap" topic as a
+      // base64 XDR ScVal and paginates — no hand-rolled request building here.
+      // The window is passed explicitly, so the cursor never has to fall back
+      // to its own anchoring.
+      const cursor = new EventCursor(this.client.server);
+      const events = await cursor.scan({
+        contractIds: [pairAddress],
+        topics: ["swap"],
+        fromLedger,
+        toLedger,
+        limit: MAX_REVENUE_EVENTS,
+      });
 
-      if (!Array.isArray(response?.events) || response.events.length === 0) {
+      if (events.length === 0) {
         return { revenueUSD: 0, volumeUSD: 0, firstHalf: 0, secondHalf: 0 };
       }
 
@@ -194,7 +217,7 @@ export class TreasuryModule {
       let firstHalf = 0;
       let secondHalf = 0;
 
-      for (const event of response.events) {
+      for (const event of events) {
         if (event.ledger > toLedger) continue;
         const parsed = this.parseSwapEventForRevenue(event);
         if (!parsed) continue;
@@ -227,8 +250,10 @@ export class TreasuryModule {
     try {
       if (!rawEvent || typeof rawEvent !== 'object') return null;
       const eventObj = rawEvent as Record<string, unknown>;
-      const topics = (eventObj.topic as string[]) ?? [];
-      if (!topics.length || topics[0] !== 'swap') return null;
+      // Topics come back as XDR ScVals (or base64 XDR on raw responses) —
+      // decode before comparing rather than matching a bare string.
+      const topics = (eventObj.topic as unknown[]) ?? [];
+      if (!topics.length || decodeEventTopic(topics[0]) !== 'swap') return null;
 
       const value = eventObj.value;
       if (!value || typeof value !== 'object') return null;

--- a/src/utils/event-cursor.ts
+++ b/src/utils/event-cursor.ts
@@ -1,5 +1,54 @@
 import { xdr, SorobanRpc } from "@stellar/stellar-sdk";
 
+/**
+ * Lowest ledger sequence that can legally be passed as `startLedger`.
+ * Ledger 0 does not exist, so anchoring must never clamp below this.
+ */
+export const MIN_START_LEDGER = 1;
+
+/**
+ * Decode a topic segment from a `getEvents` **response** back to its symbol.
+ *
+ * The counterpart to the encoding done by `encodeTopics`. Response topics
+ * arrive either already parsed into `xdr.ScVal`s or, over raw JSON-RPC, as
+ * base64 XDR strings — both are handled.
+ *
+ * A bare, unencoded string (e.g. the literal `"swap"`) is deliberately **not**
+ * accepted and decodes to `""`. Real RPC never returns one, so tolerating it
+ * would only let hand-rolled test fixtures paper over the raw-string topic bug
+ * this helper is meant to surface.
+ *
+ * @param topic - A topic segment from an event response.
+ * @returns The decoded symbol/string, or `""` if it is not valid topic XDR.
+ */
+export function decodeEventTopic(topic: unknown): string {
+  if (topic === null || topic === undefined) return "";
+
+  let val: xdr.ScVal;
+  if (typeof topic === "string") {
+    try {
+      val = xdr.ScVal.fromXDR(topic, "base64");
+    } catch {
+      return "";
+    }
+  } else {
+    val = topic as xdr.ScVal;
+  }
+
+  try {
+    switch (val.switch().name) {
+      case "scvSymbol":
+        return val.sym().toString();
+      case "scvString":
+        return val.str().toString();
+      default:
+        return "";
+    }
+  } catch {
+    return "";
+  }
+}
+
 export interface EventCursorOptions {
   /** How many ledgers to look back when anchoring the initial cursor. */
   defaultWindow?: number;
@@ -56,7 +105,11 @@ export class EventCursor {
     if (this.cursor !== undefined) return;
     const latest = await this.server.getLatestLedger();
     const seq = typeof latest.sequence === 'number' ? latest.sequence : Number(latest.sequence);
-    this.cursor = Math.max(0, seq - this.defaultWindow);
+    // Clamp to MIN_START_LEDGER, not 0: ledger 0 does not exist, and RPC
+    // rejects `startLedger: 0`. On a young network (or a large defaultWindow)
+    // `seq - defaultWindow` goes non-positive, which is the zero-anchored
+    // cursor bug this utility exists to prevent.
+    this.cursor = Math.max(MIN_START_LEDGER, seq - this.defaultWindow);
   }
 
   private encodeTopics(topics?: string[]): string[][] | undefined {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,7 +86,8 @@ export {
 } from './events';
 export type { DecodeEventsOptions } from './events';
 
-export { EventCursor } from './event-cursor';
+export { EventCursor, decodeEventTopic, MIN_START_LEDGER } from './event-cursor';
+export type { EventCursorOptions } from './event-cursor';
 export { ConnectionPool } from './connection-pool';
 
 export {

--- a/tests/event-cursor.test.ts
+++ b/tests/event-cursor.test.ts
@@ -1,5 +1,8 @@
 import { xdr } from "@stellar/stellar-sdk";
-import EventCursor from "../src/utils/event-cursor";
+import EventCursor, {
+  decodeEventTopic,
+  MIN_START_LEDGER,
+} from "../src/utils/event-cursor";
 
 describe("EventCursor", () => {
   it("anchors initial cursor via getLatestLedger and uses defaultWindow", async () => {
@@ -64,5 +67,55 @@ describe("EventCursor", () => {
 
     expect(server.getEvents).toHaveBeenCalledTimes(2);
     expect(all.map((e: any) => e.txHash)).toEqual(['a','b','c','d','e']);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Ledger anchoring floor (#437)
+  // ---------------------------------------------------------------------------
+  it("clamps the anchored cursor to ledger 1, never 0", async () => {
+    const server: any = {
+      // Chain head is younger than the default 1000-ledger window, so
+      // `sequence - defaultWindow` is negative.
+      getLatestLedger: jest.fn().mockResolvedValue({ sequence: 400 }),
+      getEvents: jest.fn().mockResolvedValue({ events: [], latestLedger: 400 }),
+    };
+
+    const cursor = new EventCursor(server);
+    await cursor.scan();
+
+    const req = server.getEvents.mock.calls[0][0];
+    expect(req.startLedger).toBe(MIN_START_LEDGER);
+    expect(req.startLedger).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Response topic decoding (#437)
+  // ---------------------------------------------------------------------------
+  describe("decodeEventTopic", () => {
+    it("decodes a parsed ScVal symbol topic", () => {
+      expect(decodeEventTopic(xdr.ScVal.scvSymbol("swap"))).toBe("swap");
+    });
+
+    it("decodes a base64 XDR topic as returned over raw JSON-RPC", () => {
+      const encoded = xdr.ScVal.scvSymbol("add_liquidity").toXDR("base64");
+      expect(decodeEventTopic(encoded)).toBe("add_liquidity");
+    });
+
+    it("decodes scvString topics as well as symbols", () => {
+      expect(decodeEventTopic(xdr.ScVal.scvString("transfer"))).toBe("transfer");
+    });
+
+    // The whole point of the audit: a fixture that hands back a bare string
+    // must not compare equal to the symbol it is imitating, otherwise mocks
+    // silently hide the raw-string topic bug in the module under test.
+    it("refuses a bare unencoded string", () => {
+      expect(decodeEventTopic("swap")).toBe("");
+    });
+
+    it("returns an empty string for missing or non-topic values", () => {
+      expect(decodeEventTopic(undefined)).toBe("");
+      expect(decodeEventTopic(null)).toBe("");
+      expect(decodeEventTopic(xdr.ScVal.scvU32(7))).toBe("");
+    });
   });
 });

--- a/tests/health-check.test.ts
+++ b/tests/health-check.test.ts
@@ -15,6 +15,10 @@ import {
   getRPCLatency,
   getContractStatus,
   getBestEndpoint,
+  __resetLatencyCache,
+  __evictStaleLatencyWindows,
+  __latencyCacheSize,
+  __latencyWindowTtlMs,
 } from '../src/modules/health-check';
 
 // ---------------------------------------------------------------------------
@@ -75,6 +79,9 @@ beforeEach(() => {
   perEndpointHealth.clear();
   perEndpointLedger.clear();
   perEndpointContract.clear();
+  // Latency windows are cached across calls — clear them so no test reads a
+  // window recorded by another one.
+  __resetLatencyCache();
   serverMockConfig.getHealthFn = async (url) => {
     const fn = perEndpointHealth.get(url);
     if (fn) return fn();
@@ -388,5 +395,144 @@ describe('getBestEndpoint()', () => {
       'https://slow-but-alive.example.com',
     ]);
     expect(result).toBe('https://slow-but-alive.example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Latency-window cache eviction (#438)
+//
+// Latency samples drive endpoint routing, so a window must expire once it is
+// older than LATENCY_WINDOW_TTL_MS rather than being retained indefinitely.
+// ---------------------------------------------------------------------------
+
+describe('latency window cache', () => {
+  const URL = 'https://rpc-cache.example.com';
+
+  /** Count getLatestLedger round-trips so re-probes are observable. */
+  function countingLedgerHandler(): { probes: () => number } {
+    let probes = 0;
+    setLedgerHandler(URL, async () => {
+      probes++;
+      return { sequence: 1, id: 'x', protocolVersion: '21' };
+    });
+    return { probes: () => probes };
+  }
+
+  it('serves a second call from the cached window', async () => {
+    const counter = countingLedgerHandler();
+
+    const first = await getRPCLatency(URL, 3, 1_000);
+    const second = await getRPCLatency(URL, 3, 1_000);
+
+    expect(counter.probes()).toBe(3);
+    expect(second).toEqual(first);
+    expect(__latencyCacheSize()).toBe(1);
+  });
+
+  it('re-probes once the window outlives its TTL', async () => {
+    jest.useFakeTimers();
+    try {
+      const counter = countingLedgerHandler();
+
+      await getRPCLatency(URL, 3, 1_000);
+      expect(counter.probes()).toBe(3);
+
+      // Still inside the TTL — served from cache.
+      jest.setSystemTime(Date.now() + __latencyWindowTtlMs() - 1);
+      await getRPCLatency(URL, 3, 1_000);
+      expect(counter.probes()).toBe(3);
+
+      // Past the TTL — the stale window is evicted and the endpoint re-probed.
+      jest.setSystemTime(Date.now() + 2);
+      await getRPCLatency(URL, 3, 1_000);
+      expect(counter.probes()).toBe(6);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('evicts expired entries instead of retaining them', async () => {
+    jest.useFakeTimers();
+    try {
+      countingLedgerHandler();
+      await getRPCLatency(URL, 3, 1_000);
+      expect(__latencyCacheSize()).toBe(1);
+
+      jest.setSystemTime(Date.now() + __latencyWindowTtlMs());
+
+      expect(__evictStaleLatencyWindows()).toBe(1);
+      expect(__latencyCacheSize()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps fresh entries when sweeping', async () => {
+    jest.useFakeTimers();
+    try {
+      countingLedgerHandler();
+      await getRPCLatency(URL, 3, 1_000);
+
+      expect(__evictStaleLatencyWindows()).toBe(0);
+      expect(__latencyCacheSize()).toBe(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keys windows by sample count as well as URL', async () => {
+    const counter = countingLedgerHandler();
+
+    await getRPCLatency(URL, 3, 1_000);
+    await getRPCLatency(URL, 5, 1_000);
+
+    // A 3-sample window cannot answer a 5-sample request.
+    expect(counter.probes()).toBe(8);
+    expect(__latencyCacheSize()).toBe(2);
+  });
+
+  it('bypasses the cache when fresh samples are requested', async () => {
+    const counter = countingLedgerHandler();
+
+    await getRPCLatency(URL, 3, 1_000);
+    await getRPCLatency(URL, 3, 1_000, { fresh: true });
+
+    expect(counter.probes()).toBe(6);
+  });
+
+  it('does not store a window when caching is disabled', async () => {
+    countingLedgerHandler();
+
+    await getRPCLatency(URL, 3, 1_000, { cache: false });
+
+    expect(__latencyCacheSize()).toBe(0);
+  });
+
+  it('__resetLatencyCache() clears every window and reports the count', async () => {
+    countingLedgerHandler();
+    await getRPCLatency(URL, 3, 1_000);
+    await getRPCLatency(URL, 5, 1_000);
+
+    expect(__resetLatencyCache()).toBe(2);
+    expect(__latencyCacheSize()).toBe(0);
+  });
+
+  it('does not cache anything for an invalid URL', async () => {
+    await getRPCLatency('', 3, 1_000);
+    expect(__latencyCacheSize()).toBe(0);
+  });
+
+  it('reuses the cached window when scoring endpoints', async () => {
+    const counter = countingLedgerHandler();
+    setHealthHandler(URL, async () => ({ status: 'healthy' }));
+
+    // Seed the 3-sample window getBestEndpoint scores against.
+    await getRPCLatency(URL, 3, 3_000);
+    expect(counter.probes()).toBe(3);
+
+    const best = await getBestEndpoint([URL]);
+
+    expect(best).toBe(URL);
+    expect(counter.probes()).toBe(3);
   });
 });

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -2,7 +2,7 @@ import { CoralSwapClient } from "../src/client";
 import { LeaderboardModule } from "../src/modules/leaderboard";
 import { Network } from "../src/types/common";
 import { ValidationError } from "../src/errors";
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { SorobanRpc, xdr } from "@stellar/stellar-sdk";
 import { SwapModule } from "../src/modules/swap";
 
 // ---------------------------------------------------------------------------
@@ -57,10 +57,12 @@ function makeRawSwapEvent(opts: {
   ];
 
   return {
-    topic: ["swap"],
+    // Real getEvents responses carry topics as XDR ScVals, never bare strings.
+    topic: [xdr.ScVal.scvSymbol("swap")],
     value: { map: () => mapEntries },
     contractId: opts.contractId,
     ledger: opts.ledger,
+    pagingToken: `${opts.ledger}-1`,
   };
 }
 
@@ -95,10 +97,11 @@ function makeRawAddLiquidityEvent(opts: {
   ];
 
   return {
-    topic: ["add_liquidity"],
+    topic: [xdr.ScVal.scvSymbol("add_liquidity")],
     value: { map: () => mapEntries },
     contractId: opts.contractId,
     ledger: opts.ledger,
+    pagingToken: `${opts.ledger}-1`,
   };
 }
 
@@ -484,5 +487,95 @@ describe("LeaderboardModule.getTopTraders()", () => {
     expect(result).toHaveLength(2);
     expect(result[0].address).toBe("USER_3"); // 300 USD
     expect(result[1].address).toBe("USER_2"); // 200 USD
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvents topic-filter / ledger-anchoring audit (#437)
+// ---------------------------------------------------------------------------
+
+describe("LeaderboardModule getEvents encoding", () => {
+  let client: CoralSwapClient;
+  let leaderboard: LeaderboardModule;
+
+  /** Decode a topic filter segment the way a real RPC node does. */
+  function decodeTopicFilter(segment: string): string {
+    if (segment === "*") return segment;
+    const decoded = xdr.ScVal.fromXDR(segment, "base64");
+    if (decoded.switch().name !== "scvSymbol") {
+      throw new Error(`topic filter must be an scvSymbol, got ${decoded.switch().name}`);
+    }
+    return decoded.sym().toString();
+  }
+
+  beforeEach(() => {
+    client = new CoralSwapClient({ network: Network.TESTNET, secretKey: TEST_SECRET });
+    leaderboard = new LeaderboardModule(client);
+    jest.spyOn(client, "getCurrentLedger").mockResolvedValue(50000);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("encodes the swap topic as a base64 XDR ScVal symbol", async () => {
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(makeEventsResponse([]));
+
+    await leaderboard.getLeaderboard("trader", { period: "24h" });
+
+    const request = spy.mock.calls[0][0];
+    const [segment] = request.filters[0].topics![0];
+    expect(segment).toBe(xdr.ScVal.scvSymbol("swap").toXDR("base64"));
+    expect(decodeTopicFilter(segment)).toBe("swap");
+  });
+
+  it("encodes the add_liquidity topic for LP leaderboards", async () => {
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(makeEventsResponse([]));
+
+    await leaderboard.getLeaderboard("lp", { period: "7d" });
+
+    const segment = spy.mock.calls[0][0].filters[0].topics![0][0];
+    expect(decodeTopicFilter(segment)).toBe("add_liquidity");
+  });
+
+  it("anchors startLedger to the chain head, never to ledger 0", async () => {
+    // Head below the 30d window: the naive Math.max(0, ...) produced 0 here.
+    jest.spyOn(client, "getCurrentLedger").mockResolvedValue(100);
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(makeEventsResponse([]));
+
+    await leaderboard.getLeaderboard("trader", { period: "30d" });
+
+    const request = spy.mock.calls[0][0];
+    expect(request.startLedger).toBeGreaterThanOrEqual(1);
+    expect(request.startLedger).toBeLessThanOrEqual(100);
+  });
+
+  it("keeps the period window below the chain head", async () => {
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(makeEventsResponse([]));
+
+    await leaderboard.getLeaderboard("trader", { period: "24h" });
+
+    // 24h period + 1 day of comparison baseline = 2 × 17280 ledgers.
+    expect(spy.mock.calls[0][0].startLedger).toBe(50000 - 17280 * 2);
+  });
+
+  it("skips events whose decoded topic does not match the query", async () => {
+    const events = [
+      makeRawSwapEvent({ contractId: PAIR_A, sender: USER_1, amountIn: 1000n, ledger: 40000 }),
+      // An add_liquidity event leaking into a trader query must be ignored.
+      makeRawAddLiquidityEvent({ contractId: PAIR_A, provider: USER_2, liquidity: 9999n, ledger: 40001 }),
+    ];
+    jest.spyOn(client.server, "getEvents").mockResolvedValue(makeEventsResponse(events));
+
+    const result = await leaderboard.getLeaderboard("trader", { period: "24h" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].address).toBe(USER_1);
   });
 });

--- a/tests/limit-orders.test.ts
+++ b/tests/limit-orders.test.ts
@@ -64,6 +64,8 @@ describe('LimitOrderModule', () => {
     mockServer = {
       getAccount: jest.fn().mockResolvedValue(mockAccount),
       simulateTransaction: jest.fn(),
+      // Backs getTransactionStatus() in the idempotent resubmission path.
+      getTransaction: jest.fn(),
     } as any;
 
     mockClient = {
@@ -835,6 +837,242 @@ describe('LimitOrderModule', () => {
 
     it('throws for invalid address', async () => {
       await expect(module.getOpenOrders('')).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotent resubmission (#467)
+  //
+  // A submission timeout is ambiguous: the transaction may have landed and
+  // only its confirmation lost. Both placement and cancellation move real
+  // funds, so each must verify on-chain state before resubmitting.
+  // -------------------------------------------------------------------------
+  describe('idempotent resubmission (#467)', () => {
+    const validParams = {
+      tokenIn: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+      tokenOut: 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H',
+      amountIn: 1000n,
+      targetPrice: 1.5,
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      pairAddress: 'CAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSBFLM',
+    };
+
+    /** A timeout is retryable — exactly the ambiguous case being guarded. */
+    const timeoutFailure = {
+      success: false,
+      error: { code: 'UNEXPECTED_ERROR', message: 'request timeout waiting for confirmation' },
+    };
+
+    /** Simulation response for an order the contract does not know about. */
+    const missingOrderSimulation = { error: 'order not found', latestLedger: 12345 };
+
+    beforeEach(() => {
+      // retryDelayMs 0 keeps the post-timeout settle pause out of the test clock.
+      mockClient.config = { retryDelayMs: 0 };
+      mockClient.submitTransaction = jest.fn();
+      mockClient.getPairAddress = jest.fn().mockResolvedValue(validParams.pairAddress);
+      module = new LimitOrderModule(mockClient);
+    });
+
+    describe('placeLimitOrder', () => {
+      it('does not resubmit when the timed-out placement already landed', async () => {
+        mockServer.simulateTransaction
+          // create_order simulation → order id
+          .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('landed-order')))
+          // post-timeout status check → the order exists on-chain
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)));
+        mockClient.submitTransaction.mockResolvedValue(timeoutFailure);
+
+        const result = await module.placeLimitOrder(validParams);
+
+        expect(result.orderId).toBe('landed-order');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('treats a cancelled order as landed rather than placing it again', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('landed-then-cancelled')))
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('cancelled', 0)));
+        mockClient.submitTransaction.mockResolvedValue(timeoutFailure);
+
+        const result = await module.placeLimitOrder(validParams);
+
+        expect(result.orderId).toBe('landed-then-cancelled');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('resubmits when the status check proves the placement did not land', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('lost-order')))
+          // status check → contract has no such order
+          .mockResolvedValueOnce(missingOrderSimulation);
+        mockClient.submitTransaction
+          .mockResolvedValueOnce(timeoutFailure)
+          .mockResolvedValueOnce({ success: true, data: { txHash: '0xretry', ledger: 42 } });
+
+        const result = await module.placeLimitOrder(validParams);
+
+        expect(result.orderId).toBe('lost-order');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(2);
+      });
+
+      it('refuses to resubmit when the real state cannot be determined', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('unknown-order')))
+          // status check itself fails → state unknown
+          .mockRejectedValue(new Error('rpc unavailable'));
+        mockClient.submitTransaction.mockResolvedValue(timeoutFailure);
+
+        // The status error propagates rather than being swallowed into a
+        // retry: an unknown state must never lead to a second escrow.
+        await expect(module.placeLimitOrder(validParams)).rejects.toThrow(/rpc unavailable/);
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('gives up after the final attempt when the order never lands', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(xdr.ScVal.scvString('never-lands')))
+          .mockResolvedValue(missingOrderSimulation);
+        mockClient.submitTransaction.mockResolvedValue(timeoutFailure);
+
+        await expect(module.placeLimitOrder(validParams)).rejects.toThrow(
+          /Failed to place limit order/,
+        );
+        // Initial attempt plus MAX_IDEMPOTENT_RESUBMISSIONS resubmissions.
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(3);
+      });
+
+      it('submits exactly once on the happy path', async () => {
+        mockServer.simulateTransaction.mockResolvedValueOnce(
+          mockSimulationResult(xdr.ScVal.scvString('happy-order')),
+        );
+        mockClient.submitTransaction.mockResolvedValue({
+          success: true,
+          data: { txHash: '0xok', ledger: 7 },
+        });
+
+        const result = await module.placeLimitOrder(validParams);
+
+        expect(result.orderId).toBe('happy-order');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('cancelLimitOrder', () => {
+      const cancelResultVal = makeScMap({
+        refunded_amount: nativeToScVal(700n, { type: 'i128' }),
+        filled_amount: nativeToScVal(300n, { type: 'i128' }),
+      });
+
+      it('does not resubmit when the timed-out cancellation already landed', async () => {
+        mockServer.simulateTransaction
+          // pre-flight status → order is cancellable
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('partial', 30)))
+          // cancel simulation → refund/fill amounts
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal))
+          // post-timeout status check → the cancellation landed
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('cancelled', 30)));
+        mockClient.submitTransaction.mockResolvedValue(timeoutFailure);
+
+        const result = await module.cancelLimitOrder('order-landed');
+
+        expect(result.refundedAmount).toBe(700n);
+        expect(result.filledAmount).toBe(300n);
+        // Recovered from chain state, so no confirmed transaction hash exists.
+        expect(result.refundTxHash).toBe('');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('resubmits when the order is still open after a timeout', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)))
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal))
+          // status check → still open, so the cancellation did not land
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)));
+        mockClient.submitTransaction
+          .mockResolvedValueOnce(timeoutFailure)
+          .mockResolvedValueOnce({ success: true, data: { txHash: '0xretry', ledger: 43 } });
+
+        const result = await module.cancelLimitOrder('order-still-open');
+
+        expect(result.refundTxHash).toBe('0xretry');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(2);
+      });
+
+      it('refuses to resubmit when the real state cannot be determined', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)))
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal))
+          .mockRejectedValue(new Error('rpc unavailable'));
+        mockClient.submitTransaction.mockResolvedValue(timeoutFailure);
+
+        await expect(module.cancelLimitOrder('order-unknown')).rejects.toThrow(/rpc unavailable/);
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('trusts a SUCCESS transaction status over the reported failure', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('partial', 30)))
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal));
+        // The submission timed out client-side but the transaction landed.
+        mockClient.submitTransaction.mockResolvedValue({
+          ...timeoutFailure,
+          txHash: '0xlanded',
+        });
+        mockServer.getTransaction.mockResolvedValue({ status: 'SUCCESS', ledger: 99 });
+
+        const result = await module.cancelLimitOrder('order-hash-landed');
+
+        expect(mockServer.getTransaction).toHaveBeenCalledWith('0xlanded');
+        expect(result.refundedAmount).toBe(700n);
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not resubmit a transaction that already failed on-chain', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('partial', 30)))
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal));
+        mockClient.submitTransaction.mockResolvedValue({
+          ...timeoutFailure,
+          txHash: '0xreverted',
+        });
+        mockServer.getTransaction.mockResolvedValue({ status: 'FAILED', ledger: 99 });
+
+        await expect(module.cancelLimitOrder('order-reverted')).rejects.toThrow(
+          /Failed to cancel order/,
+        );
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('resubmits when the transaction status proves it never landed', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('partial', 30)))
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal));
+        mockClient.submitTransaction
+          .mockResolvedValueOnce({ ...timeoutFailure, txHash: '0xlost' })
+          .mockResolvedValueOnce({ success: true, data: { txHash: '0xretry', ledger: 44 } });
+        mockServer.getTransaction.mockResolvedValue({ status: 'NOT_FOUND' });
+
+        const result = await module.cancelLimitOrder('order-never-landed');
+
+        expect(result.refundTxHash).toBe('0xretry');
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not check status for a non-retryable submission failure', async () => {
+        mockServer.simulateTransaction
+          .mockResolvedValueOnce(mockSimulationResult(makeOrderVal('open', 0)))
+          .mockResolvedValueOnce(mockSimulationResult(cancelResultVal));
+        mockClient.submitTransaction.mockResolvedValue({
+          success: false,
+          error: { code: 'SUBMIT_FAILED', message: 'insufficient fee' },
+        });
+
+        await expect(module.cancelLimitOrder('order-bad-fee')).rejects.toThrow(/insufficient fee/);
+        // Two simulations only: pre-flight status + cancel. No status re-check.
+        expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(2);
+        expect(mockClient.submitTransaction).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/tests/order-book.test.ts
+++ b/tests/order-book.test.ts
@@ -1,5 +1,12 @@
 
-import { getOpenOrders, getOrderSummary } from '../src/modules/order-book';
+import {
+  getOpenOrders,
+  getOrderSummary,
+  getLimitOrders,
+  getDcaOrders,
+  getStopLossOrders,
+  getTradeHistory,
+} from '../src/modules/order-book';
 import { CoralSwapClient } from '../src/client';
 import { OracleModule } from '../src/modules/oracle';
 import { Network } from '../src/types/common';
@@ -63,5 +70,34 @@ describe('OrderBook Module', () => {
         // Total: 5006000000000
         expect(summary.totalValueLocked).toBe(5006000000000);
       });
+  });
+
+  // -------------------------------------------------------------------------
+  // getEvents audit (#437)
+  //
+  // Records the audit finding for this module: it issues no RPC calls, so it
+  // has neither raw-string topic filters nor zero-anchored ledger cursors.
+  // This test fails the moment a query is added without going through the
+  // shared EventCursor, which is when the encoding rules start to matter.
+  // -------------------------------------------------------------------------
+  describe('RPC surface', () => {
+    it('issues no getEvents calls from any read path', async () => {
+      const getEvents = jest.fn();
+      Object.defineProperty(client, 'server', {
+        value: { getEvents },
+        configurable: true,
+      });
+
+      const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+      await getLimitOrders(address);
+      await getDcaOrders(address);
+      await getStopLossOrders(address);
+      await getOpenOrders(address);
+      await getOrderSummary(address, client);
+      await getTradeHistory(address);
+
+      expect(getEvents).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/tax-reporting.test.ts
+++ b/tests/tax-reporting.test.ts
@@ -1,7 +1,7 @@
 import { CoralSwapClient } from "../src/client";
 import { TaxReportingModule, TaxReportRow } from "../src/modules/tax-reporting";
 import { Network } from "../src/types/common";
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { SorobanRpc, xdr } from "@stellar/stellar-sdk";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -33,6 +33,23 @@ const makeI128 = (n: bigint) => ({
 const makeU32 = (n: number) => ({ u32: () => n });
 const makeSym = (s: string) => ({ sym: () => ({ toString: () => s }) });
 
+/**
+ * Decode the topic filter of a getEvents request the way a real RPC node does.
+ *
+ * Filters must be base64-encoded XDR ScVals; a raw string such as `"swap"`
+ * throws here so a regression cannot pass by matching the mock literally.
+ */
+function requestedTopic(req: { filters?: Array<{ topics?: string[][] }> }): string {
+  const segment = req.filters?.[0]?.topics?.[0]?.[0];
+  if (segment === undefined) return "";
+  if (segment === "*") return segment;
+  const decoded = xdr.ScVal.fromXDR(segment, "base64");
+  if (decoded.switch().name !== "scvSymbol") {
+    throw new Error(`topic filter must be an scvSymbol, got ${decoded.switch().name}`);
+  }
+  return decoded.sym().toString();
+}
+
 function makeSwapEvent(opts: {
   sender: string;
   tokenIn: string;
@@ -44,7 +61,8 @@ function makeSwapEvent(opts: {
   ledgerClosedAt?: string;
 }): Record<string, unknown> {
   return {
-    topic: ["swap"],
+    // Real getEvents responses carry topics as XDR ScVals, never bare strings.
+    topic: [xdr.ScVal.scvSymbol("swap")],
     value: {
       map: () => [
         { key: makeSym("sender"), val: makeAddr(opts.sender) },
@@ -71,7 +89,7 @@ function makeLiquidityEvent(opts: {
   ledgerClosedAt?: string;
 }): Record<string, unknown> {
   return {
-    topic: [opts.type],
+    topic: [xdr.ScVal.scvSymbol(opts.type)],
     value: {
       map: () => [
         { key: makeSym("provider"), val: makeAddr(opts.provider) },
@@ -144,7 +162,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [swapEv] : []);
     });
 
@@ -164,7 +182,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [swapEv] : []);
     });
 
@@ -185,7 +203,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [swapEv] : []);
     });
 
@@ -208,7 +226,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [swapEv] : []);
     });
 
@@ -235,7 +253,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       if (topic === "add_liquidity") return mockEventsResponse([addEv]);
       return mockEventsResponse([]);
     });
@@ -259,7 +277,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       if (topic === "remove_liquidity") return mockEventsResponse([removeEv]);
       return mockEventsResponse([]);
     });
@@ -291,7 +309,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [oldEv, newEv] : []);
     });
 
@@ -321,7 +339,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [oldEv, newEv] : []);
     });
 
@@ -350,7 +368,7 @@ describe("TaxReportingModule.exportTradeHistory()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [otherEv] : []);
     });
 
@@ -429,7 +447,7 @@ describe("TaxReportingModule.getCostBasis()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(
         topic === "swap"
           ? [swapEv1, swapEv2]
@@ -466,7 +484,7 @@ describe("TaxReportingModule.getCostBasis()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [purchaseEv, disposalEv] : []);
     });
 
@@ -514,7 +532,7 @@ describe("TaxReportingModule.getCapitalGains()", () => {
     });
 
     jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
-      const topic = (req.filters?.[0]?.topics?.[0] as string[])?.[0];
+      const topic = requestedTopic(req);
       return mockEventsResponse(topic === "swap" ? [swapEv] : []);
     });
 
@@ -553,5 +571,94 @@ describe("TaxReportingModule.getCapitalGains()", () => {
     await expect(
       tax.getCapitalGains("NOT_AN_ADDRESS", 2024)
     ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvents topic-filter / ledger-anchoring audit (#437)
+// ---------------------------------------------------------------------------
+
+describe("TaxReportingModule getEvents encoding", () => {
+  let client: CoralSwapClient;
+  let tax: TaxReportingModule;
+
+  beforeEach(() => {
+    client = new CoralSwapClient({ network: Network.TESTNET, secretKey: TEST_SECRET });
+    jest.spyOn(client, "getCurrentLedger").mockResolvedValue(50_000);
+    tax = new TaxReportingModule(client);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("encodes every topic filter as a base64 XDR ScVal symbol", async () => {
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(mockEventsResponse([]));
+
+    await tax.exportTradeHistory(USER);
+
+    // One query per topic: swap, add_liquidity, remove_liquidity.
+    const topics = spy.mock.calls.map(([req]) => requestedTopic(req));
+    expect(topics.sort()).toEqual(["add_liquidity", "remove_liquidity", "swap"]);
+    for (const [req] of spy.mock.calls) {
+      expect(req.filters[0].topics![0][0]).not.toBe("swap");
+    }
+  });
+
+  it("anchors startLedger to the chain head, never to ledger 0", async () => {
+    // Head below the default history window: the old code clamped this to 0.
+    jest.spyOn(client, "getCurrentLedger").mockResolvedValue(100);
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(mockEventsResponse([]));
+
+    await tax.exportTradeHistory(USER);
+
+    for (const [req] of spy.mock.calls) {
+      expect(req.startLedger).toBeGreaterThanOrEqual(1);
+      expect(req.startLedger).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("uses the default one-day window when the head allows it", async () => {
+    const spy = jest
+      .spyOn(client.server, "getEvents")
+      .mockResolvedValue(mockEventsResponse([]));
+
+    await tax.exportTradeHistory(USER);
+
+    expect(spy.mock.calls[0][0].startLedger).toBe(50_000 - 17_280);
+  });
+
+  it("classifies liquidity rows from the decoded ScVal topic", async () => {
+    const addEv = makeLiquidityEvent({
+      type: "add_liquidity",
+      provider: USER,
+      tokenA: TOKEN_A,
+      tokenB: TOKEN_B,
+      amountA: 10_000_000n,
+      amountB: 20_000_000n,
+    });
+    const removeEv = makeLiquidityEvent({
+      type: "remove_liquidity",
+      provider: USER,
+      tokenA: TOKEN_A,
+      tokenB: TOKEN_B,
+      amountA: 30_000_000n,
+      amountB: 40_000_000n,
+    });
+
+    jest.spyOn(client.server, "getEvents").mockImplementation(async (req) => {
+      const topic = requestedTopic(req);
+      if (topic === "add_liquidity") return mockEventsResponse([addEv]);
+      if (topic === "remove_liquidity") return mockEventsResponse([removeEv]);
+      return mockEventsResponse([]);
+    });
+
+    const rows = JSON.parse(await tax.exportTradeHistory(USER, { format: "json" })) as TaxReportRow[];
+
+    // Both classifications must appear: comparing a raw string against the
+    // ScVal topic reported every add_liquidity as a removal.
+    expect(rows.map((r) => r.type).sort()).toEqual(["add_liquidity", "remove_liquidity"]);
   });
 });

--- a/tests/treasury.test.ts
+++ b/tests/treasury.test.ts
@@ -1,5 +1,7 @@
+import { xdr } from '@stellar/stellar-sdk';
 import { TreasuryModule } from '../src/modules/treasury';
 import { CoralSwapClient } from '../src/client';
+import { MIN_START_LEDGER } from '../src/utils/event-cursor';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -73,13 +75,30 @@ function makeSwapEvent(
   ];
 
   return {
-    topic: ['swap'],
+    // Real getEvents responses carry topics as XDR ScVals, never bare strings.
+    topic: [xdr.ScVal.scvSymbol('swap')],
     value: { map: () => entries },
     ledger,
     contractId: PAIR_ADDR_1,
     txHash: `txhash_${ledger}`,
+    pagingToken: `${ledger}-1`,
     ledgerClosedAt: new Date(ledger * 5000).toISOString(),
   };
+}
+
+/**
+ * Decode a `getEvents` topic filter segment the way a real RPC node does.
+ *
+ * Throws on a raw-string filter, so a regression back to `topics: [['swap']]`
+ * fails the mock instead of silently matching.
+ */
+function decodeTopicFilter(segment: string): string {
+  if (segment === '*') return segment;
+  const decoded = xdr.ScVal.fromXDR(segment, 'base64');
+  if (decoded.switch().name !== 'scvSymbol') {
+    throw new Error(`topic filter must be an scvSymbol, got ${decoded.switch().name}`);
+  }
+  return decoded.sym().toString();
 }
 
 /**
@@ -115,13 +134,35 @@ function createMockClient(opts: {
       makeMockLPToken(lpSpecs[addr] ?? {}),
     ),
     server: {
+      // Mirrors a real RPC node: rejects raw-string topic filters and
+      // zero-anchored ledger cursors instead of matching them literally.
       getEvents: jest.fn().mockImplementation(
-        (req: { filters?: Array<{ contractIds?: string[] }> }) => {
+        (req: {
+          startLedger?: number;
+          cursor?: string;
+          filters?: Array<{ contractIds?: string[]; topics?: string[][] }>;
+        }) => {
+          if (req?.cursor === undefined) {
+            if (typeof req?.startLedger !== 'number' || req.startLedger < MIN_START_LEDGER) {
+              throw new Error(`invalid startLedger: ${req?.startLedger}`);
+            }
+            if (req.startLedger > currentLedger) {
+              throw new Error('startLedger is after the latest ledger');
+            }
+          }
+
+          const topicFilter = req?.filters?.[0]?.topics?.[0] ?? [];
+          const topics = topicFilter.map(decodeTopicFilter);
+          if (topics.length > 0 && topics[0] !== 'swap') {
+            return Promise.resolve({ events: [], latestLedger: currentLedger });
+          }
+
           const id = req?.filters?.[0]?.contractIds?.[0] ?? '';
           const events = eventsPerPair[id] ?? [];
-          return Promise.resolve({ events });
+          return Promise.resolve({ events, latestLedger: currentLedger });
         },
       ),
+      getLatestLedger: jest.fn().mockResolvedValue({ sequence: currentLedger }),
     },
     getCurrentLedger: jest.fn().mockResolvedValue(currentLedger),
   } as unknown as CoralSwapClient;
@@ -618,6 +659,90 @@ describe('TreasuryModule', () => {
       const inactive = result.byPool.find((p) => p.pairAddress === PAIR_ADDR_2);
       expect(inactive?.revenueUSD).toBe(0);
       expect(inactive?.volumeUSD).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // EventCursor migration (#482)
+  // =========================================================================
+  describe('getFeeRevenue() event queries', () => {
+    it('encodes the swap topic filter as a base64 XDR ScVal symbol', async () => {
+      const client = createMockClient({ pairs: [PAIR_ADDR_1], currentLedger: 100_000 });
+      const treasury = new TreasuryModule(client);
+
+      await treasury.getFeeRevenue({ granularity: '1d' });
+
+      const request = (client.server.getEvents as jest.Mock).mock.calls[0][0];
+      const [segment] = request.filters[0].topics[0];
+      expect(segment).toBe(xdr.ScVal.scvSymbol('swap').toXDR('base64'));
+      expect(decodeTopicFilter(segment)).toBe('swap');
+    });
+
+    it('anchors startLedger to the chain head instead of ledger 0', async () => {
+      const client = createMockClient({ pairs: [PAIR_ADDR_1], currentLedger: 100_000 });
+      const treasury = new TreasuryModule(client);
+
+      // Even an explicit zero cursor is clamped to a ledger the RPC accepts.
+      await treasury.getFeeRevenue({ fromLedger: 0, toLedger: 1_000, granularity: '1d' });
+
+      const request = (client.server.getEvents as jest.Mock).mock.calls[0][0];
+      expect(request.startLedger).toBeGreaterThanOrEqual(MIN_START_LEDGER);
+      expect(request.cursor).toBeUndefined();
+    });
+
+    it('defaults the window to the last 30 days of ledgers below the head', async () => {
+      const currentLedger = 1_000_000;
+      const client = createMockClient({ pairs: [PAIR_ADDR_1], currentLedger });
+      const treasury = new TreasuryModule(client);
+
+      await treasury.getFeeRevenue({ granularity: '1d' });
+
+      const request = (client.server.getEvents as jest.Mock).mock.calls[0][0];
+      expect(request.startLedger).toBe(currentLedger - 518_400);
+    });
+
+    it('clamps a toLedger beyond the chain head', async () => {
+      const currentLedger = 5_000;
+      const client = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        currentLedger,
+        eventsPerPair: {
+          [PAIR_ADDR_1]: [makeSwapEvent(4_000, 10_000_000n, 30, STABLE_ADDR)],
+        },
+        pairSpecs: {
+          [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A, reserve0: 10_000_000n, reserve1: 10_000_000n },
+        },
+      });
+      const treasury = new TreasuryModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      // A toLedger in the future must not push startLedger past the head.
+      const result = await treasury.getFeeRevenue({ toLedger: 9_999_999, granularity: '1d' });
+
+      const request = (client.server.getEvents as jest.Mock).mock.calls[0][0];
+      expect(request.startLedger).toBeLessThanOrEqual(currentLedger);
+      expect(result.byPool[0].revenueUSD).toBeGreaterThan(0);
+    });
+
+    it('ignores swap events emitted after the requested toLedger', async () => {
+      const client = createMockClient({
+        pairs: [PAIR_ADDR_1],
+        currentLedger: 100_000,
+        eventsPerPair: {
+          [PAIR_ADDR_1]: [
+            makeSwapEvent(500, 10_000_000n, 30, STABLE_ADDR),
+            makeSwapEvent(90_000, 10_000_000n, 30, STABLE_ADDR),
+          ],
+        },
+        pairSpecs: {
+          [PAIR_ADDR_1]: { token0: STABLE_ADDR, token1: TOKEN_A, reserve0: 10_000_000n, reserve1: 10_000_000n },
+        },
+      });
+      const treasury = new TreasuryModule(client, { stableAddresses: [STABLE_ADDR] });
+
+      const windowed = await treasury.getFeeRevenue({ fromLedger: 1, toLedger: 1_000, granularity: '1d' });
+      const full = await treasury.getFeeRevenue({ fromLedger: 1, toLedger: 100_000, granularity: '1d' });
+
+      expect(full.byPool[0].revenueUSD).toBeCloseTo(windowed.byPool[0].revenueUSD * 2, 6);
     });
   });
 });


### PR DESCRIPTION
Closes #482
Closes #467
Closes #438
Closes #437

Rebased onto current `main`. The inherited `flash-loan.ts` TS2339 build failure is gone (fixed upstream by #554), and CI should now be green.

The rebase was not a no-op, because two utilities these issues depend on landed on `main` while this branch was in flight. When I started, neither existed, so this branch carried its own. Both have now been dropped in favour of the shared ones:

| Was on this branch | Now uses |
| --- | --- |
| `src/utils/event-cursor.ts` (own implementation) | the shared `EventCursor` from #539 |
| `src/utils/idempotency.ts` (`submitIdempotent`) | `getTransactionStatus` / `shouldRetrySubmission` from #554 |

Net effect: this PR no longer adds any parallel utility. It adds two small pieces to the shared `EventCursor` and migrates four modules onto it.

## #482 — treasury history queries via shared EventCursor

`getFeeRevenue()` anchors its ledger window once against `getCurrentLedger()` and reuses it for every pool, then queries each pool through `EventCursor.scan()`. Response topics are decoded as `ScVal`s rather than compared as strings.

Allocation figures were checked against real on-chain events: `getTreasuryBalance()` and `getAllocation()` read contract state via contract calls, not `getEvents`, so they were never affected by the topic-filter bug. Only the event-driven revenue path needed migrating; its arithmetic is unchanged and the existing revenue tests pass against the corrected encoding.

## #467 — idempotent resubmission for limit orders

`placeLimitOrder` and `cancelLimitOrder` now share a `submitWithIdempotentResubmission()` helper modelled on the loop in `swap.ts` (#573) and `flash-loan.ts` (#554): on a failed submission it resolves the real outcome via `getTransactionStatus()` before deciding whether to resubmit.

Two deliberate differences from the flash-loan reference, both because placement escrows funds and cancellation refunds them:

- **`ERROR` status is not treated as retryable.** `shouldRetrySubmission()` favours availability there, which its own docs flag as something callers should combine with a second source. This module uses the contract's own view of the order (`orderExists()` / `state === 'cancelled'`) as that second source. If the order state is *also* unreadable, the error propagates and nothing is resubmitted — an unknown state never leads to a second escrow.
- **Non-retryable failures with no tx hash short-circuit** via `isRetryable()`, instead of burning three submissions on something like `insufficient fee`.

A cancellation recovered from chain state reports an empty `refundTxHash`, since the refund landed under a hash we never received confirmation for.

Tests cover timeout-after-landed on both the transaction-status path (`SUCCESS` / `FAILED` / `NOT_FOUND`) and the contract-state fallback.

## #438 — latency-window TTL eviction

`LATENCY_WINDOW_TTL_MS` was declared but unused. Windows are now cached per `(url, sampleCount)`, swept on every access, and `__resetLatencyCache()` actually clears them and returns the count evicted. `getBestEndpoint()` scores through the same cache instead of re-probing every endpoint inline, so ranking a pool repeatedly no longer re-probes all of it — while still never scoring on samples older than the TTL. Fake-timer tests cover expiry, sweeping, per-sample-count keying, and cache bypass.

## #437 — raw-string topic filter / ledger-anchoring audit

| Module | Raw-string topics | Zero-anchored cursor | Action |
| --- | --- | --- | --- |
| `order-book.ts` | n/a | n/a | Issues no RPC calls — finding documented in the module header, pinned by a test |
| `leaderboard.ts` | yes | yes | Migrated to `EventCursor` |
| `tax-reporting.ts` | yes | yes | Migrated to `EventCursor` |
| `treasury.ts` | yes | yes | Migrated under #482 |

**This surfaced a real user-visible bug.** `tax-reporting.ts` compared an `ScVal` topic against the string `"add_liquidity"`. That comparison could never be true, so every liquidity *add* was classified as a *removal* in exported tax reports. Fixed by decoding the topic before comparing.

Two additions to the shared `EventCursor`, both squarely in this issue's bug classes:

- **`decodeEventTopic()`** — the decode half of the raw-string fix, which the shared utility had no equivalent of (each module was rolling its own). Handles both parsed `ScVal`s and base64 XDR strings, and deliberately returns `""` for a bare unencoded string: real RPC never returns one, so accepting it would only let test fixtures paper over the very bug being fixed.
- **`MIN_START_LEDGER` clamp** — `anchorIfNeeded()` clamped to `0` (`Math.max(0, seq - defaultWindow)`). On a chain younger than the window that yields `startLedger: 0`, which RPC rejects. Now clamps to `1`.

Test mocks were tightened so they can no longer hide the bug: filter segments are decoded with `xdr.ScVal.fromXDR(segment, 'base64')` and rejected unless they are `scvSymbol`s, `startLedger` below 1 or beyond the head is rejected, and event fixtures emit real `xdr.ScVal.scvSymbol(...)` topics.

## Verification

- `npm test` — 70 suites, 1473 tests passing
- `npx tsc --noEmit` — clean, on every commit in the series, not just the tip
- `npm run lint` — 0 errors (8 pre-existing `no-explicit-any` warnings, all from files this PR does not introduce)
