### PR TITLE
export wire connection pool

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ import { FactoryModule } from '@/modules/factory';
 import { PortfolioModule } from '@/modules/portfolio';
 import { KeypairSigner } from '@/utils/signer';
 import { TransactionPoller, PollingStrategy, PollingOptions } from '@/utils/polling';
+import { ConnectionPool } from '@/utils/connection-pool';
 import { buildSimulationResult } from '@/utils/simulation';
 import { withRetry, RetryOptions } from '@/utils/retry';
 export { KeypairSigner, PollingStrategy, PollingOptions };
@@ -39,7 +40,8 @@ export class CoralSwapClient {
   networkConfig: NetworkConfig;
   private _server: SorobanRpc.Server;
   private _rpcUrls: string[] = [];
-  private _currentRpcIndex: number = 0;
+  private _activeRpcUrl: string;
+  private _connectionPool: ConnectionPool;
   private signer: Signer | null = null;
   private _publicKeyCache: string | null = null;
   private _factory: FactoryClient | null = null;
@@ -69,32 +71,40 @@ export class CoralSwapClient {
     };
 
     let lastError: unknown;
-    const initialIndex = this._currentRpcIndex;
 
-    // We try each RPC URL at least once if needed
-    for (let i = 0; i < this._rpcUrls.length; i++) {
+    for (let attempt = 0; attempt < this._connectionPool.size; attempt++) {
+      let rpcUrl: string;
       try {
-        return await withRetry(
+        rpcUrl = this._connectionPool.getEndpoint();
+      } catch (err) {
+        throw err;
+      }
+
+      if (rpcUrl !== this._activeRpcUrl) {
+        this._server = this.createRpcServer(rpcUrl);
+        this._poller = null;
+        this._activeRpcUrl = rpcUrl;
+        this.networkConfig.rpcUrl = rpcUrl;
+      }
+
+      try {
+        const result = await withRetry(
           () => fn(this.server),
           options,
           this.logger,
-          `${label}[RPC:${this._currentRpcIndex}]`,
+          `${label}[RPC:${rpcUrl}]`,
         );
+
+        this._connectionPool.reportSuccess(rpcUrl);
+        return result;
       } catch (err) {
         lastError = err;
+        this._connectionPool.reportFailure(rpcUrl);
         this.logger?.info(`executeWithFallback: RPC call failed, trying fallback`, {
           label,
-          url: this._rpcUrls[this._currentRpcIndex],
+          url: rpcUrl,
           error: err instanceof Error ? err.message : err,
         });
-
-        if (this._rpcUrls.length > 1) {
-          this.rotateRpcServer();
-          // If we've circled back to the initial index, we've tried all URLs
-          if (this._currentRpcIndex === initialIndex) break;
-        } else {
-          break;
-        }
       }
     }
 
@@ -115,16 +125,7 @@ export class CoralSwapClient {
    */
   set server(s: SorobanRpc.Server) {
     this._server = s;
-  }
-
-  /**
-   * Rotate to the next available RPC server in the fallback list.
-   * @private
-   */
-  private rotateRpcServer(): void {
-    if (this._rpcUrls.length <= 1) return;
-    this._currentRpcIndex = (this._currentRpcIndex + 1) % this._rpcUrls.length;
-    this._server = this.createRpcServer(this._rpcUrls[this._currentRpcIndex]);
+    this._poller = null;
   }
 
   /**
@@ -176,8 +177,9 @@ export class CoralSwapClient {
     // Keep networkConfig.rpcUrl in sync with the active RPC URL
     this.networkConfig.rpcUrl = this._rpcUrls[0];
 
-    this._currentRpcIndex = 0;
-    this._server = this.createRpcServer(this._rpcUrls[0]);
+    this._connectionPool = new ConnectionPool(this._rpcUrls);
+    this._activeRpcUrl = this._rpcUrls[0];
+    this._server = this.createRpcServer(this._activeRpcUrl);
 
     if (config.signer) {
       this.signer = config.signer;
@@ -314,8 +316,9 @@ export class CoralSwapClient {
     // Keep networkConfig.rpcUrl in sync with the active RPC URL
     this.networkConfig.rpcUrl = this._rpcUrls[0];
 
-    this._currentRpcIndex = 0;
-    this._server = this.createRpcServer(this._rpcUrls[0]);
+    this._connectionPool = new ConnectionPool(this._rpcUrls);
+    this._activeRpcUrl = this._rpcUrls[0];
+    this._server = this.createRpcServer(this._activeRpcUrl);
 
     // Reset contract client singletons to trigger re-initialization
     this._factory = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export {
   batchRequest,
   batchRequestOrThrow,
   DEFAULT_BATCH_CONCURRENCY,
+  ConnectionPool,
 } from './utils';
 
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,6 +86,8 @@ export {
 } from './events';
 export type { DecodeEventsOptions } from './events';
 
+export { ConnectionPool } from './connection-pool';
+
 export {
   getVotingPower,
   getVotingPowerAtLedger,

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,6 @@
 import { Keypair, SorobanRpc, xdr, Transaction, TransactionBuilder } from '@stellar/stellar-sdk';
 import { CoralSwapClient } from '../src/client';
+import { ConnectionPool } from '../src';
 import { Network, Signer } from '../src/types/common';
 import { SignerError } from '../src/errors';
 import { DEFAULTS } from '../src/config';
@@ -94,6 +95,10 @@ describe('CoralSwapClient', () => {
       });
 
       expect(client.networkConfig.rpcUrl).toBe(customRpcUrl);
+    });
+
+    it('exports ConnectionPool from the package root', () => {
+      expect(ConnectionPool).toBeDefined();
     });
 
     it('allows custom config overrides', () => {


### PR DESCRIPTION
## Description
This PR makes RPC endpoint selection health-aware by wiring CoralSwapClient to use ConnectionPool instead of the previous blind round-robin fallback loop. This allows failing endpoints to be skipped or deprioritized after repeated failures, while preserving the existing multi-RPC configuration experience for callers.

## Related Issue
Closes #433

## Changes Made
-Exported ConnectionPool from the public utility and package entrypoints so it is available from the SDK root.
-Replaced CoralSwapClient’s ad-hoc RPC rotation logic in client.ts with ConnectionPool-based endpoint selection.
-Updated the client to report RPC success and failure back to the pool so unhealthy endpoints are deprioritized until they recover.
-Kept multi-endpoint configuration backward-compatible for existing callers.
## Testing
Ran:
-npm test -- --runInBand client.test.ts tests/connection-pool.test.ts
## Result:
2/2 test suites passed
48/48 tests passed
##Checklist
 [✔️] Tests added or updated
 [✔️] Existing tests pass
[✔️] Documentation updated where applicable
[✔️] Lint passes
[✔️] No breaking changes, or any breaking changes are documented
[✔️] Commit messages are clear and follow the project convention