### PR TITLE
[SDK] Use idempotent resubmission for RWA pool interactions

### DIFF
--- a/examples/rwa-pool.ts
+++ b/examples/rwa-pool.ts
@@ -49,6 +49,7 @@ import {
   getRWAPoolAPY,
   navAdjustedSwapOutput,
   navPremiumRatio,
+  RWAModule,
   RWAPoolConfig,
 } from '../src/rwa';
 
@@ -135,6 +136,7 @@ async function main() {
 
   const liquidityModule = new LiquidityModule(client);
   const swapModule = new SwapModule(client);
+  const rwaModule = new RWAModule(client);
 
   // ══════════════════════════════════════════════════════════════════════════
   // Step 1: Create the USDC / deJTRSY pair with NAV price feed
@@ -158,26 +160,25 @@ async function main() {
   } else {
     console.log('  Creating USDC / deJTRSY pair with RedStone NAV price feed...');
 
-    // buildCreateRWAPair encodes the NAV price feed address as the third
-    // argument to the factory's `create_rwa_pair` entry-point.  The factory
-    // contract stores the feed reference in the pair's storage slot so it can
-    // be queried by governance contracts and off-chain tooling.
-    const createOp = client.factory.buildCreateRWAPair(
-      publicKey,
-      usdcAddress,
-      rwaAddress,
-      navFeedAddress,
-    );
-
-    const createResult = await client.submitTransaction([createOp]);
-
-    if (!createResult.success) {
-      console.error('  ❌ Pair creation failed:', createResult.error?.message);
+    // rwaModule.createRWAPair() builds and submits the factory's
+    // `create_rwa_pair` call. RWA pool interactions move real funds against
+    // NAV-priced positions, so a client-side timeout here must never trigger
+    // a blind resubmission -- that could attempt to register the same pair
+    // twice. On a retryable failure it checks the transaction's real
+    // on-chain status before ever resubmitting.
+    let createResult;
+    try {
+      createResult = await rwaModule.createRWAPair({
+        tokenA: usdcAddress,
+        tokenB: rwaAddress,
+        navPriceFeedAddress: navFeedAddress,
+      });
+    } catch (err) {
+      console.error('  ❌ Pair creation failed:', err instanceof Error ? err.message : err);
       process.exit(1);
     }
 
-    // Re-fetch the pair address now that it has been registered.
-    pairAddress = await client.getPairAddress(usdcAddress, rwaAddress);
+    pairAddress = createResult.pairAddress;
 
     if (!pairAddress) {
       console.error('  ❌ Pair was submitted but address could not be resolved.');
@@ -185,7 +186,7 @@ async function main() {
     }
 
     console.log(`  ✅ Pair created: ${pairAddress}`);
-    console.log(`     Tx: ${createResult.data?.ledger} (ledger)`);
+    console.log(`     Tx: ${createResult.txHash} (ledger ${createResult.ledger})`);
   }
 
   console.log('');

--- a/src/rwa.ts
+++ b/src/rwa.ts
@@ -1,4 +1,8 @@
 import { PoolState, FeeState } from '@/types/pool';
+import { CoralSwapClient } from '@/client';
+import { TransactionError } from '@/errors';
+import { validateAddress } from '@/utils/validation';
+import { getTransactionStatus, shouldRetrySubmission } from '@/utils/idempotent-resubmission';
 
 /**
  * Configuration for an RWA (Real-World Asset) liquidity pool.
@@ -184,4 +188,121 @@ export function navAdjustedSwapOutput(
 export function navPremiumRatio(spotPrice: bigint, navPerToken: bigint): bigint {
   if (navPerToken === 0n) return 0n;
   return (spotPrice * STELLAR_PRECISION) / navPerToken;
+}
+
+/** Parameters for registering a new RWA trading pair on-chain. */
+export interface CreateRWAPairRequest {
+  /** Address of the first token (e.g. a stablecoin such as USDC). */
+  tokenA: string;
+  /** Address of the second token (e.g. a yield-bearing RWA token such as deJTRSY). */
+  tokenB: string;
+  /** RedStone (or equivalent) NAV price feed contract address for `tokenB`. */
+  navPriceFeedAddress: string;
+}
+
+/** Result of a (possibly recovered) RWA pair creation. */
+export interface CreateRWAPairResult {
+  txHash: string;
+  ledger: number;
+  /** Resolved pair address, or null if it could not be looked up yet. */
+  pairAddress: string | null;
+}
+
+/**
+ * Write-path operations for RWA (Real-World Asset) pools.
+ *
+ * RWA pool interactions move real funds against NAV-priced positions, so a
+ * timeout during submission must never result in a blind resubmission --
+ * that would risk registering (or attempting to register) the same pair
+ * twice against real capital. On a retryable failure this module always
+ * checks the transaction's real on-chain status via the shared
+ * {@link getTransactionStatus} / {@link shouldRetrySubmission} utility
+ * before ever resubmitting.
+ */
+export class RWAModule {
+  private client: CoralSwapClient;
+
+  constructor(client: CoralSwapClient) {
+    this.client = client;
+  }
+
+  /**
+   * Register a new RWA trading pair, recording its NAV price feed on-chain.
+   *
+   * @throws {ValidationError} If any address is invalid.
+   * @throws {TransactionError} If the submission genuinely fails (not just times out).
+   */
+  async createRWAPair(request: CreateRWAPairRequest): Promise<CreateRWAPairResult> {
+    validateAddress(request.tokenA, 'tokenA');
+    validateAddress(request.tokenB, 'tokenB');
+    validateAddress(request.navPriceFeedAddress, 'navPriceFeedAddress');
+
+    const op = this.client.factory.buildCreateRWAPair(
+      this.client.publicKey,
+      request.tokenA,
+      request.tokenB,
+      request.navPriceFeedAddress,
+    );
+
+    const { txHash, ledger } = await this.submitIdempotent(op, 'RWA pair creation');
+
+    const pairAddress = await this.client.getPairAddress(request.tokenA, request.tokenB);
+
+    return { txHash, ledger, pairAddress };
+  }
+
+  /**
+   * Submit an operation, and on a retryable submission failure, check the
+   * transaction's real on-chain status before ever resubmitting.
+   *
+   * - Real status `SUCCESS` -- the write already landed despite the
+   *   client-side failure; return it rather than resubmitting.
+   * - Real status `FAILED` -- the write genuinely failed on-chain; throw
+   *   without resubmitting.
+   * - Real status `NOT_FOUND` / `ERROR` -- the write never landed (or its
+   *   status can't be confirmed); it is safe to resubmit exactly once.
+   */
+  private async submitIdempotent(
+    op: import('@stellar/stellar-sdk').xdr.Operation,
+    label: string,
+  ): Promise<{ txHash: string; ledger: number }> {
+    const result = await this.client.submitTransaction([op]);
+
+    if (result.success) {
+      return { txHash: result.txHash!, ledger: result.data!.ledger };
+    }
+
+    if (!result.txHash) {
+      throw new TransactionError(
+        `${label} failed: ${result.error?.message ?? 'Unknown error'}`,
+      );
+    }
+
+    const status = await getTransactionStatus(this.client.server, result.txHash);
+    const decision = shouldRetrySubmission(status);
+
+    if (!decision.shouldRetry) {
+      if (status.status === 'SUCCESS') {
+        // Timed out client-side, but the write genuinely landed -- report
+        // it rather than resubmitting a duplicate against real capital.
+        return { txHash: result.txHash, ledger: status.ledger };
+      }
+      throw new TransactionError(
+        `${label} failed on-chain: ${result.error?.message ?? 'Transaction failed'}`,
+        result.txHash,
+      );
+    }
+
+    // Genuinely never landed -- safe to resubmit exactly once. submitTransaction
+    // rebuilds the transaction (fresh account sequence number) internally.
+    const retryResult = await this.client.submitTransaction([op]);
+    if (!retryResult.success) {
+      throw new TransactionError(
+        `${label} failed after retry: ${retryResult.error?.message ?? 'Unknown error'}`,
+        retryResult.txHash,
+      );
+    }
+
+    return { txHash: retryResult.txHash!, ledger: retryResult.data!.ledger };
+  }
 }

--- a/src/utils/idempotent-resubmission.ts
+++ b/src/utils/idempotent-resubmission.ts
@@ -1,0 +1,85 @@
+import { SorobanRpc } from '@stellar/stellar-sdk';
+
+/**
+ * Real, on-chain outcome of a previously-submitted Soroban transaction.
+ *
+ * A client-side timeout or connection error while *submitting* a
+ * transaction says nothing about whether it actually landed -- the
+ * transaction may already be included in a ledger. Callers must check
+ * this before rebuilding and resubmitting, or they risk double-executing
+ * the operation.
+ */
+export type TransactionStatus =
+  | { status: 'SUCCESS'; ledger: number; txHash: string; result?: SorobanRpc.Api.GetSuccessfulTransactionResponse }
+  | { status: 'FAILED'; ledger?: number }
+  | { status: 'NOT_FOUND' }
+  | { status: 'ERROR'; message: string };
+
+/**
+ * Look up the real on-chain status of a transaction hash.
+ *
+ * @param server - The Soroban RPC server to query.
+ * @param txHash - Hash of the transaction to check.
+ */
+export async function getTransactionStatus(
+  server: SorobanRpc.Server,
+  txHash: string,
+): Promise<TransactionStatus> {
+  try {
+    const result = await server.getTransaction(txHash);
+    switch (result.status) {
+      case 'SUCCESS':
+        return {
+          status: 'SUCCESS',
+          ledger: result.ledger ?? 0,
+          txHash,
+          result: result as SorobanRpc.Api.GetSuccessfulTransactionResponse,
+        };
+      case 'FAILED':
+        return {
+          status: 'FAILED',
+          ledger: result.ledger,
+        };
+      case 'NOT_FOUND':
+        return { status: 'NOT_FOUND' };
+      default:
+        return { status: 'ERROR', message: `Unknown transaction status: ${result.status}` };
+    }
+  } catch (err) {
+    return {
+      status: 'ERROR',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export interface RetryDecision {
+  /** Whether it is safe to rebuild and resubmit the transaction. */
+  shouldRetry: boolean;
+  reason?: string;
+}
+
+/**
+ * Decide whether a transaction is safe to resubmit given its real status.
+ *
+ * - `SUCCESS` / `FAILED` -- the transaction already has a final on-chain
+ *   outcome. Resubmitting would either duplicate the effect (SUCCESS) or
+ *   is pointless (FAILED); either way, do not retry.
+ * - `NOT_FOUND` -- the network never saw it land, so it is safe to retry.
+ * - `ERROR` -- the status check itself failed. We can't confirm the
+ *   transaction didn't land, but favor availability over blocking forever;
+ *   callers combining this with other status sources (e.g. an external
+ *   bridge API) should prefer the more conservative of the two signals.
+ */
+export function shouldRetrySubmission(status: TransactionStatus): RetryDecision {
+  switch (status.status) {
+    case 'SUCCESS':
+      return { shouldRetry: false, reason: 'Transaction already succeeded' };
+    case 'FAILED':
+      return { shouldRetry: false, reason: 'Transaction already failed on-chain' };
+    case 'NOT_FOUND':
+      return { shouldRetry: true };
+    case 'ERROR':
+      return { shouldRetry: true, reason: 'Status check failed, allowing retry' };
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -96,3 +96,28 @@ export type { VotingPower, VotingPowerQueryProvider, VotingPowerQueryResult } fr
 export { checkCompatibility } from './migration';
 export type { BreakingChange, CompatibilityReport } from './migration';
 export { suppressDeprecationWarnings, deprecated } from './deprecation-warnings';
+
+/**
+ * Idempotent-resubmission helpers for state-changing on-chain calls.
+ *
+ * `submitTransaction()` (and similar) can fail with a retryable error
+ * (timeout, connection reset, RPC 503) that says nothing about whether the
+ * transaction actually landed. Before rebuilding and resubmitting on such a
+ * failure, use `getTransactionStatus()` to check the real on-chain outcome
+ * and `shouldRetrySubmission()` to decide whether it's safe to retry.
+ *
+ * @example
+ * const result = await client.submitTransaction([op]);
+ * if (!result.success && result.txHash) {
+ *   const status = await getTransactionStatus(client.server, result.txHash);
+ *   const { shouldRetry } = shouldRetrySubmission(status);
+ *   if (!shouldRetry && status.status === 'SUCCESS') {
+ *     // Already landed -- use status.ledger / status.result, don't resubmit.
+ *   }
+ * }
+ */
+export {
+  getTransactionStatus,
+  shouldRetrySubmission,
+} from './idempotent-resubmission';
+export type { TransactionStatus, RetryDecision } from './idempotent-resubmission';

--- a/tests/idempotent-resubmission.test.ts
+++ b/tests/idempotent-resubmission.test.ts
@@ -1,0 +1,106 @@
+import { SorobanRpc } from '@stellar/stellar-sdk';
+import {
+  getTransactionStatus,
+  shouldRetrySubmission,
+  TransactionStatus,
+} from '../src/utils/idempotent-resubmission';
+
+describe('idempotent-resubmission', () => {
+  const TX_HASH = 'test-tx-hash-123';
+
+  describe('getTransactionStatus', () => {
+    it('returns SUCCESS when the transaction landed successfully', async () => {
+      const mockServer = {
+        getTransaction: jest.fn().mockResolvedValue({
+          status: 'SUCCESS',
+          ledger: 12345,
+        }),
+      } as unknown as SorobanRpc.Server;
+
+      const status = await getTransactionStatus(mockServer, TX_HASH);
+
+      expect(status.status).toBe('SUCCESS');
+      if (status.status === 'SUCCESS') {
+        expect(status.ledger).toBe(12345);
+        expect(status.txHash).toBe(TX_HASH);
+      }
+    });
+
+    it('returns FAILED when the transaction failed on-chain', async () => {
+      const mockServer = {
+        getTransaction: jest.fn().mockResolvedValue({
+          status: 'FAILED',
+          ledger: 12345,
+        }),
+      } as unknown as SorobanRpc.Server;
+
+      const status = await getTransactionStatus(mockServer, TX_HASH);
+
+      expect(status.status).toBe('FAILED');
+      if (status.status === 'FAILED') {
+        expect(status.ledger).toBe(12345);
+      }
+    });
+
+    it('returns NOT_FOUND when the transaction has never been seen', async () => {
+      const mockServer = {
+        getTransaction: jest.fn().mockResolvedValue({ status: 'NOT_FOUND' }),
+      } as unknown as SorobanRpc.Server;
+
+      const status = await getTransactionStatus(mockServer, TX_HASH);
+
+      expect(status.status).toBe('NOT_FOUND');
+    });
+
+    it('returns ERROR when the RPC call throws an Error', async () => {
+      const mockServer = {
+        getTransaction: jest.fn().mockRejectedValue(new Error('RPC unavailable')),
+      } as unknown as SorobanRpc.Server;
+
+      const status = await getTransactionStatus(mockServer, TX_HASH);
+
+      expect(status.status).toBe('ERROR');
+      if (status.status === 'ERROR') {
+        expect(status.message).toBe('RPC unavailable');
+      }
+    });
+
+    it('returns ERROR when the RPC call throws a non-Error value', async () => {
+      const mockServer = {
+        getTransaction: jest.fn().mockRejectedValue('string error'),
+      } as unknown as SorobanRpc.Server;
+
+      const status = await getTransactionStatus(mockServer, TX_HASH);
+
+      expect(status.status).toBe('ERROR');
+    });
+  });
+
+  describe('shouldRetrySubmission', () => {
+    it('never retries once the transaction has succeeded', () => {
+      const status: TransactionStatus = { status: 'SUCCESS', ledger: 12345, txHash: TX_HASH };
+      const decision = shouldRetrySubmission(status);
+      expect(decision.shouldRetry).toBe(false);
+      expect(decision.reason).toContain('already succeeded');
+    });
+
+    it('never retries once the transaction has failed on-chain', () => {
+      const status: TransactionStatus = { status: 'FAILED', ledger: 12345 };
+      const decision = shouldRetrySubmission(status);
+      expect(decision.shouldRetry).toBe(false);
+      expect(decision.reason).toContain('already failed');
+    });
+
+    it('allows a retry when the transaction was never found on-chain', () => {
+      const status: TransactionStatus = { status: 'NOT_FOUND' };
+      const decision = shouldRetrySubmission(status);
+      expect(decision.shouldRetry).toBe(true);
+    });
+
+    it('allows a retry when the status check itself errors', () => {
+      const status: TransactionStatus = { status: 'ERROR', message: 'Network error' };
+      const decision = shouldRetrySubmission(status);
+      expect(decision.shouldRetry).toBe(true);
+    });
+  });
+});

--- a/tests/rwa-idempotent.test.ts
+++ b/tests/rwa-idempotent.test.ts
@@ -1,0 +1,151 @@
+import { RWAModule } from '../src/rwa';
+import { TransactionError } from '../src/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const USDC = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+const DEJTRSY = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const NAV_FEED = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const PAIR_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM';
+
+/**
+ * Build a minimal mock CoralSwapClient with controllable submitTransaction
+ * and server.getTransaction responses (mirrors tests/flash-loan.test.ts).
+ */
+function buildMockClient(options: {
+  submitResults?: object[];
+  txResult?: object;
+  pairAddress?: string | null;
+} = {}) {
+  const {
+    submitResults = [{ success: true, txHash: 'CREATE_TX', data: { ledger: 1000 } }],
+    txResult = { status: 'NOT_FOUND' },
+    pairAddress = PAIR_ADDRESS,
+  } = options;
+
+  const submitTransaction = jest.fn();
+  submitResults.forEach((r) => submitTransaction.mockResolvedValueOnce(r));
+
+  return {
+    publicKey: 'GTEST_SENDER',
+    factory: {
+      buildCreateRWAPair: jest.fn().mockReturnValue('mock_create_rwa_pair_op'),
+    },
+    getPairAddress: jest.fn().mockResolvedValue(pairAddress),
+    submitTransaction,
+    server: {
+      getTransaction: jest.fn().mockResolvedValue(txResult),
+    },
+  };
+}
+
+const REQUEST = {
+  tokenA: USDC,
+  tokenB: DEJTRSY,
+  navPriceFeedAddress: NAV_FEED,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RWAModule.createRWAPair() — idempotent resubmission', () => {
+  it('returns the pair on a normal successful submission', async () => {
+    const client = buildMockClient();
+    const module = new RWAModule(client as any);
+
+    const result = await module.createRWAPair(REQUEST);
+
+    expect(result.txHash).toBe('CREATE_TX');
+    expect(result.ledger).toBe(1000);
+    expect(result.pairAddress).toBe(PAIR_ADDRESS);
+    expect(client.submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  describe('timeout-after-landed detection', () => {
+    it('does not resubmit when submission times out but the pair creation already landed', async () => {
+      const client = buildMockClient({
+        submitResults: [
+          { success: false, error: { code: 'TX_TIMEOUT', message: 'Transaction confirmation timed out' }, txHash: 'CREATE_TX' },
+        ],
+        txResult: { status: 'SUCCESS', ledger: 54321 },
+      });
+      const module = new RWAModule(client as any);
+
+      const result = await module.createRWAPair(REQUEST);
+
+      expect(result.txHash).toBe('CREATE_TX');
+      expect(result.ledger).toBe(54321);
+      expect(client.submitTransaction).toHaveBeenCalledTimes(1);
+      expect(client.server.getTransaction).toHaveBeenCalledWith('CREATE_TX');
+    });
+
+    it('throws and does not resubmit when the transaction genuinely failed on-chain', async () => {
+      const client = buildMockClient({
+        submitResults: [
+          { success: false, error: { code: 'TX_TIMEOUT', message: 'Transaction confirmation timed out' }, txHash: 'CREATE_TX' },
+        ],
+        txResult: { status: 'FAILED', ledger: 54321 },
+      });
+      const module = new RWAModule(client as any);
+
+      await expect(module.createRWAPair(REQUEST)).rejects.toThrow(TransactionError);
+      expect(client.submitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('resubmits exactly once when the transaction was never found on-chain', async () => {
+      const client = buildMockClient({
+        submitResults: [
+          { success: false, error: { code: 'TX_TIMEOUT', message: 'Transaction confirmation timed out' }, txHash: 'CREATE_TX_1' },
+          { success: true, txHash: 'CREATE_TX_2', data: { ledger: 777 } },
+        ],
+        txResult: { status: 'NOT_FOUND' },
+      });
+      const module = new RWAModule(client as any);
+
+      const result = await module.createRWAPair(REQUEST);
+
+      expect(result.txHash).toBe('CREATE_TX_2');
+      expect(result.ledger).toBe(777);
+      expect(client.submitTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after a failed retry when the transaction never lands even after resubmission', async () => {
+      const client = buildMockClient({
+        submitResults: [
+          { success: false, error: { code: 'TX_TIMEOUT', message: 'Transaction confirmation timed out' }, txHash: 'CREATE_TX_1' },
+          { success: false, error: { code: 'TX_TIMEOUT', message: 'Transaction confirmation timed out' } },
+        ],
+        txResult: { status: 'NOT_FOUND' },
+      });
+      const module = new RWAModule(client as any);
+
+      await expect(module.createRWAPair(REQUEST)).rejects.toThrow(TransactionError);
+      expect(client.submitTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws immediately when the failed submission has no txHash to check', async () => {
+      const client = buildMockClient({
+        submitResults: [{ success: false, error: { code: 'SIMULATION_FAILED', message: 'Simulation failed' } }],
+      });
+      const module = new RWAModule(client as any);
+
+      await expect(module.createRWAPair(REQUEST)).rejects.toThrow(TransactionError);
+      expect(client.server.getTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects an invalid tokenA address before submitting anything', async () => {
+      const client = buildMockClient();
+      const module = new RWAModule(client as any);
+
+      await expect(
+        module.createRWAPair({ ...REQUEST, tokenA: 'not-an-address' }),
+      ).rejects.toThrow();
+      expect(client.submitTransaction).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #473.

RWA pool operations move real funds against NAV-priced positions, so a timeout during a write call must never be blindly resubmitted -- that risks a duplicate submission against real capital.

Note: `src/rwa.ts` previously contained only pure NAV/APY math helpers -- no write path at all. The only RWA-specific write operation (registering a new RWA pair via the factory's `create_rwa_pair` entry-point) lived as a raw, non-idempotent `client.submitTransaction()` call written inline in `examples/rwa-pool.ts`, with no retry or status-checking logic whatsoever. This PR adds that write operation as `RWAModule.createRWAPair()` directly in `rwa.ts`, with idempotent resubmission built in from the start, and updates the example to use it.

- Added a shared `getTransactionStatus` / `shouldRetrySubmission` utility (`src/utils/idempotent-resubmission.ts`), exported from `src/utils/index.ts` for reuse by other modules (companion issue #464).
- Added `RWAModule.createRWAPair()` in `src/rwa.ts`:
  - Builds and submits the `create_rwa_pair` operation.
  - On a retryable submission failure, checks the transaction's real on-chain status via the shared utility before ever resubmitting.
  - `SUCCESS` status → returns the already-landed result instead of resubmitting.
  - `FAILED` status → throws `TransactionError` without resubmitting.
  - `NOT_FOUND` / `ERROR` status → resubmits exactly once.
- Updated `examples/rwa-pool.ts` to use `RWAModule.createRWAPair()` instead of the naive inline `client.submitTransaction()` call.

## Test plan

- [x] `tests/idempotent-resubmission.test.ts` -- unit tests for the shared utility (SUCCESS/FAILED/NOT_FOUND/ERROR paths).
- [x] `tests/rwa-idempotent.test.ts` -- covers both acceptance criteria:
  - A timed-out-but-landed RWA pair creation (`SUCCESS` on-chain) is detected and not resubmitted.
  - A genuinely failed transaction (`FAILED` on-chain) throws without resubmitting.
  - A transaction that never landed (`NOT_FOUND`) resubmits exactly once and succeeds.
  - A retry that also never lands throws after exactly one resubmission attempt.
  - No `txHash` in the failed result throws immediately without a status check.
  - Input validation rejects invalid addresses before submitting anything.
- [x] Full suite: `npx jest` -- 63 suites / 1337 tests passing.
- [x] `npx eslint` on all changed/added source files -- clean.
- [x] `npx tsc --noEmit` -- no new type errors (one pre-existing, unrelated error in `src/modules/flash-loan.ts` from #517 remains; not touched by this PR). Also type-checked `examples/rwa-pool.ts` against a temporary tsconfig including it -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)