### PR TITLE
Fix remaining lint errors and broken tests from recent module migrations

### DIFF
--- a/src/modules/alerts.ts
+++ b/src/modules/alerts.ts
@@ -1000,7 +1000,7 @@ export class AlertModule {
         }
 
         this.thresholdPriceAlerts.set(id, updatedAlert);
-      } catch (error) {
+      } catch {
         // Skip alerts that fail to fetch price (e.g., oracle unavailable)
         continue;
       }
@@ -1047,7 +1047,7 @@ export class AlertModule {
     if (this.oracleAddress) {
       try {
         return await this.fetchRedStonePrice(tokenAddress);
-      } catch (error) {
+      } catch {
         // Fall through to spot price if oracle fails
       }
     }
@@ -1136,8 +1136,7 @@ export class AlertModule {
     // (not just staying on the same side)
     if (lastKnownPrice !== undefined) {
       const wasAbove = lastKnownPrice >= targetPrice;
-      const isAbove = currentPrice >= targetPrice;
-      
+
       // Trigger only if we crossed the threshold
       if (direction === 'above' && wasAbove) {
         return false; // Already above, no crossing

--- a/src/modules/fees.ts
+++ b/src/modules/fees.ts
@@ -304,7 +304,7 @@ export class FeeModule {
     const lpTokenAddr = await pair.getLPTokenAddress();
     const lpToken = this.client.lpToken(lpTokenAddr);
 
-    const [lpBalance, totalSupply, { reserve0, reserve1 }, { token0, token1 }] =
+    const [lpBalance, totalSupply, { reserve0, reserve1 }] =
       await Promise.all([
         lpToken.balance(lpAddress),
         lpToken.totalSupply(),

--- a/src/modules/flash-loan.ts
+++ b/src/modules/flash-loan.ts
@@ -13,7 +13,7 @@ import {
   calculateRepayment,
   validateFeeFloor,
 } from "@/contracts/flash-receiver";
-import { FlashLoanError, TransactionError } from "@/errors";
+import { FlashLoanError } from "@/errors";
 import { FeeModule } from "./fees";
 import { validateAddress, validatePositiveAmount } from "@/utils/validation";
 import { estimateGas } from "@/utils/gas";
@@ -429,7 +429,7 @@ export class FlashLoanModule {
   private async parseFlashLoanEvents(
     txResult: SorobanRpc.Api.GetSuccessfulTransactionResponse,
     request: FlashLoanRequest,
-    feeAmount: bigint,
+    _feeAmount: bigint,
   ): Promise<FlashLoanExecutedEvent | undefined> {
     try {
       const rawEvents = this.getRawEvents(txResult);

--- a/src/modules/swap.ts
+++ b/src/modules/swap.ts
@@ -16,7 +16,6 @@ import {
 import { PRECISION, DEFAULTS } from '../config';
 import { PairNotFoundError, ValidationError, InsufficientLiquidityError, TransactionError } from '../errors';
 import { PairClient } from '@/contracts/pair';
-import { validateAddress, validatePositiveAmount, validateDistinctTokens, isValidPath } from '@/utils/validation';
 import { SorobanRpc, xdr } from '@stellar/stellar-sdk';
 import { GasEstimate } from '../types/gas';
 import { estimateGas } from '../utils/gas';
@@ -748,8 +747,6 @@ export class SwapModule {
    */
 
   async getSwapHistory(filter: SwapHistoryFilter = {}): Promise<SwapHistoryEvent[]> {
-    const { pairAddress, userAddress } = filter;
-
     parseWithValidationError(
       swapHistoryFilterSchema,
       filter,

--- a/tests/client-rate-limiter.test.ts
+++ b/tests/client-rate-limiter.test.ts
@@ -148,7 +148,9 @@ describe('CoralSwapClient — RateLimiter integration', () => {
         const mockServer = {
             getHealth: jest.fn().mockImplementation(async () => {
                 dispatchCount += 1;
-                if (dispatchCount === 1) throw new Error('primary RPC down');
+                if (dispatchCount === 1) {
+                    throw Object.assign(new Error('primary RPC down'), { response: { status: 503 } });
+                }
                 return { status: 'healthy' };
             }),
         } as any;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -576,13 +576,26 @@ describe('executeWithFallback', () => {
 
     // Every endpoint fails with the retryable error.
     const mockGetHealth = jest.fn().mockRejectedValue(retryableError);
-    client.server.getHealth = mockGetHealth;
+    const mockServer = { getHealth: mockGetHealth } as any;
+    client.server = mockServer;
+
+    // executeWithFallback calls the private createRpcServer(url) to build a
+    // fresh, real SorobanRpc.Server on every endpoint rotation — patching
+    // client.server.getHealth once only covers the first (primary) endpoint,
+    // and the real servers it creates for rpc2/rpc3 would hit real (flaky,
+    // sometimes slow-to-fail) network calls against fake hostnames. Stub the
+    // creation itself so every rotation reuses the same mocked server.
+    const createRpcServerSpy = jest
+      .spyOn(client as any, 'createRpcServer')
+      .mockReturnValue(mockServer);
 
     // isHealthy() catches all errors and returns false — confirm it tried all endpoints.
     await expect(client.isHealthy()).resolves.toBe(false);
 
     // Should have been called once per RPC endpoint (3 total).
     expect(mockGetHealth).toHaveBeenCalledTimes(rpcUrls.length);
+
+    createRpcServerSpy.mockRestore();
   });
 
   it('stops retrying once the configured deadlineMs is exceeded and throws DeadlineError', async () => {

--- a/tests/multi-hop-routing.test.ts
+++ b/tests/multi-hop-routing.test.ts
@@ -412,11 +412,11 @@ describe('Multi-hop routing (dedicated methods)', () => {
         path: [TOKEN_A, TOKEN_B, TOKEN_C],
         amount: 1_000_000n,
         tradeType: TradeType.EXACT_IN,
-        to: 'GRECIPIENT',
+        to: 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H',
       });
 
       const [calledSender] = (client.router.buildSwapExactTokensForTokens as jest.Mock).mock.calls[0];
-      expect(calledSender).toBe('GRECIPIENT');
+      expect(calledSender).toBe('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H');
     });
   });
 });

--- a/tests/stop-loss.test.ts
+++ b/tests/stop-loss.test.ts
@@ -621,9 +621,8 @@ describe('StopLossModule', () => {
       );
     });
   });
-});
 
-describe('Oracle Staleness Checks on Enrichment Paths', () => {
+  describe('Oracle Staleness Checks on Enrichment Paths', () => {
   describe('getStopLoss() with stale oracle', () => {
     it('throws StaleOracleError by default when oracle is stale', async () => {
       jest
@@ -844,5 +843,6 @@ describe('Oracle Staleness Checks on Enrichment Paths', () => {
         stopLoss.isStopLossTriggered(makeOrder()),
       ).resolves.toBe(true);
     });
+  });
   });
 });


### PR DESCRIPTION
## Summary

Cleans up the 13 ESLint errors and 4 broken test suites left on `main` from a batch of recently merged PRs (zod-schema migrations, EventCursor migrations, idempotent-resubmission work). Every fix below was root-caused against the actual current code before editing, not guessed.

**Lint (all confirmed genuinely dead, not logic gaps):**
- `fees.ts:307` — `token0`/`token1` destructured from `pair.getTokens()` but never used anywhere else in the file. Removed from the destructure.
- `flash-loan.ts:16` — `TransactionError` imported but unused (only appears in a JSDoc comment). Removed.
- `flash-loan.ts:432` — `feeAmount` param on `parseFlashLoanEvents` unused; traced every return path and the function always derives fee data from the decoded on-chain event (`flashLoanEvent.fee`), never from this param. Renamed to `_feeAmount` per this repo's existing `argsIgnorePattern: "^_"` convention.
- `swap.ts:19` — 4 manual-validation imports (`validateAddress`, `validatePositiveAmount`, `validateDistinctTokens`, `isValidPath`) fully superseded by this file's already-completed zod schema migration. Removed.
- `swap.ts:751` — `pairAddress`/`userAddress` destructured from `filter` but unused; the rest of the function uses `filter.pairAddress`/`filter.userAddress` directly. Removed.
- `alerts.ts:1003,1050` — unused `catch (error)` bindings, both intentionally swallowed (comments explain why). Switched to bare `catch {}` (valid at this repo's ES2022 target).
- `alerts.ts:1139` — `isAbove` in `evaluateThresholdCondition` is dead: traced the full call graph and confirmed `conditionMet` (computed independently above) already re-derives the same comparison and is what actually gates the return value in every branch. Removed.

**Tests:**
- `stop-loss.test.ts` — the `'Oracle Staleness Checks on Enrichment Paths'` describe block was a top-level sibling of `'StopLossModule'` instead of nested inside it, so its 12 tests couldn't see the `client`/`stopLoss` bindings or the frozen `Date.now()` set up in `StopLossModule`'s own `beforeEach`. Nested it properly.
- `multi-hop-routing.test.ts` — replaced the placeholder `'GRECIPIENT'` (not a valid strkey) with a real, already-used-elsewhere test address.
- `client.test.ts` — the endpoint-fallback test only mocked `client.server.getHealth` once, but `executeWithFallback` builds a fresh **real** `SorobanRpc.Server` on every rotation via the private `createRpcServer()`, so the 2nd/3rd fallback attempts were hitting real network calls against fake hostnames (confirmed by direct reproduction — real DNS/connect latency, not scripted backoff). Stubbed `createRpcServer` directly instead of the `server` setter (the setter doesn't intercept the internal method's direct `_server` field assignment).
- `client-rate-limiter.test.ts` — the mocked failure (`new Error('primary RPC down')`) didn't match anything `isRetryable()` checks for, so it was correctly classified non-retryable and the test's own assumption of a 2nd attempt never happened. Changed the fixture to a `503`-shaped error, matching the pattern already used in `client.test.ts`.

## Testing

- `tsc --noEmit`: clean
- `npm run lint`: 0 errors (8 pre-existing `no-explicit-any` warnings elsewhere, out of scope)
- `npx jest --no-coverage`: 1418/1418 passing, verified clean on 4 of 5 full-suite runs; the 1 failure was `flash-loan-module.test.ts` timing out under parallel-worker load despite passing standalone in 551ms — this is pre-existing flakiness (a leaked-timer teardown warning appears on every run, pass or fail) unrelated to this diff, since that test file isn't touched here at all.
- All fixes independently re-verified by a separate read-only agent (no edit access) running the same three checks from scratch, not just my own local runs.