### PR TITLE
fix(client): short-circuit executeWithFallback on non-retryable errors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ import { PortfolioModule } from '@/modules/portfolio';
 import { KeypairSigner } from '@/utils/signer';
 import { TransactionPoller, PollingStrategy, PollingOptions } from '@/utils/polling';
 import { buildSimulationResult } from '@/utils/simulation';
-import { withRetry, RetryOptions } from '@/utils/retry';
+import { withRetry, RetryOptions, isRetryable } from '@/utils/retry';
 export { KeypairSigner, PollingStrategy, PollingOptions };
 
 /**
@@ -81,6 +81,13 @@ export class CoralSwapClient {
           `${label}[RPC:${this._currentRpcIndex}]`,
         );
       } catch (err) {
+        // Non-retryable errors (e.g. ValidationError, bad simulation) must surface
+        // immediately — cycling through every fallback endpoint cannot fix them and
+        // only multiplies latency for a failure that retrying can never resolve.
+        if (!isRetryable(err)) {
+          throw err;
+        }
+
         lastError = err;
         this.logger?.info(`executeWithFallback: RPC call failed, trying fallback`, {
           label,

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -3,6 +3,7 @@ import { CoralSwapClient } from '../src/client';
 import { Network, Signer } from '../src/types/common';
 import { SignerError } from '../src/errors';
 import { DEFAULTS } from '../src/config';
+import { resetCircuitBreakers } from '../src/utils/retry';
 
 // Mock transaction for testing
 const mockTx = {
@@ -499,5 +500,77 @@ describe('CoralSwapClient', () => {
       expect(result.error?.message).toContain('timed out');
       expect(result.txHash).toBe('test-tx-hash');
     });
+  });
+});
+
+/**
+ * Isolated tests for executeWithFallback retry / fallback behaviour.
+ *
+ * These tests drive the private method indirectly through isHealthy() which
+ * is a thin single-call wrapper — the simplest public surface that exercises
+ * the fallback loop without needing a full transaction stack.
+ */
+describe('executeWithFallback', () => {
+  const TEST_SECRET = 'SB6K2AINTGNYBFX4M7TRPGSKQ5RKNOXXWB7UZUHRYOVTM7REDUGECKZU';
+
+  beforeEach(() => {
+    resetCircuitBreakers();
+  });
+
+  it('surfaces a non-retryable error immediately without cycling through fallback endpoints', async () => {
+    // Three RPC URLs configured — only the first should ever be attempted.
+    const client = new CoralSwapClient({
+      network: Network.TESTNET,
+      secretKey: TEST_SECRET,
+      rpcUrl: [
+        'https://rpc1.example.com',
+        'https://rpc2.example.com',
+        'https://rpc3.example.com',
+      ],
+      maxRetries: 0,
+      retryDelayMs: 0,
+    });
+
+    // A non-retryable error: plain validation failure with no timeout/429/503 signal.
+    const nonRetryableError = new Error('ValidationError: bad simulation parameters');
+    const mockGetHealth = jest.fn().mockRejectedValue(nonRetryableError);
+    client.server.getHealth = mockGetHealth;
+
+    await expect(client.isHealthy()).resolves.toBe(false);
+
+    // Must only hit the RPC once — no rotation to rpc2 or rpc3.
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back across all endpoints for retryable errors (network/timeout/429/503)', async () => {
+    const rpcUrls = [
+      'https://rpc1.example.com',
+      'https://rpc2.example.com',
+      'https://rpc3.example.com',
+    ];
+
+    const client = new CoralSwapClient({
+      network: Network.TESTNET,
+      secretKey: TEST_SECRET,
+      rpcUrl: rpcUrls,
+      maxRetries: 0,   // one attempt per endpoint, no per-endpoint retries
+      retryDelayMs: 0,
+    });
+
+    // Retryable error: 503 Service Unavailable
+    const retryableError = Object.assign(
+      new Error('503 Service Unavailable'),
+      { response: { status: 503 } },
+    );
+
+    // Every endpoint fails with the retryable error.
+    const mockGetHealth = jest.fn().mockRejectedValue(retryableError);
+    client.server.getHealth = mockGetHealth;
+
+    // isHealthy() catches all errors and returns false — confirm it tried all endpoints.
+    await expect(client.isHealthy()).resolves.toBe(false);
+
+    // Should have been called once per RPC endpoint (3 total).
+    expect(mockGetHealth).toHaveBeenCalledTimes(rpcUrls.length);
   });
 });


### PR DESCRIPTION
Before this change, executeWithFallback would rotate through every configured RPC endpoint on *any* error, including non-retryable ones like ValidationError or bad simulation results. This multiplied latency for failures that retrying across endpoints can never fix.

Fix: check isRetryable() (already in src/utils/retry.ts) before rotating to the next endpoint. Non-retryable errors are re-thrown immediately; retryable errors (network/timeout/429/503) keep the existing fallback behaviour.

Closes #435

## Description

Describe what this PR changes and why it is needed.

## Related Issue

Closes #XXX

Replace `XXX` with the issue number this PR resolves. If there is no linked issue, explain why.

## Changes Made

- List the key changes included in this PR.

## Testing

Describe the tests or manual checks performed for this change.

- [ ] Tests added or updated
- [ ] Existing tests pass

## Checklist

- [ ] Tests added where applicable
- [ ] Documentation updated where applicable
- [ ] Lint passes
- [ ] No breaking changes, or any breaking changes are documented
- [ ] Commit messages are clear and follow the project convention

closes #435 