### PR TITLE
Fix leaked timer in health-check probes and a real network call in flash-loan tests

### DIFF
--- a/src/modules/health-check.ts
+++ b/src/modules/health-check.ts
@@ -96,6 +96,28 @@ function makeServer(url: string): SorobanRpc.Server {
 }
 
 /**
+ * Race a probe promise against a timeout, rejecting with `timeoutMessage`
+ * if `timeoutMs` elapses first.
+ *
+ * Always clears the timeout timer once the race settles, regardless of
+ * which side wins — an uncleared `setTimeout` in the losing branch keeps
+ * the event loop (and any test worker) alive until it naturally fires.
+ */
+function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+/**
  * Probe a single RPC endpoint for basic health.
  *
  * Returns an {@link RPCHealthResult} indicating whether the endpoint is
@@ -131,12 +153,7 @@ export async function checkRPCHealth(
 
   const start = Date.now();
   try {
-    const health = await Promise.race([
-      server.getHealth(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('health probe timeout')), timeoutMs),
-      ),
-    ]);
+    const health = await raceWithTimeout(server.getHealth(), timeoutMs, 'health probe timeout');
     const latencyMs = Date.now() - start;
     const status = (health as { status?: string }).status ?? 'unknown';
     return {
@@ -219,12 +236,7 @@ export async function getRPCLatency(
   for (let i = 0; i < samples; i++) {
     const start = Date.now();
     try {
-      await Promise.race([
-        server.getLatestLedger(),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('latency probe timeout')), timeoutMs),
-        ),
-      ]);
+      await raceWithTimeout(server.getLatestLedger(), timeoutMs, 'latency probe timeout');
       latencies.push(Date.now() - start);
     } catch {
       failures++;
@@ -307,12 +319,11 @@ export async function getContractStatus(
     // Wrap the raw 32-byte contract hash in an ScVal Bytes for the instance key.
     const key = xdr.ScVal.scvBytes(Buffer.from(rawContractId));
 
-    const response = await Promise.race([
+    const response = await raceWithTimeout(
       server.getContractData(contract, key),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('contract status probe timeout')), 8_000),
-      ),
-    ]);
+      8_000,
+      'contract status probe timeout',
+    );
 
     const entry = response as any;
     const result = response as any;
@@ -412,12 +423,7 @@ export async function getBestEndpoint(urls: string[]): Promise<string | null> {
       for (let i = 0; i < 3; i++) {
         const start = Date.now();
         try {
-          await Promise.race([
-            server.getLatestLedger(),
-            new Promise<never>((_, reject) =>
-              setTimeout(() => reject(new Error('score probe timeout')), 3_000),
-            ),
-          ]);
+          await raceWithTimeout(server.getLatestLedger(), 3_000, 'score probe timeout');
           latencySamples.push(Date.now() - start);
         } catch {
           failures++;

--- a/tests/flash-loan-module.test.ts
+++ b/tests/flash-loan-module.test.ts
@@ -45,6 +45,14 @@ describe("FlashLoanModule", () => {
 
     // Mock the client.pair() method to return our mock
     jest.spyOn(client, "pair").mockReturnValue(mockPairClient);
+
+    // execute()'s success path fetches the full transaction to decode events;
+    // default to a non-SUCCESS status so tests that don't care about event
+    // parsing skip it cleanly instead of hitting the real (unmocked) testnet
+    // RPC with a fake tx hash.
+    jest
+      .spyOn(client.server, "getTransaction")
+      .mockResolvedValue({ status: "NOT_FOUND" } as any);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes the pre-existing flaky `tests/flash-loan-module.test.ts` timeout and the "A worker process has failed to exit gracefully" warning that appeared on every jest run, both caused by two separate real bugs (not the same one).

**1. `src/modules/health-check.ts` — leaked timer, duplicated 4 times**

Every timeout-bounded probe used `Promise.race([realCall, new Promise((_, reject) => setTimeout(...))])` without ever clearing the timeout when the real call won the race. The scheduled rejection kept running in the background for up to 8 seconds after the function had already returned, keeping the event loop (and any Jest worker) alive. This exact pattern was duplicated in `checkRPCHealth`, `getRPCLatency`, `getContractStatus`, and the scoring loop in `getBestEndpoint`. Extracted one `raceWithTimeout()` helper that clears the timer in a `.finally()` regardless of which side wins, used at all 4 call sites — fixes the bug once instead of leaving 4 copies that could drift again.

**2. `tests/flash-loan-module.test.ts` — a real network call inside a unit test**

The first `describe("FlashLoanModule", ...)` block constructs a real `CoralSwapClient` (this file has no `@stellar/stellar-sdk` module mock, unlike its sibling describe block further down which does mock `getTransaction` per test). Two `execute()` success-path tests never mocked `client.server.getTransaction`, so `execute()`'s event-decoding step was making a real network call to the actual Stellar testnet RPC with a fake tx hash — explaining both the ~500ms per-call latency (confirmed: both tests dropped to 2ms after the fix) and the occasional 5000ms timeout under load. Added a default `getTransaction` mock (non-`SUCCESS` status, so event parsing cleanly no-ops) to the shared `beforeEach`, protecting both current tests and any future ones added to this block.

## Testing

- `tsc --noEmit`: clean
- `npm run lint`: 0 errors (8 pre-existing `no-explicit-any` warnings, unrelated)
- `npx jest --no-coverage --detectOpenHandles`: no leaked-handle warning (previously present on every run)
- 9 consecutive full-suite runs (5 by me, 4 by an independent read-only verification agent with no edit access): 70/70 suites, 1418/1418 tests, zero failures, zero timeouts, zero leak warnings across all 9
- Isolated timing check: the two previously-slow tests in `flash-loan-module.test.ts` went from 530ms/506ms to 2ms/2ms